### PR TITLE
add cpuNum for environment

### DIFF
--- a/internal/environment.go
+++ b/internal/environment.go
@@ -12,6 +12,7 @@ type Environment struct {
 	GOARCH   string `env:"GOARCH"`
 	GOOS     string `env:"GOOS"`
 	Version  string `env:"Version"`
+	NumCPU   string `env:"NumCPU"`
 }
 
 var (
@@ -21,6 +22,7 @@ var (
 		GOARCH:   "arch",
 		GOOS:     "goos",
 		Version:  "vers",
+		NumCPU:   "numCPU",
 	}
 )
 
@@ -31,6 +33,7 @@ func NewEnvironment() Environment {
 		GOARCH:   runtime.GOARCH,
 		GOOS:     runtime.GOOS,
 		Version:  runtime.Version(),
+		NumCPU:   runtime.NumCPU(),
 	}
 }
 

--- a/internal/environment_test.go
+++ b/internal/environment_test.go
@@ -11,7 +11,7 @@ func TestMarshalEnvironment(t *testing.T) {
 	if nil != err {
 		t.Fatal(err)
 	}
-	expect := `[["Compiler","comp"],["GOARCH","arch"],["GOOS","goos"],["Version","vers"]]`
+	expect := `[["Compiler","comp"],["GOARCH","arch"],["GOOS","goos"],["Version","vers"],["NumCPU","numCPU"]]`
 	if string(js) != expect {
 		t.Fatal(string(js))
 	}
@@ -30,5 +30,8 @@ func TestEnvironmentFields(t *testing.T) {
 	}
 	if env.Version != runtime.Version() {
 		t.Error(env.Version, runtime.Version())
+	}
+	if env.NumCPU != runtime.NumCPU() {
+		t.Error(env.NumCPU, runtime.NumCPU())
 	}
 }


### PR DESCRIPTION
I want this in environment page. 
<img width="337" alt="screen shot 2016-07-23 at 22 18 17" src="https://cloud.githubusercontent.com/assets/9318209/17079804/65d3c1f8-5123-11e6-8b58-e5ac16615896.png">

Currently I not see Logical process or Physical process in APM UI for GO.
I don't know if server side support this name `NumCPU `? 