### PR TITLE
Override High Security in custom events

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,6 +7,17 @@ import (
 	"strings"
 )
 
+//
+type HighSecurityFeature uint16
+const (
+	EnabledHttpParam HighSecurityFeature = 1 << iota	// 1
+	EnabledMessageQueueParam				// 2
+	EnabledRawQueryStatement				// 4
+	EnabledUserAttribute					// 8
+	EnabledNoticeErrorAttribute				// 16
+	EnabledCustomEvents					// 32
+)
+
 // Config contains Application and Transaction behavior settings.
 // Use NewConfig to create a Config with proper defaults.
 type Config struct {
@@ -40,6 +51,11 @@ type Config struct {
 	//
 	// https://docs.newrelic.com/docs/accounts-partnerships/accounts/security/high-security
 	HighSecurity bool
+
+	// HighSecurityOverride is an addition to HighSecurity flag providing
+	// control of which feature should be allowed despite HighSecurity
+	// being set
+	HighSecurityOverride HighSecurityFeature
 
 	// CustomInsightsEvents controls the behavior of
 	// Application.RecordCustomEvent.
@@ -141,6 +157,7 @@ func NewConfig(appname, license string) Config {
 	c.TransactionEvents.Enabled = true
 	c.TransactionEvents.Attributes.Enabled = true
 	c.HighSecurity = false
+	c.HighSecurityOverride = 0 // all features are disabled by default
 	c.UseTLS = true
 	c.ErrorCollector.Enabled = true
 	c.ErrorCollector.CaptureEvents = true

--- a/config.go
+++ b/config.go
@@ -7,7 +7,11 @@ import (
 	"strings"
 )
 
-//
+// Flags for features of High Security mode (as described here:
+// https://docs.newrelic.com/docs/agents/manage-apm-agents/configuration/high-security-mode#version2description)
+// 
+// When a flag is turned on - the relevant feature is enabled despite
+// High Security mode being set
 type HighSecurityFeature uint16
 const (
 	EnabledHttpParam HighSecurityFeature = 1 << iota	// 1

--- a/internal_app.go
+++ b/internal_app.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/newrelic/go-agent/internal"
-	"github.com/newrelic/go-agent/internal/logger"
+	"github.com/VadimBelov/go-agent/internal"
+	"github.com/VadimBelov/go-agent/internal/logger"
 )
 
 var (
@@ -385,7 +385,9 @@ var (
 
 // RecordCustomEvent implements newrelic.Application's RecordCustomEvent.
 func (app *app) RecordCustomEvent(eventType string, params map[string]interface{}) error {
-	if app.config.HighSecurity {
+
+	if app.config.HighSecurity &&
+		EnabledCustomEvents != app.config.HighSecurityOverride & EnabledCustomEvents {
 		return errHighSecurityEnabled
 	}
 

--- a/internal_app.go
+++ b/internal_app.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/VadimBelov/go-agent/internal"
-	"github.com/VadimBelov/go-agent/internal/logger"
+	"github.com/newrelic/go-agent/internal"
+	"github.com/newrelic/go-agent/internal/logger"
 )
 
 var (

--- a/internal_config.go
+++ b/internal_config.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/VadimBelov/go-agent/internal"
-	"github.com/VadimBelov/go-agent/internal/logger"
-	"github.com/VadimBelov/go-agent/internal/utilization"
+	"github.com/newrelic/go-agent/internal"
+	"github.com/newrelic/go-agent/internal/logger"
+	"github.com/newrelic/go-agent/internal/utilization"
 )
 
 func copyDestConfig(c AttributeDestinationConfig) AttributeDestinationConfig {

--- a/internal_config.go
+++ b/internal_config.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/newrelic/go-agent/internal"
-	"github.com/newrelic/go-agent/internal/logger"
-	"github.com/newrelic/go-agent/internal/utilization"
+	"github.com/VadimBelov/go-agent/internal"
+	"github.com/VadimBelov/go-agent/internal/logger"
+	"github.com/VadimBelov/go-agent/internal/utilization"
 )
 
 func copyDestConfig(c AttributeDestinationConfig) AttributeDestinationConfig {
@@ -100,29 +100,31 @@ func (s settings) MarshalJSON() ([]byte, error) {
 
 func configConnectJSONInternal(c Config, pid int, util *utilization.Data, e internal.Environment, version string) ([]byte, error) {
 	return json.Marshal([]interface{}{struct {
-		Pid             int                  `json:"pid"`
-		Language        string               `json:"language"`
-		Version         string               `json:"agent_version"`
-		Host            string               `json:"host"`
-		HostDisplayName string               `json:"display_host,omitempty"`
-		Settings        interface{}          `json:"settings"`
-		AppName         []string             `json:"app_name"`
-		HighSecurity    bool                 `json:"high_security"`
-		Labels          internal.Labels      `json:"labels,omitempty"`
-		Environment     internal.Environment `json:"environment"`
-		Identifier      string               `json:"identifier"`
-		Util            *utilization.Data    `json:"utilization"`
+		Pid                  int                  `json:"pid"`
+		Language             string               `json:"language"`
+		Version              string               `json:"agent_version"`
+		Host                 string               `json:"host"`
+		HostDisplayName      string               `json:"display_host,omitempty"`
+		Settings             interface{}          `json:"settings"`
+		AppName              []string             `json:"app_name"`
+		HighSecurity         bool                 `json:"high_security"`
+		HighSecurityOverride HighSecurityFeature  `json:"high_security_override"`
+		Labels               internal.Labels      `json:"labels,omitempty"`
+		Environment          internal.Environment `json:"environment"`
+		Identifier           string               `json:"identifier"`
+		Util                 *utilization.Data    `json:"utilization"`
 	}{
-		Pid:             pid,
-		Language:        agentLanguage,
-		Version:         version,
-		Host:            internal.StringLengthByteLimit(util.Hostname, hostByteLimit),
-		HostDisplayName: internal.StringLengthByteLimit(c.HostDisplayName, hostByteLimit),
-		Settings:        (settings)(c),
-		AppName:         strings.Split(c.AppName, ";"),
-		HighSecurity:    c.HighSecurity,
-		Labels:          internal.Labels(c.Labels),
-		Environment:     e,
+		Pid:                  pid,
+		Language:             agentLanguage,
+		Version:              version,
+		Host:                 internal.StringLengthByteLimit(util.Hostname, hostByteLimit),
+		HostDisplayName:      internal.StringLengthByteLimit(c.HostDisplayName, hostByteLimit),
+		Settings:             (settings)(c),
+		AppName:              strings.Split(c.AppName, ";"),
+		HighSecurity:         c.HighSecurity,
+		HighSecurityOverride: c.HighSecurityOverride,
+		Labels:               internal.Labels(c.Labels),
+		Environment:          e,
 		// This identifier field is provided to avoid:
 		// https://newrelic.atlassian.net/browse/DSCORE-778
 		//

--- a/internal_test.go
+++ b/internal_test.go
@@ -174,7 +174,7 @@ func TestRecordCustomEventHighSecurityEnabled(t *testing.T) {
 func TestRecordCustomEventHighSecurityEnabledOverride(t *testing.T) {
 	cfgfn := func(cfg *Config) {
 		cfg.HighSecurity = true
-		cfg.HighSecurityOverride = EnabledCustomEvents
+		cfg.HighSecurityOverride |= EnabledCustomEvents
 	}
 	app := testApp(nil, cfgfn, t)
 	err := app.RecordCustomEvent("myType", validParams)

--- a/internal_test.go
+++ b/internal_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/newrelic/go-agent/internal"
-	"github.com/newrelic/go-agent/internal/utilization"
+	"github.com/VadimBelov/go-agent/internal"
+	"github.com/VadimBelov/go-agent/internal/utilization"
 )
 
 // compatibleResponseRecorder wraps ResponseRecorder to ensure consistent behavior
@@ -169,6 +169,19 @@ func TestRecordCustomEventHighSecurityEnabled(t *testing.T) {
 		t.Error(err)
 	}
 	app.ExpectCustomEvents(t, []internal.WantCustomEvent{})
+}
+
+func TestRecordCustomEventHighSecurityEnabledOverride(t *testing.T) {
+	cfgfn := func(cfg *Config) {
+		cfg.HighSecurity = true
+		cfg.HighSecurityOverride = EnabledCustomEvents
+	}
+	app := testApp(nil, cfgfn, t)
+	err := app.RecordCustomEvent("myType", validParams)
+	if err != nil {
+		t.Error(err)
+	}
+	app.ExpectCustomEvents(t, []internal.WantCustomEvent{{"myType", validParams}})
 }
 
 func TestRecordCustomEventEventsDisabled(t *testing.T) {
@@ -2199,6 +2212,7 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 				"IgnoreStatusCodes":[404,405]
 			},
 			"HighSecurity":false,
+			"HighSecurityOverride":0,
 			"HostDisplayName":"",
 			"Labels":{"zip":"zap"},
 			"Logger":"*logger.logFile",
@@ -2219,6 +2233,7 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 		},
 		"app_name":["my appname"],
 		"high_security":false,
+		"high_security_override":0,
 		"labels":[{"label_type":"zip","label_value":"zap"}],
 		"environment":[
 			["runtime.Compiler","comp"],
@@ -2270,6 +2285,7 @@ func TestCopyConfigReferenceFieldsAbsent(t *testing.T) {
 				"IgnoreStatusCodes":null
 			},
 			"HighSecurity":false,
+			"HighSecurityOverride":0,
 			"HostDisplayName":"",
 			"Labels":null,
 			"Logger":null,
@@ -2290,6 +2306,7 @@ func TestCopyConfigReferenceFieldsAbsent(t *testing.T) {
 		},
 		"app_name":["my appname"],
 		"high_security":false,
+		"high_security_override":0,
 		"environment":[
 			["runtime.Compiler","comp"],
 			["runtime.GOARCH","arch"],

--- a/internal_test.go
+++ b/internal_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/VadimBelov/go-agent/internal"
-	"github.com/VadimBelov/go-agent/internal/utilization"
+	"github.com/newrelic/go-agent/internal"
+	"github.com/newrelic/go-agent/internal/utilization"
 )
 
 // compatibleResponseRecorder wraps ResponseRecorder to ensure consistent behavior


### PR DESCRIPTION
* Addition of flags for each of the features described [here](https://docs.newrelic.com/docs/agents/manage-apm-agents/configuration/high-security-mode#version2description)
* When turned on - each flag overrides the High Security mode in context of the given feature
* In this implementation Custom Events are sent even if High Security mode is enabled