### PR TITLE
add in Start/End Backdated funcs for Segments

### DIFF
--- a/segments.go
+++ b/segments.go
@@ -1,6 +1,9 @@
 package newrelic
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+)
 
 // SegmentStartTime is created by Transaction.StartSegmentNow and marks the
 // beginning of a segment.  A segment with a zero-valued SegmentStartTime may
@@ -64,13 +67,22 @@ type ExternalSegment struct {
 }
 
 // End finishes the segment.
-func (s *Segment) End() error { return endSegment(s) }
+func (s *Segment) End() error { return endSegment(s, time.Now()) }
+
+// BackdatedEnd finishes the segment that finished some time in the past.
+func (s *Segment) BackdatedEnd(t time.Time) error { return endSegment(s, t) }
 
 // End finishes the datastore segment.
-func (s *DatastoreSegment) End() error { return endDatastore(s) }
+func (s *DatastoreSegment) End() error { return endDatastore(s, time.Now()) }
+
+// BackdatedEnd finishes the datastore segment that finished some time in the past.
+func (s *DatastoreSegment) BackdatedEnd(t time.Time) error { return endDatastore(s, t) }
 
 // End finishes the external segment.
-func (s *ExternalSegment) End() error { return endExternal(s) }
+func (s *ExternalSegment) End() error { return endExternal(s, time.Now()) }
+
+// BackdatedEnd finishes the external segment that finished some time in the past.
+func (s *ExternalSegment) BackdatedEnd(t time.Time) error { return endExternal(s, t) }
 
 // OutboundHeaders returns the headers that should be attached to the external
 // request.

--- a/transaction.go
+++ b/transaction.go
@@ -2,6 +2,7 @@ package newrelic
 
 import (
 	"net/http"
+	"time"
 )
 
 // Transaction represents a request or a background task.
@@ -44,6 +45,8 @@ type Transaction interface {
 	// `StartSegmentNow` functions which checks if the Transaction is nil.
 	// See segments.go
 	StartSegmentNow() SegmentStartTime
+
+	StartBackdatedSegment(t time.Time) SegmentStartTime
 
 	// CreateDistributedTracePayload creates a payload to link the calls
 	// between transactions. This method never returns nil. Instead, it may


### PR DESCRIPTION
I was looking into how I could handle more automatic reporting about database transactions with Cassandra, and the gocql package provides an easy way to hook into every query being executed using something called a [QueryObserver](https://godoc.org/github.com/gocql/gocql#QueryObserver). This gets called after the query is finished with the Start and End times given in the provided object.

In order to use this, I need a way to be able to set segment start and end times to those other than `time.Now()`, hence these changes I made. It didn't seem like this should really be a problem given the model of how segments are only supposed to belong to a single non-concurrent transaction, so allowing for a backdated segment that fits within the model of segments being a stack doesn't cause any problems.

Looking at the past pull requests it looks like they are often taken internally and applied to an internal repo if they are acceptable, so I didn't bother to add as much documentation/tests as ai might normally in a pull request, I hope that is okay. Another thing I was considering is whether the `StartBackdatedSegment` function should return and error if the start time is too early. I left that out for now, but seems like it might be good to add in.