### PR TITLE
Correct StartTime struct field name in guide

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -240,8 +240,8 @@ External segments are instrumented using `ExternalSegment`.  Populate either the
 ```go
 func external(txn newrelic.Transaction, url string) (*http.Response, error) {
 	defer newrelic.ExternalSegment{
-		Start: newrelic.StartSegmentNow(txn),
-		URL:   url,
+		StartTime: newrelic.StartSegmentNow(txn),
+		URL:       url,
 	}.End()
 
 	return http.Get(url)


### PR DESCRIPTION
This PR corrects the struct field name for `StartTime` in the example documentation for external segments. `Start` is not correct, the correct field name is `StartTime` as reflected in the type definition here: https://github.com/newrelic/go-agent/blob/master/segments.go#L45
