### PR TITLE
Add Flush Method to Allow User to Control Harvests

### DIFF
--- a/application.go
+++ b/application.go
@@ -50,6 +50,11 @@ type Application interface {
 	// collected.  This method will block until all final data is sent to
 	// New Relic or the timeout has elapsed.
 	Shutdown(timeout time.Duration)
+
+	// Flush will flush data to New Relic's servers without stopping the
+	// agent-related goroutines managing this application. This method will block
+	// until the data is flushed or the timeout has elapsed.
+	Flush(timeout time.Duration)
 }
 
 // NewApplication creates an Application and spawns goroutines to manage the


### PR DESCRIPTION
# Problem Summary
I was attempting to instrument an application that runs within AWS Lambda with New Relic and found that I was losing a lot of data due to the Lambda container dying before all of my metrics were flushed to New Relic. I attempted to use the `Shutdown()` method that's provided, but this adds an unacceptable amount of overhead to every one of our lambda executions (we would have to create and shutdown the app for every invocation). Further, it appeared that there was no publicly exposed way to manage the harvest period of the application and even if there was I don't think this would totally solve our problem.

# Solution
I added a `Flush()` method to the application so that a consumer can decide when their data gets pushed to New Relic. This allows us to maintain our application connection within a lambda container while still pushing data as needed. Additionally we won't have to worry about dropping data if a container dies before it is awake long enough to flush harvested data automatically.