### PR TITLE
Allow segments to be started at an explicit time

### DIFF
--- a/internal_test.go
+++ b/internal_test.go
@@ -776,6 +776,8 @@ func TestZeroSegmentsSafe(t *testing.T) {
 
 	StartSegmentNow(nil)
 
+	StartSegmentAt(nil, time.Now())
+
 	ds := DatastoreSegment{}
 	ds.End()
 

--- a/internal_txn.go
+++ b/internal_txn.go
@@ -453,10 +453,14 @@ func (txn *txn) Ignore() error {
 }
 
 func (txn *txn) StartSegmentNow() SegmentStartTime {
+	return txn.StartSegmentAt(time.Now())
+}
+
+func (txn *txn) StartSegmentAt(startedAt time.Time) SegmentStartTime {
 	var s internal.SegmentStartTime
 	txn.Lock()
 	if !txn.finished {
-		s = internal.StartSegment(&txn.TxnData, time.Now())
+		s = internal.StartSegment(&txn.TxnData, startedAt)
 	}
 	txn.Unlock()
 	return SegmentStartTime{

--- a/segments.go
+++ b/segments.go
@@ -1,6 +1,9 @@
 package newrelic
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+)
 
 // SegmentStartTime is created by Transaction.StartSegmentNow and marks the
 // beginning of a segment.  A segment with a zero-valued SegmentStartTime may
@@ -82,6 +85,14 @@ func (s *ExternalSegment) OutboundHeaders() http.Header {
 func StartSegmentNow(txn Transaction) SegmentStartTime {
 	if nil != txn {
 		return txn.StartSegmentNow()
+	}
+	return SegmentStartTime{}
+}
+
+// StartSegmentAt allows setting the start time of a segment.
+func StartSegmentAt(txn Transaction, startedAt time.Time) SegmentStartTime {
+	if nil != txn {
+		return txn.StartSegmentAt(startedAt)
 	}
 	return SegmentStartTime{}
 }

--- a/transaction.go
+++ b/transaction.go
@@ -1,6 +1,9 @@
 package newrelic
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+)
 
 // Transaction represents a request or a background task.
 // Each Transaction should only be used in a single goroutine.
@@ -42,4 +45,7 @@ type Transaction interface {
 	// `StartSegmentNow` functions which checks if the Transaction is nil.
 	// See segments.go
 	StartSegmentNow() SegmentStartTime
+
+	// StartSegmentAt allows timing of code that has already executed.
+	StartSegmentAt(startedAt time.Time) SegmentStartTime
 }


### PR DESCRIPTION
I'm working on a case where we handle a `post-execution` event which contains the start time of the operation in question but does not allow any means of starting the segment timing before the operation begins.

This PR introduces the ability to start a segment at a specific time which allows this use case to be handled.