### PR TITLE
Allow to start external segment with nil request

### DIFF
--- a/segments.go
+++ b/segments.go
@@ -119,9 +119,11 @@ func StartExternalSegment(txn Transaction, request *http.Request) ExternalSegmen
 		Request:   request,
 	}
 
-	for key, values := range s.OutboundHeaders() {
-		for _, value := range values {
-			request.Header.Add(key, value)
+	if nil != request {
+		for key, values := range s.OutboundHeaders() {
+			for _, value := range values {
+				request.Header.Add(key, value)
+			}
 		}
 	}
 


### PR DESCRIPTION
A user often can not access the HTTP request made by other libraries. The alternative way is to start external segment with nil HTTP request, and hard-code the URL. For example:

segment := newrelic.StartExternalSegment(txn, nil)
segment.URL = "https:/abc.com"
// Make a library call to access external API
segment.End()

This patch let go-agent to tolerate nil request object.