### PR TITLE
Add generic HTTP interface

### DIFF
--- a/application.go
+++ b/application.go
@@ -15,7 +15,7 @@ type Application interface {
 	// * If an http.ResponseWriter is provided then the Transaction can be
 	//   used in its place.  This allows instrumentation of the response
 	//   code and response headers.
-	StartTransaction(name string, w http.ResponseWriter, r *http.Request) Transaction
+	StartTransaction(name string, w http.ResponseWriter, r interface{}) Transaction
 
 	// RecordCustomEvent adds a custom event to the application.  This
 	// feature is incompatible with high security mode.

--- a/http/header.go
+++ b/http/header.go
@@ -1,0 +1,7 @@
+package http
+
+type Header interface {
+	Add(key, value string)
+	Set(key, value string)
+	Get(key string) string
+}

--- a/http/request.go
+++ b/http/request.go
@@ -1,0 +1,11 @@
+package http
+
+import (
+	"net/url"
+)
+
+type Request interface {
+	URL() *url.URL
+	Method() string
+	Header() Header
+}

--- a/http/requestwrapper.go
+++ b/http/requestwrapper.go
@@ -1,0 +1,22 @@
+package http
+
+import (
+	"net/http"
+	"net/url"
+)
+
+type RequestWrapper struct {
+	*http.Request
+}
+
+func (r RequestWrapper) Header() Header {
+	return r.Request.Header
+}
+
+func (r RequestWrapper) Method() string {
+	return r.Request.Method
+}
+
+func (r RequestWrapper) URL() *url.URL {
+	return r.Request.URL
+}

--- a/http/response.go
+++ b/http/response.go
@@ -1,0 +1,7 @@
+package http
+
+type Response interface {
+	Header() Header
+	Code() int
+	Request() Request
+}

--- a/http/responsewrapper.go
+++ b/http/responsewrapper.go
@@ -1,0 +1,19 @@
+package http
+
+import "net/http"
+
+type ResponseWrapper struct {
+	*http.Response
+}
+
+func (r ResponseWrapper) Header() Header {
+	return r.Response.Header
+}
+
+func (r ResponseWrapper) Code() int {
+	return r.Response.StatusCode
+}
+
+func (r ResponseWrapper) Request() Request {
+	return RequestWrapper{r.Response.Request}
+}

--- a/internal/attributes.go
+++ b/internal/attributes.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"sort"
 	"strconv"
 	"strings"
+
+	http "github.com/newrelic/go-agent/http"
 )
 
 // New agent attributes must be added in the following places:
@@ -492,10 +493,10 @@ func getAgentAttributes(a *Attributes, d destinationSet) map[string]interface{} 
 }
 
 // RequestAgentAttributes gathers agent attributes out of the request.
