### PR TITLE
Get AppID for an application

### DIFF
--- a/application.go
+++ b/application.go
@@ -44,6 +44,11 @@ type Application interface {
 	// application is connected successfully.
 	WaitForConnection(timeout time.Duration) error
 
+	// ID returns the application's ID in New Relic. It will return the ID of the
+	// application only after connection has been established.
+	// Returns an error, if connection has not been established yet.
+	ID() (string, error)
+
 	// Shutdown flushes data to New Relic's servers and stops all
 	// agent-related goroutines managing this application.  After Shutdown
 	// is called, the application is disabled and no more data will be

--- a/internal_app.go
+++ b/internal_app.go
@@ -374,6 +374,24 @@ func (app *app) WaitForConnection(timeout time.Duration) error {
 	}
 }
 
+func (app *app) ID() (string, error) {
+	if !app.config.Enabled {
+		return "", fmt.Errorf("config not enabled")
+	}
+
+	run, err := app.getState()
+	if nil != err {
+		return "", fmt.Errorf("not connected. %s", err)
+	}
+
+	if run.RunID != "" {
+		return run.AppID, nil
+	}
+
+	// Should never happen
+	return "", fmt.Errorf("id is empty")
+}
+
 func newApp(c Config) (Application, error) {
 	c = copyConfigReferenceFields(c)
 	if err := c.Validate(); nil != err {

--- a/internal_test.go
+++ b/internal_test.go
@@ -1452,3 +1452,16 @@ func TestTraceSegmentsBelowThreshold(t *testing.T) {
 		NumSegments: 0,
 	}})
 }
+
+func TestID(t *testing.T) {
+	cfgfn := func(cfg *Config) {
+		cfg.TransactionTracer.Threshold.IsApdexFailing = false
+		cfg.TransactionTracer.Threshold.Duration = 0
+		cfg.TransactionTracer.SegmentThreshold = 0
+	}
+	app := testApp(nil, cfgfn, t)
+	appID, err := app.ID()
+	if err == nil {
+		t.Errorf("Expected error because app is not connected.AppID:%s", appID)
+	}
+}


### PR DESCRIPTION
Retrieve the NewRelic AppID from the go-agent instead of hitting the REST API to get the Application ID.

**Problem:**
Need to tag deployments from the service itself.
A HTTP call needs to be made to get the AppID from the REST API which will list all the applications and filter by name.

**Solution:**
Since the go-agent maintains the AppID after connection has been established to the NewRelic servers, retrieving it from here would reduce JSON encode/decode and a HTTP call.