### PR TITLE
gorilla: carry the transaction within the request context

### DIFF
--- a/_integrations/nrgorilla/v1/nrgorilla.go
+++ b/_integrations/nrgorilla/v1/nrgorilla.go
@@ -3,6 +3,7 @@
 package nrgorilla
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -20,6 +21,7 @@ type instrumentedHandler struct {
 
 func (h instrumentedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	txn := h.app.StartTransaction(h.name, w, r)
+	r = r.WithContext(NewContext(r.Context(), txn))
 	defer txn.End()
 
 	h.orig.ServeHTTP(txn, r)
@@ -63,3 +65,20 @@ func InstrumentRoutes(r *mux.Router, app newrelic.Application) *mux.Router {
 	}
 	return r
 }
+
+// NewContext returns a new Context that carries the provided transcation.
+func NewContext(ctx context.Context, txn newrelic.Transaction) context.Context {
+	return context.WithValue(ctx, contextKey, txn)
+}
+
+// FromContext returns the Transaction in the context, if any. If there
+// isn't a transaction in the context, nil is returned.
+func FromContext(ctx context.Context) newrelic.Transaction {
+	h, _ := ctx.Value(contextKey).(newrelic.Transaction)
+	return h
+}
+
+type contextKeyType struct{}
+
+// globally unique, since it is an unexported type
+var contextKey = contextKeyType(struct{}{})

--- a/examples/_gorilla/main.go
+++ b/examples/_gorilla/main.go
@@ -12,6 +12,12 @@ import (
 
 func makeHandler(text string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		txn := nrgorilla.FromContext(r.Context())
+		req, _ := http.NewRequest(http.MethodGet, "https://support.newrelic.com/", nil)
+		s := newrelic.StartExternalSegment(txn, req)
+		resp, _ := http.DefaultClient.Do(req)
+		s.Response = resp
+		s.End()
 		w.Write([]byte(text))
 	})
 }


### PR DESCRIPTION
So the user is able to easily get the current transaction in any method that has the context.

It should be useful to add the external calls as well sql calls :) 