-func RequestAgentAttributes(a *Attributes, r *http.Request) {
-	a.Agent.RequestMethod = r.Method
+func RequestAgentAttributes(a *Attributes, r http.Request) {
+	a.Agent.RequestMethod = r.Method()
 
-	h := r.Header
+	h := r.Header()
 	if nil == h {
 		return
 	}

--- a/internal/queuing.go
+++ b/internal/queuing.go
@@ -1,10 +1,11 @@
 package internal
 
 import (
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/newrelic/go-agent/http"
 )
 
 const (

--- a/internal_http_response.go
+++ b/internal_http_response.go
@@ -1,0 +1,25 @@
+package newrelic
+
+import (
+	"net/http"
+
+	nrhttp "github.com/newrelic/go-agent/http"
+)
+
+type simpleHttpResponse struct {
+	header     http.Header
+	statusCode int
+	request    nrhttp.Request
+}
+
+func (r simpleHttpResponse) Header() nrhttp.Header {
+	return r.header
+}
+
+func (r simpleHttpResponse) Code() int {
+	return r.statusCode
+}
+
+func (r simpleHttpResponse) Request() nrhttp.Request {
+	return r.request
+}

--- a/internal_test.go
+++ b/internal_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	nrhttp "github.com/newrelic/go-agent/http"
 	"github.com/newrelic/go-agent/internal"
 )
 
@@ -683,21 +684,21 @@ func TestExternalSegmentURL(t *testing.T) {
 		t.Error(u, err, internal.HostFromURL(u))
 	}
 	// segment only containing request
-	u, err = externalSegmentURL(ExternalSegment{Request: req})
+	u, err = externalSegmentURL(ExternalSegment{Request: nrhttp.RequestWrapper{req}})
 	host = internal.HostFromURL(u)
 	if nil != err || "request.com" != host {
 		t.Error(host)
 	}
 	// segment only containing response
-	u, err = externalSegmentURL(ExternalSegment{Response: response})
+	u, err = externalSegmentURL(ExternalSegment{Response: nrhttp.ResponseWrapper{response}})
 	host = internal.HostFromURL(u)
 	if nil != err || "response.com" != host {
 		t.Error(host)
 	}
 	// segment containing request and response
 	u, err = externalSegmentURL(ExternalSegment{
-		Request:  req,
-		Response: response,
+		Request:  nrhttp.RequestWrapper{req},
+		Response: nrhttp.ResponseWrapper{response},
 	})
 	host = internal.HostFromURL(u)
 	if nil != err || "response.com" != host {
@@ -706,8 +707,8 @@ func TestExternalSegmentURL(t *testing.T) {
 	// segment containing url, request, and response
 	u, err = externalSegmentURL(ExternalSegment{
 		URL:      rawURL,
-		Request:  req,
-		Response: response,
+		Request:  nrhttp.RequestWrapper{req},
+		Response: nrhttp.ResponseWrapper{response},
 	})
 	host = internal.HostFromURL(u)
 	if nil != err || "url.com" != host {

--- a/segments.go
+++ b/segments.go
@@ -1,6 +1,6 @@
 package newrelic
 
-import "net/http"
+import "github.com/newrelic/go-agent/http"
 
 // SegmentStartTime is created by Transaction.StartSegmentNow and marks the
 // beginning of a segment.  A segment with a zero-valued SegmentStartTime may
@@ -53,8 +53,8 @@ type DatastoreSegment struct {
 // is recommended when you have access to an http.Request.
 type ExternalSegment struct {
 	StartTime SegmentStartTime
-	Request   *http.Request
-	Response  *http.Response
+	Request   http.Request
+	Response  http.Response
 	// If you do not have access to the request, this URL field should be
 	// used to indicate the endpoint.  NOTE: If non-empty, this field
 	// is parsed using url.Parse and therefore it MUST include the protocol
@@ -107,7 +107,7 @@ func StartSegment(txn Transaction, name string) Segment {
 //    segment.Response = resp
 //    segment.End()
 //
-func StartExternalSegment(txn Transaction, request *http.Request) ExternalSegment {
+func StartExternalSegment(txn Transaction, request http.Request) ExternalSegment {
 	return ExternalSegment{
 		StartTime: StartSegmentNow(txn),
 		Request:   request,

--- a/transaction.go
+++ b/transaction.go
@@ -1,6 +1,10 @@
 package newrelic
 
-import "net/http"
+import (
+	"net/http"
+
+	nrhttp "github.com/newrelic/go-agent/http"
+)
 
 // Transaction represents a request or a background task.
 // Each Transaction should only be used in a single goroutine.
@@ -35,6 +39,11 @@ type Transaction interface {
 	// For more information, see:
 	// https://docs.newrelic.com/docs/agents/manage-apm-agents/agent-metrics/collect-custom-attributes
 	AddAttribute(key string, value interface{}) error
+
+	// Notifies the transaction that the response has just been written.
+	// This is automatically handled if a ResponseWriter as passed when creating
+	// the transaction.
+	ResponseSent(response nrhttp.Response)
 
 	// StartSegmentNow allows the timing of functions, external calls, and
 	// datastore calls.  The segments of each transaction MUST be used in a


### PR DESCRIPTION
This enables HTTP libraries that aren't based on net/http to be used.

Unfortunately, it breaks ExternalSegment interface. Do anyone have a better idea that doesn't do this?

Addresses #19