### PR TITLE
Expose enough internals to facilitate non-http based microservices

### DIFF
--- a/application.go
+++ b/application.go
@@ -17,6 +17,12 @@ type Application interface {
 	//   code and response headers.
 	StartTransaction(name string, w http.ResponseWriter, r *http.Request) Transaction
 
+	// StartAdvancedTransaction begins a Transaction much like StartTransaction.
+	// The same rules for a standard transaction apply to a advanced transaction.
+	// This type of transaction allows greater freedom as to how the vital headers
+	// are handled for CAT and how the web transaction is built
+	StartAdvancedTransaction(name string) AdvancedTransaction
+
 	// RecordCustomEvent adds a custom event to the application.  This
 	// feature is incompatible with high security mode.
 	//

--- a/internal/tracing.go
+++ b/internal/tracing.go
@@ -199,7 +199,20 @@ func EndBasicSegment(t *TxnData, start SegmentStartTime, now time.Time, name str
 }
 
 // EndExternalSegment ends an external segment.
-func EndExternalSegment(t *TxnData, start SegmentStartTime, now time.Time, u *url.URL, resp *http.Response) error {
+func EndExternalSegment(t *TxnData, start SegmentStartTime, now time.Time, u *url.URL, resp *http.Response) (err error) {
+	var appData *cat.AppDataHeader
+	if resp != nil {
+		appData, err = t.CrossProcess.ParseAppData(HTTPHeaderToAppData(resp.Header))
+		if err != nil {
+			return err
+		}
+	}
+
+	return EndAdvancedExternalSegment(t, start, now, u, appData)
+}
+
+// EndAdvancedExternalSegment ends an external segment.
+func EndAdvancedExternalSegment(t *TxnData, start SegmentStartTime, now time.Time, u *url.URL, appData *cat.AppDataHeader) error {
 	end, err := endSegment(t, start, now)
 	if nil != err {
 		return err
@@ -208,14 +221,6 @@ func EndExternalSegment(t *TxnData, start SegmentStartTime, now time.Time, u *ur
 	host := HostFromURL(u)
 	if "" == host {
 		host = "unknown"
-	}
-
-	var appData *cat.AppDataHeader
-	if resp != nil {
-		appData, err = t.CrossProcess.ParseAppData(HTTPHeaderToAppData(resp.Header))
-		if err != nil {
-			return err
-		}
 	}
 
 	var crossProcessID string

--- a/internal_app.go
+++ b/internal_app.go
@@ -488,6 +488,17 @@ func (app *app) StartTransaction(name string, w http.ResponseWriter, r *http.Req
 	}, r, name))
 }
 
+// StartAdvancedTransaction implements newrelic.Application's StartAdvancedTransaction.
+func (app *app) StartAdvancedTransaction(name string) AdvancedTransaction {
+	run, _ := app.getState()
+	return newAdvancedTxn(txnInput{
+		Config:     app.config,
+		Reply:      run.ConnectReply,
+		Consumer:   app,
+		attrConfig: app.attrConfig,
+	}, name)
+}
+
 var (
 	errHighSecurityEnabled        = errors.New("high security enabled")
 	errCustomEventsDisabled       = errors.New("custom events disabled")

--- a/transaction.go
+++ b/transaction.go
@@ -1,6 +1,9 @@
 package newrelic
 
-import "net/http"
+import (
+	"net/http"
+	"net/url"
+)
 
 // Transaction represents a request or a background task.
 // Each Transaction should only be used in a single goroutine.
@@ -42,4 +45,25 @@ type Transaction interface {
 	// `StartSegmentNow` functions which checks if the Transaction is nil.
 	// See segments.go
 	StartSegmentNow() SegmentStartTime
+}
+
+// AdvancedTransaction represents a request or a background task.
+// The same rules apply to a AdvancedTransaction as a Transaction.
+// This is provided as a method for more advanced usage beyond simple
+// http requests
+type AdvancedTransaction interface {
+	Transaction
+
+	// SetWeb will convert the transaction to a web transaction for a given URL
+	// in the normal transaction this is set to true when given a *http.Request
+	// with the *url.URL being pulled from that request
+	SetWeb(web bool, url *url.URL)
+
+	// SetCrossProcess will configure the required CrossProcess infromation
+	// normally extracted from the *http.Request.Headers
+	SetCrossProcess(id, txnData, synthetics string)
+
+	// SetResponseCode permits recording of the http response code (eg: 200)
+	// which would normally be collected automatically by the standard transaction
+	SetResponseCode(code int)
 }


### PR DESCRIPTION
The framework we're using for microservices is not http based (strictly speaking), it's GRPC based but the transport is interchangeable and not conveniently accessible.

We also suffer from splitting our payloads over an event based websocket and a simple rest interface.

Without access to a http.Request or http.ResponseWriter getting web request tracking, or CAT working was a bit of a challenge involving emulating both the request and the writer.

This commit is a little bit rough around the edges but we can use this to do the same thing without the overhead of creating Requests and ResponseWriters.

To further complicate things we have an out of band method of passing metadata forward from our routers to the microservices but not for the reverse.

example middleware for a microservice:

```go
func (n NewRelicHelper) middleware() server.HandlerWrapper {
	return func(fn server.HandlerFunc) server.HandlerFunc {
		return func(ctx context.Context, req server.Request, rsp interface{}) error {
			md, _ := metadata.FromContext(ctx)
			path := "/grpc/" + req.Method()
			txn := App.StartAdvancedTransaction(path)
			defer txn.End()
			txn.SetWeb(true, &url.URL{Path: path})
			txn.SetCrossProcess(md["Newrelic-Id"], md["Newrelic-Transaction"], md["Newrelic-Synthetics"])

			err := fn(context.WithValue(ctx, Transaction{}, txn), req, rsp)
			if err != nil {
				txn.SetResponseCode(http.StatusInternalServerError)
			} else {
				txn.SetResponseCode(http.StatusOK)
			}

			return err
		}
	}
}
```

metadata is the out of band method of receiving data from the router.


Example call wrapper from the router.
```go
func (t *ClientWrapper) Call(ctx context.Context, req client.Request, rsp interface{}, opts ...client.CallOption) error {
	txnIface := ctx.Value(Transaction{})
	if txnIface == nil {
		return t.Client.Call(ctx, req, rsp)
	}
	txn := txnIface.(newrelic.AdvancedTransaction)
	md, _ := metadata.FromContext(ctx)
	name := "/grpc/" + req.Method()
	path := "http://" + req.Service() + name
	seg := newrelic.StartAdvancedExternalSegment(txn, name, path)
	defer seg.End()

	// Rebuild metadata - TODO wrap this up in a function
	nmd := metadata.Metadata{}
	for k, v := range md {
		nmd[k] = v
	}

	nmd["Newrelic-Id"] = seg.CrossProcessMetadata.ID
	nmd["Newrelic-Transaction"] = seg.CrossProcessMetadata.TxnData
	nmd["Newrelic-Synthetics"] = seg.CrossProcessMetadata.Synthetics

	nctx := metadata.NewContext(ctx, nmd)

	seg.RestartTiming()
	err := t.Client.Call(nctx, req, rsp)

	return err
}
```

An alternative to using local timing, is to import appdata that would normally be included in the response headers from the microservice - but we don't have this facility, I just included it for testing.

```go
	oob, err := t.Client.Call(nctx, req, rsp)
	seg.Import(oob.NewrelicAppData)
```

With regards to the naming, I originally started with "custom" but thought that would be confusing. Something more like "WarrantyVoidIfUsed" would be a better prefix.