### PR TITLE
Improve error exposure on RPM failure

### DIFF
--- a/internal/collector.go
+++ b/internal/collector.go
@@ -154,7 +154,7 @@ func CollectorRequest(cmd RpmCmd, cs RpmControls) ([]byte, error) {
 
 	resp, err := collectorRequestInternal(url, cmd.Data, cs)
 	if err != nil {
-		cs.Logger.Debug("rpm failure", map[string]interface{}{
+		cs.Logger.Error("rpm failure", map[string]interface{}{
 			"command": cmd.Name,
 			"url":     url,
 			"error":   err.Error(),


### PR DESCRIPTION
There is some situations where RPM setup fails. For example, if the Go app is not properly configured to do HTTPs requests...

In this situations, it is interesting to expose those errors to keep things visible and enable proper troubleshoot!