### PR TITLE
Improved Async Support:  Transaction.NewGoroutine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,37 @@
 ## ChangeLog
 
-* Introduced `Transaction.NewGoroutine() Transaction` method which allows the
-  transaction to be used in multiple goroutines!  `NewGoroutine` must be called
-  when the `Transaction` is passed to a different goroutine.  The entire
-  `Transaction` will end when `End()` is called in any goroutine.  Example use:
+* Introduced `Transaction.NewGoroutine() Transaction` method which allows
+  transactions to create segments in multiple goroutines!
+
+`NewGoroutine` returns a new reference to the `Transaction`.  This must be
+called any time you are passing the `Transaction` to another goroutine which
+makes segments.  Each segment-creating goroutine must have its own `Transaction`
+reference.  It does not matter if you call this before or after the other
+goroutine has started.
+
+All `Transaction` methods can be used in any `Transaction` reference.  The
+`Transaction` will end when `End()` is called in any goroutine.
+
+Example passing a new `Transaction` reference directly to another goroutine:
 
 ```go
 	go func(txn newrelic.Transaction) {
 		defer newrelic.StartSegment(txn, "async").End()
 		time.Sleep(100 * time.Millisecond)
 	}(txn.NewGoroutine())
+```
+
+Example passing a new `Transaction` reference on a channel to another
+goroutine:
+
+```go
+	ch := make(chan newrelic.Transaction)
+	go func() {
+		txn := <-ch
+		defer newrelic.StartSegment(txn, "async").End()
+		time.Sleep(100 * time.Millisecond)
+	}()
+	ch <- txn.NewGoroutine()
 ```
 
 ## 2.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## ChangeLog
 
+* Introduced `Transaction.NewGoroutine() Transaction` method which allows the
+  transaction to be used in multiple goroutines!  `NewGoroutine` must be called
+  when the `Transaction` is passed to a different goroutine.  The entire
+  `Transaction` will end when `End()` is called in any goroutine.  Example use:
+
+```go
+	go func(txn newrelic.Transaction) {
+		defer newrelic.StartSegment(txn, "async").End()
+		time.Sleep(100 * time.Millisecond)
+	}(txn.NewGoroutine())
+```
+
 ## 2.5.0
 
 * Added support for [New Relic Browser](https://docs.newrelic.com/docs/browser)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -8,42 +8,227 @@ under the following BSD license:
 All other components of this product are Copyright: (c) 2016-2019 New Relic,
 Inc. All rights reserved.
 
-Certain inventions disclosed in this file may be claimed within patents owned or
-patent applications filed by New Relic, Inc. or third parties.
+By downloading or using the beta, alpha and pre-release versions of New Relic
+software (i.e. agents, SDKs, APIs, integrations, private locations, code, etc.),
+services, features, user-interfaces, and platforms made available for evaluation
+purposes (the “Beta Service(s)”) you signify that you have read, understood, and
+accept the terms of this Beta Agreement (the “Agreement”). This Agreement is
+entered into by and between New Relic, Inc. (“New Relic”) and you on behalf of
+yourself or the entity associated with your New Relic account (collectively
+referred to herein as “you” or “your,”) as of the date you click “I Agree” below
+(the “Effective Date”). You represent and warrant that you have the legal
+authority to enter into this Agreement personally or on behalf of the company or
+organization associated with your New Relic account. Please read this Agreement
+carefully as your use of Beta Service(s) may have unintended consequences and
+materially impact your data or use of the New Relic services and products.
 
-Subject to the terms of this notice, New Relic grants you a nonexclusive,
-nontransferable license, without the right to sublicense, to (a) install and
-execute one copy of these files on any number of workstations owned or
-controlled by you and (b) distribute verbatim copies of these files to third
-parties.  These files and their contents shall not be used in conjunction with
-any other product or software that may compete with any New Relic product,
-feature, or software or be used for the purpose of research, reverse engineering
-or developing such competitive products, features, or software.  As a condition
-to the foregoing grant, you must provide this notice along with each copy you
-distribute and you must not remove, alter, or obscure this notice.  In the event
-you submit or provide any feedback, code, pull requests, or suggestions to New
-Relic you hereby grant New Relic a worldwide, non-exclusive, irrevocable,
-transferrable, fully paid-up license to use the code, algorithms, patents, and
-ideas therein in our products.
+1. Introduction.
 
-All other use, reproduction, modification, distribution, or other exploitation
-of these files is strictly prohibited, except as may be set forth in a separate
-written license agreement between you and New Relic.  The terms of any such
-license agreement will control over this notice.  The license stated above will
-be automatically terminated and revoked if you exceed its scope or violate any
-of the terms of this notice.
+This Agreement enables you to test experimental features and products before
+they are made generally available. New Relic reserves the right to withhold or
+discontinue any Beta Service, which may be designated as an alpha, beta, pilot,
+limited release, developer preview, technology preview, non-production,
+evaluation, or by a similar description, in its sole discretion and provides no
+guarantee that any Beta Service will eventually be made commercially or
+generally available. Beta Services are pre-release versions and may have bugs,
+stability issues, or other problems. Use of the Beta Services may result in
+unexpected results, loss of data, outages, or other damage to your systems or
+networks. New Relic advises against using the Beta Services in production. No
+support is offered with or for Beta Services. You hereby release New Relic from
+any liability arising from or related to your use of the Beta Services. In
+connection with your use of the Beta Services, you may provide feedback,
+comments, and/or suggestions based on or relating to the Beta Services
+(“Feedback”). The Beta Services and any related information, including without
+limitation features, functionality, designs, user interface, capabilities,
+specifications, architectural diagrams, usage data, APIs, deployment schedules,
+email lists, bug databases, know how, source code, potential features, Feedback,
+and information related to any business or technical information of New Relic,
+including without limitation product plans, costs, prices, finances, marketing
+plans, business opportunities, research, development, negotiations, and the
+terms of this agreement are considered the confidential information of New Relic
+(“Confidential Information”).
 
-This License does not grant permission to use the trade names, trademarks,
-service marks, or product names of New Relic, except as required for reasonable
-and customary use in describing the origin of this file and reproducing the
-content of this notice.  You may not mark or brand this file with any trade
-name, trademarks, service marks, or product names other than the original brand
-(if any) provided by New Relic.
+2. License and Restrictions.
 
-Unless otherwise expressly agreed by New Relic in a separate written license
-agreement, these files are provided AS IS, WITHOUT WARRANTY OF ANY KIND,
-including without any implied warranties of MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT.  As a condition to your use of
-these files, you are solely responsible for such use. New Relic will have no
-liability to you for direct, indirect, consequential, incidental, special, or
-punitive damages or for lost profits or data.
+2.1 Evaluation License. Subject to your compliance with the Agreement, New Relic
+hereby grants you a limited, non-exclusive, non-transferable, revocable license,
+during the term of this Agreement, to use the Beta Service(s) solely for the
+purpose of internal evaluation and supplying Feedback to New Relic.
+
+2.2 License Restrictions. You may not (and may not authorize or enable a third
+party to): (i) reverse engineer, decompile, disassemble, or otherwise attempt to
+discover source code or other trade secrets in the Beta Services; (ii) access
+the Beta Services in order to build a similar or competitive application,
+service, feature or other competitive purpose; (iii) remove or destroy any
+copyright notices or other proprietary marks contained on or in the Beta
+Services; (iv) use the Beta Services for any benchmarking purposes or in
+connection with a service bureau, timeshare, service provider, or like activity
+where you operate the Beta Services on behalf of a third party; (v) mirror,
+frame, copy, modify, host, rent, lease, sell, commercialize, sublicense, assign
+or otherwise transfer the Beta Services, use of the Beta Services, or access to
+the Beta Services; (vi) use the Beta Services in a manner that may violate or
+infringe the intellectual property, data protection, or other proprietary right
+of a third party; (vii) use or access the Beta Services in an unauthorized
+manner and/or in a manner that violates any applicable law, rule, contract, or
+guideline (including but not limited to our Community Guidelines); (viii) use
+the Beta Services to transmit worms, viruses, malicious code, security
+vulnerabilities, or otherwise negatively impact network operations, third
+parties, or New Relic; (ix) use any data mining or similar data gathering and
+extraction methods in connection with the Beta Services; (x) use the Beta
+Services to process sensitive personal information, e.g., “personal information”
+of children as defined by the Children’s Online Privacy Protection Act,
+“protected health information” as defined by the Health Insurance Portability
+and Accountability Act of 1996, government issued identification numbers,
+financial account information, payment card data, “special categories of data”
+as described in the EU General Data Protection Regulation (GDPR), or other
+information subject to regulatory, statutory, or contractual restrictions. New
+Relic reserves the right, but not the obligation, to monitor or review your use
+of the Beta Services at any time and may investigate any suspected violations of
+this Agreement.
+
+2.3 Intellectual Property Rights. You acknowledge and agree that, as between you
+and New Relic, New Relic owns all right, title, and interest in and to the Beta
+Services, Confidential Information, and Feedback, including but not limited to
+all intellectual property and proprietary rights therein. New Relic and its
+licensors reserve all rights and licenses not expressly granted herein.
+
+2.4 Feedback.  You may provide feedback, comments, and/or suggestions based on
+or relating to the Beta Services (“Feedback”). You acknowledge and agree that
+all Feedback will be the sole and exclusive property of New Relic. You hereby
+irrevocably transfer and assign to New Relic all right, title, and interest in
+all Feedback, including but not limited to all intellectual property and
+proprietary rights therein.
+
+3. Confidential Information. You will not use or disclose any Confidential
+Information, except as necessary for the performance of this Agreement, and you
+will use reasonable efforts to protect Confidential Information from
+unauthorized use or disclosure. You may disclose Confidential Information only
+to those employees with a bona fide need to know, provided that each employee
+has signed a written agreement with nondisclosure restrictions at least as
+protective of the Confidential Information as those set forth herein. For the
+purposes of this section, information will not be deemed Confidential
+Information if it (a) is or becomes generally known to the public through no
+fault or breach of this Agreement; (b) is rightfully known by you at the time of
+disclosure without an obligation of confidentiality; (c) is independently
+developed by you without access to or use of the Confidential Information; or
+(d) is rightfully obtained by you from a third party without restriction on use
+or disclosure. Upon New Relic’s request, you agree to destroy all Confidential
+Information in your possession within 30 days of termination of this Agreement.
+“Confidential Information” includes the Beta Services and any related
+information, including without limitation features, functionality, designs, user
+interface, capabilities, specifications, architectural diagrams, usage data,
+APIs, deployment schedules, email lists, bug databases, know how, source code,
+potential features, Feedback, and information related to any business or
+technical information of New Relic, including without limitation product plans,
+costs, prices, finances, marketing plans, business opportunities, research,
+development, negotiations, and the terms of this Agreement.
+
+4. Disclaimers & Acknowledgement
+
+4.1 Acknowledgement of Beta Services. You acknowledge and agree that (a) the
+Beta Service is not an official product and has not been commercially released
+for sale by New Relic; (b) the Beta Service may not operate properly, be in
+final form, or fully function; (c) the Beta Service may contain errors, design
+flaws, security vulnerabilities, or other problems; (d) it may not be possible
+to make the Beta Service fully functional or secure; (e) the information
+obtained using the Beta Services may not be accurate; (f) use of the Beta
+Service may result in unexpected results, vulnerabilities, loss of data, project
+delays, or other unpredictable damage or loss, including without limitation to
+your use of New Relic services and products not governed by this Agreement
+(collectively “Unintended Effects”); (g) New Relic is under no obligation to
+release a commercial or generally available version of the Beta Service; and (h)
+New Relic has the right unilaterally to abandon development of the Beta Service
+at any time and without any obligation or liability to you.
+
+4.2 Your Data. You acknowledge and agree that you should not rely on the Beta
+Service for any reason. You further acknowledge and agree that you are solely
+responsible for maintaining and protecting all data and information that is
+stored, retrieved, or otherwise processed by the Beta Service in accordance with
+your contractual obligations and requirements under applicable law. Without
+limiting the foregoing, you are responsible for all costs and expenses required
+to backup and restore any data and information that is lost or corrupted as a
+result of your use of the Beta Services or any Unintended Effects. You
+understand and agree that your Data may be transferred to the United States for
+storage, processing, and use by New Relic to provide the Beta Services. For any
+data that you process using the Beta Services, you represent and warrant that
+you have all necessary rights and consent to do so. New Relic has no obligation
+to store any data you process using the Beta Services and shall have no
+liability for the deletion or accuracy of such data.
+
+4.3 Warranty Disclaimers. YOU ACKNOWLEDGE THAT BETA SERVICES ARE PROVIDED “AS
+IS.” TO THE EXTENT PERMITTED BY APPLICABLE LAW, NEW RELIC DISCLAIMS ALL
+WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES
+REGARDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT,
+SECURITY, AND ANY WARRANTIES ARISING OUT OF THE COURSE OF DEALING OR USAGE OF
+TRADE. NEW RELIC MAKES NO WARRANTY THAT BETA SERVICES WILL MEET YOUR
+REQUIREMENTS OR WILL BE ACCURATE, RELIABLE, ERROR-FREE, UNINTERRUPTED, TIMELY,
+OR SECURE. YOUR USE OF BETA SERVICES IS AT YOUR OWN RISK.
+
+5. Limitation of Liability. TO THE EXTENT PERMITTED BY APPLICABLE LAW, IN NO
+EVENT WILL NEW RELIC, ITS AFFILIATES, OFFICERS, EMPLOYEES, AGENTS, SUPPLIERS OR
+LICENSORS BE LIABLE FOR ANY INDIRECT, SPECIAL, INCIDENTAL, PUNITIVE, EXEMPLARY
+OR CONSEQUENTIAL (INCLUDING LOSS OF USE, DATA, BUSINESS, OR PROFITS) DAMAGES,
+REGARDLESS OF LEGAL THEORY, WHETHER OR NOT NEW RELIC HAS BEEN WARNED OF THE
+POSSIBILITY OF SUCH DAMAGES, AND EVEN IF A REMEDY FAILS OF ITS ESSENTIAL
+PURPOSE. NEW RELIC’S AGGREGATE LIABILITY FOR ALL CLAIMS RELATING TO THIS
+AGREEMENT, THE BETA SERVICES, OR ANY UNINTENDED EFFECTS WILL BE LIMITED TO FIFTY
+U.S. DOLLARS (U.S. $50). THE LIMITATIONS OF DAMAGES SET FORTH ABOVE ARE
+FUNDAMENTAL ELEMENTS OF THE BASIS OF THE BARGAIN BETWEEN NEW RELIC AND YOU.
+
+6. Indemnity. You agree to indemnify and hold New Relic, its parents,
+subsidiaries, affiliates,  officers, agents, employees, and licensors harmless
+from any claims, fees, fines, demands, losses, liabilities, damages, and costs,
+including reasonable attorney’s fees, arising from or related to your use of the
+Beta Services, including but not limited to allegations arising from your breach
+of any terms herein and/or allegations that data processed by the Beta Services
+violates or infringes the privacy, data protection, or intellectual property
+rights of a third party.
+
+7. Export Restrictions. You acknowledge that the software in the Beta Services
+licensed hereunder may be subject to the export control laws and regulations of
+the U.S. and other countries. You agree that you will not export or re-export
+the Beta Service, any part thereof, or any process or service that is the direct
+product of the Beta Service to any country, person or entity subject to U.S.
+export restrictions.
+
+8. Term and Termination. This Agreement shall commence upon the Effective Date
+and shall remain in effect until terminated upon the earliest of: (i) New Relic
+making the Beta Service or a successor version of the Beta Service generally
+available or available for commercial release, (ii) New Relic ceasing to make
+the Beta Service available to you, or (iii) New Relic terminating this
+Agreement. New Relic may terminate this Agreement for any reason upon notice to
+you. Sections 2.2, 2.3, 2.4, 3, 4, 5, 6, 7, and 9 will survive any termination
+or expiration of this Agreement.
+
+9. General. You represent and warrant that you have the legal authority to enter
+into this Agreement personally or on behalf of the company or organization
+associated with your New Relic account. This Agreement will be governed by and
+construed in accordance with the laws of the State of California. The parties
+expressly agree that the United Nations Convention on Contracts for the
+International Sale of Goods will not apply. Any legal action or proceeding
+arising under this Agreement, will be brought exclusively in the federal or
+state courts located in San Francisco County, California and the parties hereby
+irrevocably consent to the personal jurisdiction and venue.  If any provision of
+this Agreement is held invalid or unenforceable by a court of competent
+jurisdiction, such provision will be construed so as to be enforceable to the
+maximum extent permissible by law, and the remaining provisions of the Agreement
+will remain in full force and effect. You may not assign this Agreement, by
+operation of law or otherwise, without the prior written consent of New Relic.
+Any attempted assignment without such consent will be void and of no effect.
+Your obligations under this Agreement shall survive termination of the Agreement
+and shall be binding upon your agents, representatives, heirs, successors and
+assigns. All notices or reports to New Relic as permitted or required under this
+Agreement shall be in writing and must be received at New Relic Inc., 188 Spear
+Street, Suite 1200, ATTN: General Counsel, San Francisco, CA 94105, USA by
+personal delivery or by certified or registered mail, return receipt requested,
+and shall be deemed given upon personal delivery to or if sent by certified or
+registered mail, three (3) days after the date of mailing. All notices or
+reports to you shall be delivered by posting a notice, message, banner, or other
+form of alert to your New Relic account, by email, or by facsimile transmission.
+This Agreement constitutes the entire agreement between the parties pertaining
+to the subject matter hereof, and supersedes any and all prior agreements,
+communications and understandings (both written and oral) regarding such subject
+matter.  For clarity, in the event of any inconsistency, conflict, or ambiguity
+between this Agreement and any other contract agreement between the parties, as
+it relates to Beta Services, or any Unintended Effects, this Agreement shall
+govern.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # New Relic Go Agent [![GoDoc](https://godoc.org/github.com/newrelic/go-agent?status.svg)](https://godoc.org/github.com/newrelic/go-agent)
 
+## Pre-Release
+
+WARNING: THIS CODE IS IN DEVELOPMENT.  IT IS NOT A FINAL NEW RELIC PRODUCT OR
+OFFERING. DO NOT USE IN PRODUCTION. USE AT YOUR OWN RISK. TERMS AND CONDITIONS
+APPLY - SEE LICENSE FILE.
+
 ## Description
 
 The New Relic Go Agent allows you to monitor your Go applications with New

--- a/internal/errors_test.go
+++ b/internal/errors_test.go
@@ -40,6 +40,7 @@ func TestErrorTraceMarshal(t *testing.T) {
 				ID:       "txn-id",
 				Priority: 0.5,
 			},
+			TotalTime: 2 * time.Second,
 		},
 	}
 	js, err := json.Marshal(he)
@@ -57,6 +58,7 @@ func TestErrorTraceMarshal(t *testing.T) {
 			"agentAttributes":{},
 			"userAttributes":{},
 			"intrinsics":{
+				"totalTime":2,
 				"guid":"txn-id",
 				"traceId":"txn-id",
 				"priority":0.500000,
@@ -82,6 +84,7 @@ func TestErrorTraceMarshalOldCAT(t *testing.T) {
 			BetterCAT: BetterCAT{
 				Enabled: false,
 			},
+			TotalTime: 2 * time.Second,
 		},
 	}
 	js, err := json.Marshal(he)
@@ -98,7 +101,9 @@ func TestErrorTraceMarshalOldCAT(t *testing.T) {
 		{
 			"agentAttributes":{},
 			"userAttributes":{},
-			"intrinsics":{},
+			"intrinsics":{
+				"totalTime":2
+			},
 			"stack_trace":[]
 		}
 	]`
@@ -131,6 +136,7 @@ func TestErrorTraceAttributes(t *testing.T) {
 				ID:       "txn-id",
 				Priority: 0.5,
 			},
+			TotalTime: 2 * time.Second,
 		},
 	}
 	js, err := json.Marshal(he)
@@ -147,6 +153,7 @@ func TestErrorTraceAttributes(t *testing.T) {
 			"agentAttributes":{"request.uri":"my_request_uri"},
 			"userAttributes":{"zip":456},
 			"intrinsics":{
+				"totalTime":2,
 				"guid":"txn-id",
 				"traceId":"txn-id",
 				"priority":0.500000,
@@ -181,6 +188,7 @@ func TestErrorTraceAttributesOldCAT(t *testing.T) {
 			BetterCAT: BetterCAT{
 				Enabled: false,
 			},
+			TotalTime: 2 * time.Second,
 		},
 	}
 	js, err := json.Marshal(he)
@@ -196,7 +204,9 @@ func TestErrorTraceAttributesOldCAT(t *testing.T) {
 		{
 			"agentAttributes":{"request.uri":"my_request_uri"},
 			"userAttributes":{"zip":456},
-			"intrinsics":{}
+			"intrinsics":{
+				"totalTime":2
+			}
 		}
 	]`
 	testExpectedJSON(t, expect, string(js))
@@ -220,6 +230,7 @@ func TestErrorsLifecycle(t *testing.T) {
 			ID:       "txn-id",
 			Priority: 0.5,
 		},
+		TotalTime: 2 * time.Second,
 	})
 	js, err := he.Data("agentRunID", time.Now())
 	if nil != err {
@@ -238,6 +249,7 @@ func TestErrorsLifecycle(t *testing.T) {
             "agentAttributes":{},
             "userAttributes":{},
             "intrinsics":{
+               "totalTime":2,
                "guid":"txn-id",
                "traceId":"txn-id",
                "priority":0.500000,
@@ -254,6 +266,7 @@ func TestErrorsLifecycle(t *testing.T) {
             "agentAttributes":{},
             "userAttributes":{},
             "intrinsics":{
+               "totalTime":2,
                "guid":"txn-id",
                "traceId":"txn-id",
                "priority":0.500000,
@@ -270,6 +283,7 @@ func TestErrorsLifecycle(t *testing.T) {
             "agentAttributes":{},
             "userAttributes":{},
             "intrinsics":{
+               "totalTime":2,
                "guid":"txn-id",
                "traceId":"txn-id",
                "priority":0.500000,

--- a/internal/expect.go
+++ b/internal/expect.go
@@ -62,7 +62,7 @@ type WantError struct {
 	Caller  string
 	// NotNoticed should be true if the stack trace was not generated within
 	// txn.NoticeError.  This field is provided to account for extra stack
-	// frames when running with -race.
+	// frames when running tests with -race.
 	NotNoticed      bool
 	UserAttributes  map[string]interface{}
 	AgentAttributes map[string]interface{}

--- a/internal/expect.go
+++ b/internal/expect.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime"
+
+	"github.com/newrelic/go-agent/internal/racedetector"
 )
 
 var (
@@ -54,10 +56,14 @@ type WantMetric struct {
 
 // WantError is a traced error expectation.
 type WantError struct {
-	TxnName         string
-	Msg             string
-	Klass           string
-	Caller          string
+	TxnName string
+	Msg     string
+	Klass   string
+	Caller  string
+	// NotNoticed should be true if the stack trace was not generated within
+	// txn.NoticeError.  This field is provided to account for extra stack
+	// frames when running with -race.
+	NotNoticed      bool
 	UserAttributes  map[string]interface{}
 	AgentAttributes map[string]interface{}
 }
@@ -133,6 +139,8 @@ func ExpectTxnMetrics(t Validator, mt *metricTable, want WantTxn) {
 		metrics = []WantMetric{
 			{Name: "WebTransaction/Go/" + want.Name, Scope: "", Forced: true, Data: nil},
 			{Name: "WebTransaction", Scope: "", Forced: true, Data: nil},
+			{Name: "WebTransactionTotalTime/Go/" + want.Name, Scope: "", Forced: false, Data: nil},
+			{Name: "WebTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 			{Name: "HttpDispatcher", Scope: "", Forced: true, Data: nil},
 			{Name: "Apdex", Scope: "", Forced: true, Data: nil},
 			{Name: "Apdex/Go/" + want.Name, Scope: "", Forced: false, Data: nil},
@@ -143,6 +151,8 @@ func ExpectTxnMetrics(t Validator, mt *metricTable, want WantTxn) {
 		metrics = []WantMetric{
 			{Name: "OtherTransaction/Go/" + want.Name, Scope: "", Forced: true, Data: nil},
 			{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
+			{Name: "OtherTransactionTotalTime/Go/" + want.Name, Scope: "", Forced: false, Data: nil},
+			{Name: "OtherTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		}
 	}
 	if want.NumErrors > 0 {
@@ -557,6 +567,7 @@ func ExpectTxnEvents(v Validator, events *txnEvents, expect []WantEvent) {
 					"type":      "Transaction",
 					"timestamp": MatchAnything,
 					"duration":  MatchAnything,
+					"totalTime": MatchAnything,
 					"error":     MatchAnything,
 				}, e.Intrinsics)
 			}
@@ -566,7 +577,14 @@ func ExpectTxnEvents(v Validator, events *txnEvents, expect []WantEvent) {
 }
 
 func expectError(v Validator, err *tracedError, expect WantError) {
-	caller := topCallerNameBase(err.ErrorData.Stack)
+	extraSkipFrames := 0
+	if !expect.NotNoticed && racedetector.Enabled {
+		// If the race detector is enabled then the stacktraces produced
+		// by txn.NoticeError will have an extra stack frame caused by
+		// embedding the txn into the thread.
+		extraSkipFrames = 1
+	}
+	caller := topCallerNameBase(err.ErrorData.Stack, extraSkipFrames)
 	validateStringField(v, "caller", expect.Caller, caller)
 	validateStringField(v, "txnName", expect.TxnName, err.FinalName)
 	validateStringField(v, "klass", expect.Klass, err.Klass)

--- a/internal/harvest.go
+++ b/internal/harvest.go
@@ -145,7 +145,7 @@ func CreateTxnMetrics(args *TxnData, metrics *metricTable) {
 		totalTimeRollup = totalTimeBackground
 	}
 
-	metrics.addDuration(args.FinalName, "", args.Duration, args.Duration, forced)
+	metrics.addDuration(args.FinalName, "", args.Duration, 0, forced)
 	metrics.addDuration(durationRollup, "", args.Duration, args.Duration, forced)
 
 	metrics.addDuration(totalTimeRollup, "", args.TotalTime, args.TotalTime, forced)

--- a/internal/harvest.go
+++ b/internal/harvest.go
@@ -146,7 +146,7 @@ func CreateTxnMetrics(args *TxnData, metrics *metricTable) {
 	}
 
 	metrics.addDuration(args.FinalName, "", args.Duration, 0, forced)
-	metrics.addDuration(durationRollup, "", args.Duration, args.Duration, forced)
+	metrics.addDuration(durationRollup, "", args.Duration, 0, forced)
 
 	metrics.addDuration(totalTimeRollup, "", args.TotalTime, args.TotalTime, forced)
 	metrics.addDuration(totalTimeRollup+"/"+withoutFirstSegment, "", args.TotalTime, args.TotalTime, unforced)

--- a/internal/harvest.go
+++ b/internal/harvest.go
@@ -131,15 +131,25 @@ func supportMetric(metrics *metricTable, b bool, metricName string) {
 
 // CreateTxnMetrics creates metrics for a transaction.
 func CreateTxnMetrics(args *TxnData, metrics *metricTable) {
+	withoutFirstSegment := removeFirstSegment(args.FinalName)
+
 	// Duration Metrics
-	rollup := backgroundRollup
+	var durationRollup string
+	var totalTimeRollup string
 	if args.IsWeb {
-		rollup = webRollup
+		durationRollup = webRollup
+		totalTimeRollup = totalTimeWeb
 		metrics.addDuration(dispatcherMetric, "", args.Duration, 0, forced)
+	} else {
+		durationRollup = backgroundRollup
+		totalTimeRollup = totalTimeBackground
 	}
 
-	metrics.addDuration(args.FinalName, "", args.Duration, args.Exclusive, forced)
-	metrics.addDuration(rollup, "", args.Duration, args.Exclusive, forced)
+	metrics.addDuration(args.FinalName, "", args.Duration, args.Duration, forced)
+	metrics.addDuration(durationRollup, "", args.Duration, args.Duration, forced)
+
+	metrics.addDuration(totalTimeRollup, "", args.TotalTime, args.TotalTime, forced)
+	metrics.addDuration(totalTimeRollup+"/"+withoutFirstSegment, "", args.TotalTime, args.TotalTime, unforced)
 
 	// Better CAT Metrics
 	if cat := args.BetterCAT; cat.Enabled {
@@ -182,7 +192,7 @@ func CreateTxnMetrics(args *TxnData, metrics *metricTable) {
 	if args.Zone != ApdexNone {
 		metrics.addApdex(apdexRollup, "", args.ApdexThreshold, args.Zone, forced)
 
-		mname := apdexPrefix + removeFirstSegment(args.FinalName)
+		mname := apdexPrefix + withoutFirstSegment
 		metrics.addApdex(mname, "", args.ApdexThreshold, args.Zone, unforced)
 	}
 

--- a/internal/harvest_test.go
+++ b/internal/harvest_test.go
@@ -265,7 +265,7 @@ func TestCreateTxnMetrics(t *testing.T) {
 	CreateTxnMetrics(args, metrics)
 	ExpectMetrics(t, metrics, []WantMetric{
 		{webName, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
-		{webRollup, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{webRollup, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{dispatcherMetric, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{"WebTransactionTotalTime", "", true, []float64{1, 150, 150, 150, 150, 150 * 150}},
 		{"WebTransactionTotalTime/zip/zap", "", false, []float64{1, 150, 150, 150, 150, 150 * 150}},
@@ -288,7 +288,7 @@ func TestCreateTxnMetrics(t *testing.T) {
 	CreateTxnMetrics(args, metrics)
 	ExpectMetrics(t, metrics, []WantMetric{
 		{webName, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
-		{webRollup, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{webRollup, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{dispatcherMetric, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{"WebTransactionTotalTime", "", true, []float64{1, 150, 150, 150, 150, 150 * 150}},
 		{"WebTransactionTotalTime/zip/zap", "", false, []float64{1, 150, 150, 150, 150, 150 * 150}},
@@ -306,7 +306,7 @@ func TestCreateTxnMetrics(t *testing.T) {
 	CreateTxnMetrics(args, metrics)
 	ExpectMetrics(t, metrics, []WantMetric{
 		{backgroundName, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
-		{backgroundRollup, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{backgroundRollup, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{"OtherTransactionTotalTime", "", true, []float64{1, 150, 150, 150, 150, 150 * 150}},
 		{"OtherTransactionTotalTime/zip/zap", "", false, []float64{1, 150, 150, 150, 150, 150 * 150}},
 		{"Errors/all", "", true, []float64{1, 0, 0, 0, 0, 0}},
@@ -326,7 +326,7 @@ func TestCreateTxnMetrics(t *testing.T) {
 	CreateTxnMetrics(args, metrics)
 	ExpectMetrics(t, metrics, []WantMetric{
 		{backgroundName, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
-		{backgroundRollup, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{backgroundRollup, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{"OtherTransactionTotalTime", "", true, []float64{1, 150, 150, 150, 150, 150 * 150}},
 		{"OtherTransactionTotalTime/zip/zap", "", false, []float64{1, 150, 150, 150, 150, 150 * 150}},
 		{"DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", "", false, []float64{1, 123, 123, 123, 123, 123 * 123}},
@@ -374,7 +374,7 @@ func TestCreateTxnMetricsOldCAT(t *testing.T) {
 	CreateTxnMetrics(args, metrics)
 	ExpectMetrics(t, metrics, []WantMetric{
 		{webName, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
-		{webRollup, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{webRollup, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{dispatcherMetric, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{"WebTransactionTotalTime", "", true, []float64{1, 150, 150, 150, 150, 150 * 150}},
 		{"WebTransactionTotalTime/zip/zap", "", false, []float64{1, 150, 150, 150, 150, 150 * 150}},
@@ -393,7 +393,7 @@ func TestCreateTxnMetricsOldCAT(t *testing.T) {
 	CreateTxnMetrics(args, metrics)
 	ExpectMetrics(t, metrics, []WantMetric{
 		{webName, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
-		{webRollup, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{webRollup, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{dispatcherMetric, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{"WebTransactionTotalTime", "", true, []float64{1, 150, 150, 150, 150, 150 * 150}},
 		{"WebTransactionTotalTime/zip/zap", "", false, []float64{1, 150, 150, 150, 150, 150 * 150}},
@@ -409,7 +409,7 @@ func TestCreateTxnMetricsOldCAT(t *testing.T) {
 	CreateTxnMetrics(args, metrics)
 	ExpectMetrics(t, metrics, []WantMetric{
 		{backgroundName, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
-		{backgroundRollup, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{backgroundRollup, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{"OtherTransactionTotalTime", "", true, []float64{1, 150, 150, 150, 150, 150 * 150}},
 		{"OtherTransactionTotalTime/zip/zap", "", false, []float64{1, 150, 150, 150, 150, 150 * 150}},
 		{"Errors/all", "", true, []float64{1, 0, 0, 0, 0, 0}},
@@ -425,7 +425,7 @@ func TestCreateTxnMetricsOldCAT(t *testing.T) {
 	CreateTxnMetrics(args, metrics)
 	ExpectMetrics(t, metrics, []WantMetric{
 		{backgroundName, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
-		{backgroundRollup, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{backgroundRollup, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{"OtherTransactionTotalTime", "", true, []float64{1, 150, 150, 150, 150, 150 * 150}},
 		{"OtherTransactionTotalTime/zip/zap", "", false, []float64{1, 150, 150, 150, 150, 150 * 150}},
 	})

--- a/internal/harvest_test.go
+++ b/internal/harvest_test.go
@@ -264,7 +264,7 @@ func TestCreateTxnMetrics(t *testing.T) {
 	metrics := newMetricTable(100, time.Now())
 	CreateTxnMetrics(args, metrics)
 	ExpectMetrics(t, metrics, []WantMetric{
-		{webName, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{webName, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{webRollup, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
 		{dispatcherMetric, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{"WebTransactionTotalTime", "", true, []float64{1, 150, 150, 150, 150, 150 * 150}},
@@ -287,7 +287,7 @@ func TestCreateTxnMetrics(t *testing.T) {
 	metrics = newMetricTable(100, time.Now())
 	CreateTxnMetrics(args, metrics)
 	ExpectMetrics(t, metrics, []WantMetric{
-		{webName, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{webName, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{webRollup, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
 		{dispatcherMetric, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{"WebTransactionTotalTime", "", true, []float64{1, 150, 150, 150, 150, 150 * 150}},
@@ -305,7 +305,7 @@ func TestCreateTxnMetrics(t *testing.T) {
 	metrics = newMetricTable(100, time.Now())
 	CreateTxnMetrics(args, metrics)
 	ExpectMetrics(t, metrics, []WantMetric{
-		{backgroundName, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{backgroundName, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{backgroundRollup, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
 		{"OtherTransactionTotalTime", "", true, []float64{1, 150, 150, 150, 150, 150 * 150}},
 		{"OtherTransactionTotalTime/zip/zap", "", false, []float64{1, 150, 150, 150, 150, 150 * 150}},
@@ -325,7 +325,7 @@ func TestCreateTxnMetrics(t *testing.T) {
 	metrics = newMetricTable(100, time.Now())
 	CreateTxnMetrics(args, metrics)
 	ExpectMetrics(t, metrics, []WantMetric{
-		{backgroundName, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{backgroundName, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{backgroundRollup, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
 		{"OtherTransactionTotalTime", "", true, []float64{1, 150, 150, 150, 150, 150 * 150}},
 		{"OtherTransactionTotalTime/zip/zap", "", false, []float64{1, 150, 150, 150, 150, 150 * 150}},
@@ -373,7 +373,7 @@ func TestCreateTxnMetricsOldCAT(t *testing.T) {
 	metrics := newMetricTable(100, time.Now())
 	CreateTxnMetrics(args, metrics)
 	ExpectMetrics(t, metrics, []WantMetric{
-		{webName, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{webName, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{webRollup, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
 		{dispatcherMetric, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{"WebTransactionTotalTime", "", true, []float64{1, 150, 150, 150, 150, 150 * 150}},
@@ -392,7 +392,7 @@ func TestCreateTxnMetricsOldCAT(t *testing.T) {
 	metrics = newMetricTable(100, time.Now())
 	CreateTxnMetrics(args, metrics)
 	ExpectMetrics(t, metrics, []WantMetric{
-		{webName, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{webName, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{webRollup, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
 		{dispatcherMetric, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{"WebTransactionTotalTime", "", true, []float64{1, 150, 150, 150, 150, 150 * 150}},
@@ -408,7 +408,7 @@ func TestCreateTxnMetricsOldCAT(t *testing.T) {
 	metrics = newMetricTable(100, time.Now())
 	CreateTxnMetrics(args, metrics)
 	ExpectMetrics(t, metrics, []WantMetric{
-		{backgroundName, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{backgroundName, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{backgroundRollup, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
 		{"OtherTransactionTotalTime", "", true, []float64{1, 150, 150, 150, 150, 150 * 150}},
 		{"OtherTransactionTotalTime/zip/zap", "", false, []float64{1, 150, 150, 150, 150, 150 * 150}},
@@ -424,7 +424,7 @@ func TestCreateTxnMetricsOldCAT(t *testing.T) {
 	metrics = newMetricTable(100, time.Now())
 	CreateTxnMetrics(args, metrics)
 	ExpectMetrics(t, metrics, []WantMetric{
-		{backgroundName, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{backgroundName, "", true, []float64{1, 123, 0, 123, 123, 123 * 123}},
 		{backgroundRollup, "", true, []float64{1, 123, 123, 123, 123, 123 * 123}},
 		{"OtherTransactionTotalTime", "", true, []float64{1, 150, 150, 150, 150, 150 * 150}},
 		{"OtherTransactionTotalTime/zip/zap", "", false, []float64{1, 150, 150, 150, 150, 150 * 150}},

--- a/internal/intrinsics.go
+++ b/internal/intrinsics.go
@@ -15,6 +15,8 @@ func intrinsicsJSON(e *TxnEvent, buf *bytes.Buffer) {
 
 	buf.WriteByte('{')
 
+	w.floatField("totalTime", e.TotalTime.Seconds())
+
 	if e.BetterCAT.Enabled {
 		w.stringField("guid", e.BetterCAT.ID)
 		w.stringField("traceId", e.BetterCAT.TraceID())

--- a/internal/metric_names.go
+++ b/internal/metric_names.go
@@ -7,6 +7,10 @@ const (
 	webRollup        = "WebTransaction"
 	backgroundRollup = "OtherTransaction/all"
 
+	// https://source.datanerd.us/agents/agent-specs/blob/master/Total-Time-Async.md
+	totalTimeWeb        = "WebTransactionTotalTime"
+	totalTimeBackground = "OtherTransactionTotalTime"
+
 	errorsPrefix = "Errors/"
 
 	// "HttpDispatcher" metric is used for the overview graph, and

--- a/internal/racedetector/disabled.go
+++ b/internal/racedetector/disabled.go
@@ -1,0 +1,6 @@
+// +build !race
+
+package racedetector
+
+// Enabled indicates if the race detector is enabled.
+const Enabled = false

--- a/internal/racedetector/enabled.go
+++ b/internal/racedetector/enabled.go
@@ -1,0 +1,6 @@
+// +build race
+
+package racedetector
+
+// Enabled indicates if the race detector is enabled.
+const Enabled = true

--- a/internal/stacktrace.go
+++ b/internal/stacktrace.go
@@ -31,8 +31,8 @@ func pcToFunc(pc uintptr) (*runtime.Func, uintptr) {
 	return runtime.FuncForPC(place), place
 }
 
-func topCallerNameBase(st StackTrace) string {
-	f, _ := pcToFunc(st[0])
+func topCallerNameBase(st StackTrace, extraSkipFrames int) string {
+	f, _ := pcToFunc(st[extraSkipFrames])
 	if nil == f {
 		return ""
 	}

--- a/internal/tools/interface-wrapping/transaction_response_writer.json
+++ b/internal/tools/interface-wrapping/transaction_response_writer.json
@@ -1,7 +1,7 @@
 {
 	"comment": "used in internal_response_writer.go",
-	"variable_name": "txn",
-	"test_variable_name": "txn.writer",
+	"variable_name": "trd",
+	"test_variable_name": "trd.txn.writer",
 	"required_interfaces": [
 		"Transaction"
 	],

--- a/internal/tools/interface-wrapping/transaction_response_writer.json
+++ b/internal/tools/interface-wrapping/transaction_response_writer.json
@@ -1,7 +1,7 @@
 {
 	"comment": "used in internal_response_writer.go",
-	"variable_name": "trd",
-	"test_variable_name": "trd.txn.writer",
+	"variable_name": "thd",
+	"test_variable_name": "thd.txn.writer",
 	"required_interfaces": [
 		"Transaction"
 	],

--- a/internal/tracing.go
+++ b/internal/tracing.go
@@ -29,6 +29,7 @@ type TxnEvent struct {
 	FinalName string
 	Start     time.Time
 	Duration  time.Duration
+	TotalTime time.Duration
 	Queuing   time.Duration
 	Zone      ApdexZone
 	Attrs     *Attributes
@@ -64,11 +65,9 @@ type TxnData struct {
 	Errors         TxnErrors // Lazily initialized.
 	Stop           time.Time
 	ApdexThreshold time.Duration
-	Exclusive      time.Duration
 
-	finishedChildren time.Duration
-	stamp            segmentStamp
-	stack            []segmentFrame
+	stamp           segmentStamp
+	threadIDCounter uint64
 
 	LazilyCalculateSampled func() bool
 	SpanEventsEnabled      bool
@@ -88,6 +87,45 @@ type TxnData struct {
 	// These better CAT supportability fields are left outside of
 	// TxnEvent.BetterCAT to minimize the size of transaction event memory.
 	DistributedTracingSupport
+}
+
+// Thread contains a segment stack that is used to track segment parenting time
+// within a single goroutine.
+type Thread struct {
+	threadID uint64
+	stack    []segmentFrame
+	// start and end are used to track the TotalTime this Thread was active.
+	start time.Time
+	end   time.Time
+}
+
+// RecordActivity indicates that activity happened at this time on this
+// goroutine which helps track total time.
+func (thread *Thread) RecordActivity(now time.Time) {
+	if thread.start.IsZero() || now.Before(thread.start) {
+		thread.start = now
+	}
+	if now.After(thread.end) {
+		thread.end = now
+	}
+}
+
+// TotalTime returns the amount to time that this thread contributes to the
+// total time.
+func (thread *Thread) TotalTime() time.Duration {
+	if thread.start.Before(thread.end) {
+		return thread.end.Sub(thread.start)
+	}
+	return 0
+}
+
+// NewThread returns a new Thread to track segments in a new goroutine.
+func NewThread(txndata *TxnData) *Thread {
+	// Each thread needs a unique ID.
+	txndata.threadIDCounter++
+	return &Thread{
+		threadID: txndata.threadIDCounter,
+	}
 }
 
 type segmentStamp uint64
@@ -117,6 +155,7 @@ type segmentEnd struct {
 	exclusive time.Duration
 	SpanID    string
 	ParentID  string
+	threadID  uint64
 }
 
 func (end segmentEnd) spanEvent() *SpanEvent {
@@ -151,26 +190,17 @@ func (t *TxnData) time(now time.Time) segmentTime {
 	}
 }
 
-// TracerRootChildren is used to calculate a transaction's exclusive duration.
-func TracerRootChildren(t *TxnData) time.Duration {
-	var lostChildren time.Duration
-	for i := 0; i < len(t.stack); i++ {
-		lostChildren += t.stack[i].children
-	}
-	return t.finishedChildren + lostChildren
-}
-
 // StartSegment begins a segment.
-func StartSegment(t *TxnData, now time.Time) SegmentStartTime {
+func StartSegment(t *TxnData, thread *Thread, now time.Time) SegmentStartTime {
 	tm := t.time(now)
-	t.stack = append(t.stack, segmentFrame{
+	thread.stack = append(thread.stack, segmentFrame{
 		segmentTime: tm,
 		children:    0,
 	})
 
 	return SegmentStartTime{
 		Stamp: tm.Stamp,
-		Depth: len(t.stack) - 1,
+		Depth: len(thread.stack) - 1,
 	}
 }
 
@@ -190,14 +220,14 @@ func (t *TxnData) getRootSpanID() string {
 
 // CurrentSpanIdentifier returns the identifier of the span at the top of the
 // segment stack.
-func (t *TxnData) CurrentSpanIdentifier() string {
-	if 0 == len(t.stack) {
+func (t *TxnData) CurrentSpanIdentifier(thread *Thread) string {
+	if 0 == len(thread.stack) {
 		return t.getRootSpanID()
 	}
-	if "" == t.stack[len(t.stack)-1].spanID {
-		t.stack[len(t.stack)-1].spanID = NewSpanID()
+	if "" == thread.stack[len(thread.stack)-1].spanID {
+		thread.stack[len(thread.stack)-1].spanID = NewSpanID()
 	}
-	return t.stack[len(t.stack)-1].spanID
+	return thread.stack[len(thread.stack)-1].spanID
 }
 
 func (t *TxnData) saveSpanEvent(e *SpanEvent) {
@@ -213,24 +243,24 @@ var (
 		`see https://github.com/newrelic/go-agent/blob/master/GUIDE.md#segments`)
 )
 
-func endSegment(t *TxnData, start SegmentStartTime, now time.Time) (segmentEnd, error) {
+func endSegment(t *TxnData, thread *Thread, start SegmentStartTime, now time.Time) (segmentEnd, error) {
 	if 0 == start.Stamp {
 		return segmentEnd{}, errMalformedSegment
 	}
-	if start.Depth >= len(t.stack) {
+	if start.Depth >= len(thread.stack) {
 		return segmentEnd{}, errSegmentOrder
 	}
 	if start.Depth < 0 {
 		return segmentEnd{}, errMalformedSegment
 	}
-	frame := t.stack[start.Depth]
+	frame := thread.stack[start.Depth]
 	if start.Stamp != frame.Stamp {
 		return segmentEnd{}, errSegmentOrder
 	}
 
 	var children time.Duration
-	for i := start.Depth; i < len(t.stack); i++ {
-		children += t.stack[i].children
+	for i := start.Depth; i < len(thread.stack); i++ {
+		children += thread.stack[i].children
 	}
 	s := segmentEnd{
 		stop:  t.time(now),
@@ -247,13 +277,11 @@ func endSegment(t *TxnData, start SegmentStartTime, now time.Time) (segmentEnd, 
 	// (depth < (len(t.stack) - 1)), that's ok: could be a panic popped
 	// some stack frames (and the consumer was not using defer).
 
-	if 0 == start.Depth {
-		t.finishedChildren += s.duration
-	} else {
-		t.stack[start.Depth-1].children += s.duration
+	if start.Depth > 0 {
+		thread.stack[start.Depth-1].children += s.duration
 	}
 
-	t.stack = t.stack[0:start.Depth]
+	thread.stack = thread.stack[0:start.Depth]
 
 	if t.SpanEventsEnabled && t.LazilyCalculateSampled() {
 		s.SpanID = frame.spanID
@@ -263,15 +291,20 @@ func endSegment(t *TxnData, start SegmentStartTime, now time.Time) (segmentEnd, 
 		// Note that the current span identifier is the parent's
 		// identifier because we've already popped the segment that's
 		// ending off of the stack.
-		s.ParentID = t.CurrentSpanIdentifier()
+		s.ParentID = t.CurrentSpanIdentifier(thread)
 	}
+
+	s.threadID = thread.threadID
+
+	thread.RecordActivity(s.start.Time)
+	thread.RecordActivity(s.stop.Time)
 
 	return s, nil
 }
 
 // EndBasicSegment ends a basic segment.
-func EndBasicSegment(t *TxnData, start SegmentStartTime, now time.Time, name string) error {
-	end, err := endSegment(t, start, now)
+func EndBasicSegment(t *TxnData, thread *Thread, start SegmentStartTime, now time.Time, name string) error {
+	end, err := endSegment(t, thread, start, now)
 	if nil != err {
 		return err
 	}
@@ -303,8 +336,8 @@ func EndBasicSegment(t *TxnData, start SegmentStartTime, now time.Time, name str
 }
 
 // EndExternalSegment ends an external segment.
-func EndExternalSegment(t *TxnData, start SegmentStartTime, now time.Time, u *url.URL, method string, resp *http.Response) error {
-	end, err := endSegment(t, start, now)
+func EndExternalSegment(t *TxnData, thread *Thread, start SegmentStartTime, now time.Time, u *url.URL, method string, resp *http.Response) error {
+	end, err := endSegment(t, thread, start, now)
 	if nil != err {
 		return err
 	}
@@ -374,7 +407,8 @@ func EndExternalSegment(t *TxnData, start SegmentStartTime, now time.Time, u *ur
 
 // EndDatastoreParams contains the parameters for EndDatastoreSegment.
 type EndDatastoreParams struct {
-	Tracer             *TxnData
+	TxnData            *TxnData
+	Thread             *Thread
 	Start              SegmentStartTime
 	Now                time.Time
 	Product            string
@@ -427,7 +461,7 @@ func datastoreSpanAddress(host, portPathOrID string) string {
 
 // EndDatastoreSegment ends a datastore segment.
 func EndDatastoreSegment(p EndDatastoreParams) error {
-	end, err := endSegment(p.Tracer, p.Start, p.Now)
+	end, err := endSegment(p.TxnData, p.Thread, p.Start, p.Now)
 	if nil != err {
 		return err
 	}
@@ -466,27 +500,27 @@ func EndDatastoreSegment(p EndDatastoreParams) error {
 		Host:         p.Host,
 		PortPathOrID: p.PortPathOrID,
 	}
-	if nil == p.Tracer.datastoreSegments {
-		p.Tracer.datastoreSegments = make(map[DatastoreMetricKey]*metricData)
+	if nil == p.TxnData.datastoreSegments {
+		p.TxnData.datastoreSegments = make(map[DatastoreMetricKey]*metricData)
 	}
-	p.Tracer.datastoreCallCount++
-	p.Tracer.datastoreDuration += end.duration
+	p.TxnData.datastoreCallCount++
+	p.TxnData.datastoreDuration += end.duration
 	m := metricDataFromDuration(end.duration, end.exclusive)
-	if data, ok := p.Tracer.datastoreSegments[key]; ok {
+	if data, ok := p.TxnData.datastoreSegments[key]; ok {
 		data.aggregate(m)
 	} else {
 		// Use `new` in place of &m so that m is not
 		// automatically moved to the heap.
 		cpy := new(metricData)
 		*cpy = m
-		p.Tracer.datastoreSegments[key] = cpy
+		p.TxnData.datastoreSegments[key] = cpy
 	}
 
 	scopedMetric := datastoreScopedMetric(key)
 	queryParams := vetQueryParameters(p.QueryParameters)
 
-	if p.Tracer.TxnTrace.considerNode(end) {
-		p.Tracer.TxnTrace.witnessNode(end, scopedMetric, &traceNodeParams{
+	if p.TxnData.TxnTrace.considerNode(end) {
+		p.TxnData.TxnTrace.witnessNode(end, scopedMetric, &traceNodeParams{
 			Host:            p.Host,
 			PortPathOrID:    p.PortPathOrID,
 			Database:        p.Database,
@@ -495,16 +529,16 @@ func EndDatastoreSegment(p EndDatastoreParams) error {
 		})
 	}
 
-	if p.Tracer.slowQueryWorthy(end.duration) {
-		if nil == p.Tracer.SlowQueries {
-			p.Tracer.SlowQueries = newSlowQueries(maxTxnSlowQueries)
+	if p.TxnData.slowQueryWorthy(end.duration) {
+		if nil == p.TxnData.SlowQueries {
+			p.TxnData.SlowQueries = newSlowQueries(maxTxnSlowQueries)
 		}
 		// Frames to skip:
 		//   this function
 		//   endDatastore
 		//   DatastoreSegment.End
 		skipFrames := 3
-		p.Tracer.SlowQueries.observeInstance(slowQueryInstance{
+		p.TxnData.SlowQueries.observeInstance(slowQueryInstance{
 			Duration:           end.duration,
 			DatastoreMetric:    scopedMetric,
 			ParameterizedQuery: p.ParameterizedQuery,
@@ -526,7 +560,7 @@ func EndDatastoreSegment(p EndDatastoreParams) error {
 			Address:   datastoreSpanAddress(p.Host, p.PortPathOrID),
 			Hostname:  p.Host,
 		}
-		p.Tracer.saveSpanEvent(evt)
+		p.TxnData.saveSpanEvent(evt)
 	}
 
 	return nil

--- a/internal/txn_events.go
+++ b/internal/txn_events.go
@@ -32,6 +32,10 @@ func (e *TxnEvent) WriteJSON(buf *bytes.Buffer) {
 
 	sharedTransactionIntrinsics(e, &w)
 
+	// totalTime gets put into transaction events but not error events:
+	// https://source.datanerd.us/agents/agent-specs/blob/master/Total-Time-Async.md#attributes
+	w.floatField("totalTime", e.TotalTime.Seconds())
+
 	// Write better CAT intrinsics if enabled
 	sharedBetterCATIntrinsics(e, &w)
 

--- a/internal/txn_events_test.go
+++ b/internal/txn_events_test.go
@@ -8,7 +8,13 @@ import (
 	"github.com/newrelic/go-agent/internal/cat"
 )
 
-func testTxnEventJSON(t *testing.T, e *TxnEvent, expect string) {
+func testTxnEventJSON(t testing.TB, e *TxnEvent, expect string) {
+	// Type assertion to support early Go versions.
+	if h, ok := t.(interface {
+		Helper()
+	}); ok {
+		h.Helper()
+	}
 	js, err := json.Marshal(e)
 	if nil != err {
 		t.Error(err)
@@ -28,10 +34,11 @@ var (
 			ID:       "txn-id",
 			Priority: 0.5,
 		},
-		Start:    timeFromUnixMilliseconds(1488393111000),
-		Duration: 2 * time.Second,
-		Zone:     ApdexNone,
-		Attrs:    nil,
+		Start:     timeFromUnixMilliseconds(1488393111000),
+		Duration:  2 * time.Second,
+		TotalTime: 3 * time.Second,
+		Zone:      ApdexNone,
+		Attrs:     nil,
 	}
 
 	sampleTxnEventWithOldCAT = TxnEvent{
@@ -39,10 +46,11 @@ var (
 		BetterCAT: BetterCAT{
 			Enabled: false,
 		},
-		Start:    timeFromUnixMilliseconds(1488393111000),
-		Duration: 2 * time.Second,
-		Zone:     ApdexNone,
-		Attrs:    nil,
+		Start:     timeFromUnixMilliseconds(1488393111000),
+		Duration:  2 * time.Second,
+		TotalTime: 3 * time.Second,
+		Zone:      ApdexNone,
+		Attrs:     nil,
 	}
 
 	sampleTxnEventWithError = TxnEvent{
@@ -52,11 +60,12 @@ var (
 			ID:       "txn-id",
 			Priority: 0.5,
 		},
-		Start:    timeFromUnixMilliseconds(1488393111000),
-		Duration: 2 * time.Second,
-		Zone:     ApdexNone,
-		Attrs:    nil,
-		HasError: true,
+		Start:     timeFromUnixMilliseconds(1488393111000),
+		Duration:  2 * time.Second,
+		TotalTime: 3 * time.Second,
+		Zone:      ApdexNone,
+		Attrs:     nil,
+		HasError:  true,
 	}
 )
 
@@ -69,6 +78,7 @@ func TestTxnEventMarshal(t *testing.T) {
 		"timestamp":1.488393111e+09,
 		"error":false,
 		"duration":2,
+		"totalTime":3,
 		"guid":"txn-id",
 		"traceId":"txn-id",
 		"priority":0.500000,
@@ -89,6 +99,7 @@ func TestTxnEventMarshalWithApdex(t *testing.T) {
 		"nr.apdexPerfZone":"F",
 		"error":false,
 		"duration":2,
+		"totalTime":3,
 		"guid":"txn-id",
 		"traceId":"txn-id",
 		"priority":0.500000,
@@ -117,6 +128,7 @@ func TestTxnEventMarshalWithDatastoreExternal(t *testing.T) {
 		"externalDuration":1122.334,
 		"databaseCallCount":33,
 		"databaseDuration":5566.778,
+		"totalTime":3,
 		"guid":"txn-id",
 		"traceId":"txn-id",
 		"priority":0.500000,
@@ -147,6 +159,7 @@ func TestTxnEventMarshalWithInboundCaller(t *testing.T) {
 		"timestamp":1.488393111e+09,
 		"error":false,
 		"duration":2,
+		"totalTime":3,
 		"parent.type": "Browser",
 		"parent.app": "caller-app",
 		"parent.account": "caller-account",
@@ -183,7 +196,8 @@ func TestTxnEventMarshalWithInboundCallerOldCAT(t *testing.T) {
 		"name":"myOldName",
 		"timestamp":1.488393111e+09,
 		"error":false,
-		"duration":2
+		"duration":2,
+		"totalTime":3
 	},
 	{},
 	{}]`)
@@ -208,6 +222,7 @@ func TestTxnEventMarshalWithAttributes(t *testing.T) {
 		"timestamp":1.488393111e+09,
 		"error":false,
 		"duration":2,
+		"totalTime":3,
 		"guid":"txn-id",
 		"traceId":"txn-id",
 		"priority":0.500000,
@@ -324,6 +339,7 @@ func TestTxnEventMarshalWithError(t *testing.T) {
 		"timestamp":1.488393111e+09,
 		"error":true,
 		"duration":2,
+		"totalTime":3,
 		"guid":"txn-id",
 		"traceId":"txn-id",
 		"priority":0.500000,

--- a/internal/txn_trace.go
+++ b/internal/txn_trace.go
@@ -289,10 +289,9 @@ func (trace *HarvestTrace) writeJSON(buf *bytes.Buffer) {
 	})
 
 	// exclusive_duration_millis field is added to fix the transaction trace
-	// summary tab.  If exclusive_duration_millis is not provided, the
-	// Seldon and Wanda UIs will calculate exclusive time, which doesn't
-	// work for this root node since all async goroutines are children of
-	// this root.
+	// summary tab.  If exclusive_duration_millis is not provided, the UIs
+	// will calculate exclusive time, which doesn't work for this root node
+	// since all async goroutines are children of this root.
 	exclusiveDurationMillis := trace.Duration.Seconds() * 1000.0
 	printNodeStart(buf, nodeDetails{ // begin inner root
 		name:          trace.FinalName,

--- a/internal/txn_trace_test.go
+++ b/internal/txn_trace_test.go
@@ -10,15 +10,17 @@ import (
 
 func TestTxnTrace(t *testing.T) {
 	start := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
-	tr := &TxnData{}
-	tr.TxnTrace.Enabled = true
-	tr.TxnTrace.StackTraceThreshold = 1 * time.Hour
-	tr.TxnTrace.SegmentThreshold = 0
+	txndata := &TxnData{}
+	thread := &Thread{}
+	txndata.TxnTrace.Enabled = true
+	txndata.TxnTrace.StackTraceThreshold = 1 * time.Hour
+	txndata.TxnTrace.SegmentThreshold = 0
 
-	t1 := StartSegment(tr, start.Add(1*time.Second))
-	t2 := StartSegment(tr, start.Add(2*time.Second))
+	t1 := StartSegment(txndata, thread, start.Add(1*time.Second))
+	t2 := StartSegment(txndata, thread, start.Add(2*time.Second))
 	EndDatastoreSegment(EndDatastoreParams{
-		Tracer:             tr,
+		TxnData:            txndata,
+		Thread:             thread,
 		Start:              t2,
 		Now:                start.Add(3 * time.Second),
 		Product:            "MySQL",
@@ -30,26 +32,27 @@ func TestTxnTrace(t *testing.T) {
 		Host:               "db-server-1",
 		PortPathOrID:       "3306",
 	})
-	t3 := StartSegment(tr, start.Add(4*time.Second))
-	EndExternalSegment(tr, t3, start.Add(5*time.Second), parseURL("http://example.com/zip/zap?secret=shhh"), "", nil)
-	EndBasicSegment(tr, t1, start.Add(6*time.Second), "t1")
-	t4 := StartSegment(tr, start.Add(7*time.Second))
-	t5 := StartSegment(tr, start.Add(8*time.Second))
-	t6 := StartSegment(tr, start.Add(9*time.Second))
-	EndBasicSegment(tr, t6, start.Add(10*time.Second), "t6")
-	EndBasicSegment(tr, t5, start.Add(11*time.Second), "t5")
-	t7 := StartSegment(tr, start.Add(12*time.Second))
+	t3 := StartSegment(txndata, thread, start.Add(4*time.Second))
+	EndExternalSegment(txndata, thread, t3, start.Add(5*time.Second), parseURL("http://example.com/zip/zap?secret=shhh"), "", nil)
+	EndBasicSegment(txndata, thread, t1, start.Add(6*time.Second), "t1")
+	t4 := StartSegment(txndata, thread, start.Add(7*time.Second))
+	t5 := StartSegment(txndata, thread, start.Add(8*time.Second))
+	t6 := StartSegment(txndata, thread, start.Add(9*time.Second))
+	EndBasicSegment(txndata, thread, t6, start.Add(10*time.Second), "t6")
+	EndBasicSegment(txndata, thread, t5, start.Add(11*time.Second), "t5")
+	t7 := StartSegment(txndata, thread, start.Add(12*time.Second))
 	EndDatastoreSegment(EndDatastoreParams{
-		Tracer:    tr,
+		TxnData:   txndata,
+		Thread:    thread,
 		Start:     t7,
 		Now:       start.Add(13 * time.Second),
 		Product:   "MySQL",
 		Operation: "SELECT",
 		// no collection
 	})
-	t8 := StartSegment(tr, start.Add(14*time.Second))
-	EndExternalSegment(tr, t8, start.Add(15*time.Second), nil, "", nil)
-	EndBasicSegment(tr, t4, start.Add(16*time.Second), "t4")
+	t8 := StartSegment(txndata, thread, start.Add(14*time.Second))
+	EndExternalSegment(txndata, thread, t8, start.Add(15*time.Second), nil, "", nil)
+	EndBasicSegment(txndata, thread, t4, start.Add(16*time.Second), "t4")
 
 	acfg := CreateAttributeConfig(sampleAttributeConfigInput, true)
 	attr := NewAttributes(acfg)
@@ -61,6 +64,7 @@ func TestTxnTrace(t *testing.T) {
 		TxnEvent: TxnEvent{
 			Start:     start,
 			Duration:  20 * time.Second,
+			TotalTime: 30 * time.Second,
 			FinalName: "WebTransaction/Go/hello",
 			Attrs:     attr,
 			BetterCAT: BetterCAT{
@@ -69,7 +73,7 @@ func TestTxnTrace(t *testing.T) {
 				Priority: 0.5,
 			},
 		},
-		Trace: tr.TxnTrace,
+		Trace: txndata.TxnTrace,
 	})
 
 	expect := `["12345",[[
@@ -91,7 +95,7 @@ func TestTxnTrace(t *testing.T) {
 	               0,
 	               20000,
 	               "WebTransaction/Go/hello",
-	               {},
+	               {"exclusive_duration_millis":0},
 	               [
 	                  [
 	                     1000,
@@ -176,6 +180,7 @@ func TestTxnTrace(t *testing.T) {
 	            "zap":123
 	         },
 	         "intrinsics":{
+	         	"totalTime":30,
 	         	"guid":"txn-id",
 	         	"traceId":"txn-id",
 	         	"priority":0.500000,
@@ -197,17 +202,270 @@ func TestTxnTrace(t *testing.T) {
 	testExpectedJSON(t, expect, string(js))
 }
 
+func TestTxnTraceNoNodes(t *testing.T) {
+	start := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
+	txndata := &TxnData{}
+	txndata.TxnTrace.Enabled = true
+	txndata.TxnTrace.StackTraceThreshold = 1 * time.Hour
+	txndata.TxnTrace.SegmentThreshold = 0
+
+	ht := newHarvestTraces()
+	ht.regular.addTxnTrace(&HarvestTrace{
+		TxnEvent: TxnEvent{
+			Start:     start,
+			Duration:  20 * time.Second,
+			TotalTime: 30 * time.Second,
+			FinalName: "WebTransaction/Go/hello",
+			Attrs:     nil,
+			BetterCAT: BetterCAT{
+				Enabled:  true,
+				ID:       "txn-id",
+				Priority: 0.5,
+			},
+		},
+		Trace: txndata.TxnTrace,
+	})
+
+	expect := `[
+	   1417136460000000,
+	   20000,
+	   "WebTransaction/Go/hello",
+	   null,
+	   [
+	      0,
+	      {},
+	      {},
+	      [
+	         0,
+	         20000,
+	         "ROOT",
+	         {},
+	         [
+	            [
+	               0,
+	               20000,
+	               "WebTransaction/Go/hello",
+	               {"exclusive_duration_millis":0},
+	               [
+	               ]
+	            ]
+	         ]
+	      ],
+	      {
+	         "agentAttributes":{},
+	         "userAttributes":{},
+	         "intrinsics":{
+	         	"totalTime":30,
+	         	"guid":"txn-id",
+	         	"traceId":"txn-id",
+	         	"priority":0.500000,
+	         	"sampled":false
+	         }
+	      }
+	   ],
+	   "",
+	   null,
+	   false,
+	   null,
+	   ""
+	]`
+
+	js, err := ht.slice()[0].MarshalJSON()
+	if nil != err {
+		t.Fatal(err)
+	}
+	testExpectedJSON(t, expect, string(js))
+}
+
+func TestTxnTraceAsync(t *testing.T) {
+	start := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
+	txndata := &TxnData{}
+	thread1 := &Thread{}
+	txndata.TxnTrace.Enabled = true
+	txndata.TxnTrace.StackTraceThreshold = 1 * time.Hour
+	txndata.TxnTrace.SegmentThreshold = 0
+	txndata.BetterCAT.Sampled = true
+	txndata.SpanEventsEnabled = true
+	txndata.LazilyCalculateSampled = func() bool { return true }
+
+	t1s1 := StartSegment(txndata, thread1, start.Add(1*time.Second))
+	t1s2 := StartSegment(txndata, thread1, start.Add(2*time.Second))
+	thread2 := NewThread(txndata)
+	t2s1 := StartSegment(txndata, thread2, start.Add(3*time.Second))
+	EndBasicSegment(txndata, thread1, t1s2, start.Add(4*time.Second), "thread1.segment2")
+	EndBasicSegment(txndata, thread2, t2s1, start.Add(5*time.Second), "thread2.segment1")
+	thread3 := NewThread(txndata)
+	t3s1 := StartSegment(txndata, thread3, start.Add(6*time.Second))
+	t3s2 := StartSegment(txndata, thread3, start.Add(7*time.Second))
+	EndBasicSegment(txndata, thread1, t1s1, start.Add(8*time.Second), "thread1.segment1")
+	EndBasicSegment(txndata, thread3, t3s2, start.Add(9*time.Second), "thread3.segment2")
+	EndBasicSegment(txndata, thread3, t3s1, start.Add(10*time.Second), "thread3.segment1")
+
+	if tt := thread1.TotalTime(); tt != 7*time.Second {
+		t.Error(tt)
+	}
+	if tt := thread2.TotalTime(); tt != 2*time.Second {
+		t.Error(tt)
+	}
+	if tt := thread3.TotalTime(); tt != 4*time.Second {
+		t.Error(tt)
+	}
+
+	if len(txndata.spanEvents) != 5 {
+		t.Fatal(txndata.spanEvents)
+	}
+	for _, e := range txndata.spanEvents {
+		if e.GUID == "" || e.ParentID == "" {
+			t.Error(e.GUID, e.ParentID)
+		}
+	}
+	spanEventT1S2 := txndata.spanEvents[0]
+	spanEventT2S1 := txndata.spanEvents[1]
+	spanEventT1S1 := txndata.spanEvents[2]
+	spanEventT3S2 := txndata.spanEvents[3]
+	spanEventT3S1 := txndata.spanEvents[4]
+
+	if txndata.rootSpanID == "" {
+		t.Error(txndata.rootSpanID)
+	}
+	if spanEventT1S1.ParentID != txndata.rootSpanID {
+		t.Error(spanEventT1S1.ParentID, txndata.rootSpanID)
+	}
+	if spanEventT1S2.ParentID != spanEventT1S1.GUID {
+		t.Error(spanEventT1S2.ParentID, spanEventT1S1.GUID)
+	}
+	if spanEventT2S1.ParentID != txndata.rootSpanID {
+		t.Error(spanEventT2S1.ParentID, txndata.rootSpanID)
+	}
+	if spanEventT3S1.ParentID != txndata.rootSpanID {
+		t.Error(spanEventT3S1.ParentID, txndata.rootSpanID)
+	}
+	if spanEventT3S2.ParentID != spanEventT3S1.GUID {
+		t.Error(spanEventT3S2.ParentID, spanEventT3S1.GUID)
+	}
+
+	ht := newHarvestTraces()
+	ht.regular.addTxnTrace(&HarvestTrace{
+		TxnEvent: TxnEvent{
+			Start:     start,
+			Duration:  20 * time.Second,
+			TotalTime: 30 * time.Second,
+			FinalName: "WebTransaction/Go/hello",
+			Attrs:     nil,
+			BetterCAT: BetterCAT{
+				Enabled:  true,
+				ID:       "txn-id",
+				Priority: 0.5,
+			},
+		},
+		Trace: txndata.TxnTrace,
+	})
+
+	expect := `[
+   1417136460000000,
+   20000,
+   "WebTransaction/Go/hello",
+   null,
+   [
+      0,
+      {},
+      {},
+      [
+         0,
+         20000,
+         "ROOT",
+         {},
+         [
+            [
+               0,
+               20000,
+               "WebTransaction/Go/hello",
+               {"exclusive_duration_millis":0},
+               [
+                  [
+                     1000,
+                     8000,
+                     "Custom/thread1.segment1",
+                     {},
+                     [
+                        [
+                           2000,
+                           4000,
+                           "Custom/thread1.segment2",
+                           {},
+                           []
+                        ]
+                     ]
+                  ],
+                  [
+                     3000,
+                     5000,
+                     "Custom/thread2.segment1",
+                     {},
+                     []
+                  ],
+                  [
+                     6000,
+                     10000,
+                     "Custom/thread3.segment1",
+                     {},
+                     [
+                        [
+                           7000,
+                           9000,
+                           "Custom/thread3.segment2",
+                           {},
+                           []
+                        ]
+                     ]
+                  ]
+               ]
+            ]
+         ]
+      ],
+      {
+         "agentAttributes":{
+
+         },
+         "userAttributes":{
+
+         },
+         "intrinsics":{
+            "totalTime":30,
+            "guid":"txn-id",
+            "traceId":"txn-id",
+            "priority":0.500000,
+            "sampled":false
+         }
+      }
+   ],
+   "",
+   null,
+   false,
+   null,
+   ""
+]`
+
+	js, err := ht.slice()[0].MarshalJSON()
+	if nil != err {
+		t.Fatal(err)
+	}
+	testExpectedJSON(t, expect, string(js))
+}
+
 func TestTxnTraceOldCAT(t *testing.T) {
 	start := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
-	tr := &TxnData{}
-	tr.TxnTrace.Enabled = true
-	tr.TxnTrace.StackTraceThreshold = 1 * time.Hour
-	tr.TxnTrace.SegmentThreshold = 0
+	txndata := &TxnData{}
+	thread := &Thread{}
+	txndata.TxnTrace.Enabled = true
+	txndata.TxnTrace.StackTraceThreshold = 1 * time.Hour
+	txndata.TxnTrace.SegmentThreshold = 0
 
-	t1 := StartSegment(tr, start.Add(1*time.Second))
-	t2 := StartSegment(tr, start.Add(2*time.Second))
+	t1 := StartSegment(txndata, thread, start.Add(1*time.Second))
+	t2 := StartSegment(txndata, thread, start.Add(2*time.Second))
 	EndDatastoreSegment(EndDatastoreParams{
-		Tracer:             tr,
+		TxnData:            txndata,
+		Thread:             thread,
 		Start:              t2,
 		Now:                start.Add(3 * time.Second),
 		Product:            "MySQL",
@@ -219,26 +477,27 @@ func TestTxnTraceOldCAT(t *testing.T) {
 		Host:               "db-server-1",
 		PortPathOrID:       "3306",
 	})
-	t3 := StartSegment(tr, start.Add(4*time.Second))
-	EndExternalSegment(tr, t3, start.Add(5*time.Second), parseURL("http://example.com/zip/zap?secret=shhh"), "", nil)
-	EndBasicSegment(tr, t1, start.Add(6*time.Second), "t1")
-	t4 := StartSegment(tr, start.Add(7*time.Second))
-	t5 := StartSegment(tr, start.Add(8*time.Second))
-	t6 := StartSegment(tr, start.Add(9*time.Second))
-	EndBasicSegment(tr, t6, start.Add(10*time.Second), "t6")
-	EndBasicSegment(tr, t5, start.Add(11*time.Second), "t5")
-	t7 := StartSegment(tr, start.Add(12*time.Second))
+	t3 := StartSegment(txndata, thread, start.Add(4*time.Second))
+	EndExternalSegment(txndata, thread, t3, start.Add(5*time.Second), parseURL("http://example.com/zip/zap?secret=shhh"), "", nil)
+	EndBasicSegment(txndata, thread, t1, start.Add(6*time.Second), "t1")
+	t4 := StartSegment(txndata, thread, start.Add(7*time.Second))
+	t5 := StartSegment(txndata, thread, start.Add(8*time.Second))
+	t6 := StartSegment(txndata, thread, start.Add(9*time.Second))
+	EndBasicSegment(txndata, thread, t6, start.Add(10*time.Second), "t6")
+	EndBasicSegment(txndata, thread, t5, start.Add(11*time.Second), "t5")
+	t7 := StartSegment(txndata, thread, start.Add(12*time.Second))
 	EndDatastoreSegment(EndDatastoreParams{
-		Tracer:    tr,
+		TxnData:   txndata,
+		Thread:    thread,
 		Start:     t7,
 		Now:       start.Add(13 * time.Second),
 		Product:   "MySQL",
 		Operation: "SELECT",
 		// no collection
 	})
-	t8 := StartSegment(tr, start.Add(14*time.Second))
-	EndExternalSegment(tr, t8, start.Add(15*time.Second), nil, "", nil)
-	EndBasicSegment(tr, t4, start.Add(16*time.Second), "t4")
+	t8 := StartSegment(txndata, thread, start.Add(14*time.Second))
+	EndExternalSegment(txndata, thread, t8, start.Add(15*time.Second), nil, "", nil)
+	EndBasicSegment(txndata, thread, t4, start.Add(16*time.Second), "t4")
 
 	acfg := CreateAttributeConfig(sampleAttributeConfigInput, true)
 	attr := NewAttributes(acfg)
@@ -250,10 +509,11 @@ func TestTxnTraceOldCAT(t *testing.T) {
 		TxnEvent: TxnEvent{
 			Start:     start,
 			Duration:  20 * time.Second,
+			TotalTime: 30 * time.Second,
 			FinalName: "WebTransaction/Go/hello",
 			Attrs:     attr,
 		},
-		Trace: tr.TxnTrace,
+		Trace: txndata.TxnTrace,
 	})
 
 	expect := `["12345",[[
@@ -275,7 +535,7 @@ func TestTxnTraceOldCAT(t *testing.T) {
 	               0,
 	               20000,
 	               "WebTransaction/Go/hello",
-	               {},
+	               {"exclusive_duration_millis":0},
 	               [
 	                  [
 	                     1000,
@@ -357,7 +617,9 @@ func TestTxnTraceOldCAT(t *testing.T) {
 	         "userAttributes":{
 	            "zap":123
 	         },
-	         "intrinsics":{}
+	         "intrinsics":{
+	            "totalTime":30
+	         }
 	      }
 	   ],
 	   "",
@@ -422,7 +684,7 @@ func TestTxnTraceExcludeURI(t *testing.T) {
 	               0,
 	               20000,
 	               "WebTransaction/Go/hello",
-	               {},
+	               {"exclusive_duration_millis":0},
 	               []
 	            ]
 	         ]
@@ -431,6 +693,7 @@ func TestTxnTraceExcludeURI(t *testing.T) {
 	         "agentAttributes":{},
 	         "userAttributes":{},
 	         "intrinsics":{
+	            "totalTime":0,
 		        "guid":"txn-id",
 	         	"traceId":"txn-id",
 	         	"priority":0.500000,
@@ -453,10 +716,10 @@ func TestTxnTraceExcludeURI(t *testing.T) {
 
 func TestTxnTraceNoSegmentsNoAttributes(t *testing.T) {
 	start := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
-	tr := &TxnData{}
-	tr.TxnTrace.Enabled = true
-	tr.TxnTrace.StackTraceThreshold = 1 * time.Hour
-	tr.TxnTrace.SegmentThreshold = 0
+	txndata := &TxnData{}
+	txndata.TxnTrace.Enabled = true
+	txndata.TxnTrace.StackTraceThreshold = 1 * time.Hour
+	txndata.TxnTrace.SegmentThreshold = 0
 
 	acfg := CreateAttributeConfig(sampleAttributeConfigInput, true)
 	attr := NewAttributes(acfg)
@@ -466,6 +729,7 @@ func TestTxnTraceNoSegmentsNoAttributes(t *testing.T) {
 		TxnEvent: TxnEvent{
 			Start:     start,
 			Duration:  20 * time.Second,
+			TotalTime: 30 * time.Second,
 			FinalName: "WebTransaction/Go/hello",
 			Attrs:     attr,
 			BetterCAT: BetterCAT{
@@ -474,7 +738,7 @@ func TestTxnTraceNoSegmentsNoAttributes(t *testing.T) {
 				Priority: 0.5,
 			},
 		},
-		Trace: tr.TxnTrace,
+		Trace: txndata.TxnTrace,
 	})
 
 	expect := `["12345",[[
@@ -496,7 +760,7 @@ func TestTxnTraceNoSegmentsNoAttributes(t *testing.T) {
 	               0,
 	               20000,
 	               "WebTransaction/Go/hello",
-	               {},
+	               {"exclusive_duration_millis":0},
 	               []
 	            ]
 	         ]
@@ -505,7 +769,8 @@ func TestTxnTraceNoSegmentsNoAttributes(t *testing.T) {
 	         "agentAttributes":{},
 	         "userAttributes":{},
 	         "intrinsics":{
-		        "guid":"txn-id",
+	         	"totalTime":30,
+	         	"guid":"txn-id",
 	         	"traceId":"txn-id",
 	         	"priority":0.500000,
 	         	"sampled":false
@@ -527,10 +792,10 @@ func TestTxnTraceNoSegmentsNoAttributes(t *testing.T) {
 
 func TestTxnTraceNoSegmentsNoAttributesOldCAT(t *testing.T) {
 	start := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
-	tr := &TxnData{}
-	tr.TxnTrace.Enabled = true
-	tr.TxnTrace.StackTraceThreshold = 1 * time.Hour
-	tr.TxnTrace.SegmentThreshold = 0
+	txndata := &TxnData{}
+	txndata.TxnTrace.Enabled = true
+	txndata.TxnTrace.StackTraceThreshold = 1 * time.Hour
+	txndata.TxnTrace.SegmentThreshold = 0
 
 	acfg := CreateAttributeConfig(sampleAttributeConfigInput, true)
 	attr := NewAttributes(acfg)
@@ -540,10 +805,11 @@ func TestTxnTraceNoSegmentsNoAttributesOldCAT(t *testing.T) {
 		TxnEvent: TxnEvent{
 			Start:     start,
 			Duration:  20 * time.Second,
+			TotalTime: 30 * time.Second,
 			FinalName: "WebTransaction/Go/hello",
 			Attrs:     attr,
 		},
-		Trace: tr.TxnTrace,
+		Trace: txndata.TxnTrace,
 	})
 
 	expect := `["12345",[[
@@ -565,7 +831,7 @@ func TestTxnTraceNoSegmentsNoAttributesOldCAT(t *testing.T) {
 	               0,
 	               20000,
 	               "WebTransaction/Go/hello",
-	               {},
+	               {"exclusive_duration_millis":0},
 	               []
 	            ]
 	         ]
@@ -573,7 +839,9 @@ func TestTxnTraceNoSegmentsNoAttributesOldCAT(t *testing.T) {
 	      {
 	         "agentAttributes":{},
 	         "userAttributes":{},
-	         "intrinsics":{}
+	         "intrinsics":{
+	            "totalTime":30
+	         }
 	      }
 	   ],
 	   "",
@@ -591,18 +859,19 @@ func TestTxnTraceNoSegmentsNoAttributesOldCAT(t *testing.T) {
 
 func TestTxnTraceSlowestNodesSaved(t *testing.T) {
 	start := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
-	tr := &TxnData{}
-	tr.TxnTrace.Enabled = true
-	tr.TxnTrace.StackTraceThreshold = 1 * time.Hour
-	tr.TxnTrace.SegmentThreshold = 0
-	tr.TxnTrace.maxNodes = 5
+	txndata := &TxnData{}
+	thread := &Thread{}
+	txndata.TxnTrace.Enabled = true
+	txndata.TxnTrace.StackTraceThreshold = 1 * time.Hour
+	txndata.TxnTrace.SegmentThreshold = 0
+	txndata.TxnTrace.maxNodes = 5
 
 	durations := []int{5, 4, 6, 3, 7, 2, 8, 1, 9}
 	now := start
 	for _, d := range durations {
-		s := StartSegment(tr, now)
+		s := StartSegment(txndata, thread, now)
 		now = now.Add(time.Duration(d) * time.Second)
-		EndBasicSegment(tr, s, now, strconv.Itoa(d))
+		EndBasicSegment(txndata, thread, s, now, strconv.Itoa(d))
 	}
 
 	acfg := CreateAttributeConfig(sampleAttributeConfigInput, true)
@@ -614,6 +883,7 @@ func TestTxnTraceSlowestNodesSaved(t *testing.T) {
 		TxnEvent: TxnEvent{
 			Start:     start,
 			Duration:  123 * time.Second,
+			TotalTime: 200 * time.Second,
 			FinalName: "WebTransaction/Go/hello",
 			Attrs:     attr,
 			BetterCAT: BetterCAT{
@@ -622,7 +892,7 @@ func TestTxnTraceSlowestNodesSaved(t *testing.T) {
 				Priority: 0.5,
 			},
 		},
-		Trace: tr.TxnTrace,
+		Trace: txndata.TxnTrace,
 	})
 
 	expect := `["12345",[[
@@ -644,7 +914,7 @@ func TestTxnTraceSlowestNodesSaved(t *testing.T) {
 	               0,
 	               123000,
 	               "WebTransaction/Go/hello",
-	               {},
+	               {"exclusive_duration_millis":0},
 	               [
 	                  [
 	                     0,
@@ -689,7 +959,8 @@ func TestTxnTraceSlowestNodesSaved(t *testing.T) {
 	         "agentAttributes":{"request.uri":"/url"},
 	         "userAttributes":{},
 	         "intrinsics":{
-		        "guid":"txn-id",
+	         	"totalTime":200,
+	         	"guid":"txn-id",
 	         	"traceId":"txn-id",
 	         	"priority":0.500000,
 	         	"sampled":false
@@ -711,18 +982,19 @@ func TestTxnTraceSlowestNodesSaved(t *testing.T) {
 
 func TestTxnTraceSlowestNodesSavedOldCAT(t *testing.T) {
 	start := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
-	tr := &TxnData{}
-	tr.TxnTrace.Enabled = true
-	tr.TxnTrace.StackTraceThreshold = 1 * time.Hour
-	tr.TxnTrace.SegmentThreshold = 0
-	tr.TxnTrace.maxNodes = 5
+	txndata := &TxnData{}
+	thread := &Thread{}
+	txndata.TxnTrace.Enabled = true
+	txndata.TxnTrace.StackTraceThreshold = 1 * time.Hour
+	txndata.TxnTrace.SegmentThreshold = 0
+	txndata.TxnTrace.maxNodes = 5
 
 	durations := []int{5, 4, 6, 3, 7, 2, 8, 1, 9}
 	now := start
 	for _, d := range durations {
-		s := StartSegment(tr, now)
+		s := StartSegment(txndata, thread, now)
 		now = now.Add(time.Duration(d) * time.Second)
-		EndBasicSegment(tr, s, now, strconv.Itoa(d))
+		EndBasicSegment(txndata, thread, s, now, strconv.Itoa(d))
 	}
 
 	acfg := CreateAttributeConfig(sampleAttributeConfigInput, true)
@@ -734,10 +1006,11 @@ func TestTxnTraceSlowestNodesSavedOldCAT(t *testing.T) {
 		TxnEvent: TxnEvent{
 			Start:     start,
 			Duration:  123 * time.Second,
+			TotalTime: 200 * time.Second,
 			FinalName: "WebTransaction/Go/hello",
 			Attrs:     attr,
 		},
-		Trace: tr.TxnTrace,
+		Trace: txndata.TxnTrace,
 	})
 
 	expect := `["12345",[[
@@ -759,7 +1032,7 @@ func TestTxnTraceSlowestNodesSavedOldCAT(t *testing.T) {
 	               0,
 	               123000,
 	               "WebTransaction/Go/hello",
-	               {},
+	               {"exclusive_duration_millis":0},
 	               [
 	                  [
 	                     0,
@@ -803,7 +1076,9 @@ func TestTxnTraceSlowestNodesSavedOldCAT(t *testing.T) {
 	      {
 	         "agentAttributes":{"request.uri":"/url"},
 	         "userAttributes":{},
-	         "intrinsics":{}
+	         "intrinsics":{
+	            "totalTime":200
+	         }
 	      }
 	   ],
 	   "",
@@ -821,18 +1096,19 @@ func TestTxnTraceSlowestNodesSavedOldCAT(t *testing.T) {
 
 func TestTxnTraceSegmentThreshold(t *testing.T) {
 	start := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
-	tr := &TxnData{}
-	tr.TxnTrace.Enabled = true
-	tr.TxnTrace.StackTraceThreshold = 1 * time.Hour
-	tr.TxnTrace.SegmentThreshold = 7 * time.Second
-	tr.TxnTrace.maxNodes = 5
+	txndata := &TxnData{}
+	thread := &Thread{}
+	txndata.TxnTrace.Enabled = true
+	txndata.TxnTrace.StackTraceThreshold = 1 * time.Hour
+	txndata.TxnTrace.SegmentThreshold = 7 * time.Second
+	txndata.TxnTrace.maxNodes = 5
 
 	durations := []int{5, 4, 6, 3, 7, 2, 8, 1, 9}
 	now := start
 	for _, d := range durations {
-		s := StartSegment(tr, now)
+		s := StartSegment(txndata, thread, now)
 		now = now.Add(time.Duration(d) * time.Second)
-		EndBasicSegment(tr, s, now, strconv.Itoa(d))
+		EndBasicSegment(txndata, thread, s, now, strconv.Itoa(d))
 	}
 
 	acfg := CreateAttributeConfig(sampleAttributeConfigInput, true)
@@ -844,6 +1120,7 @@ func TestTxnTraceSegmentThreshold(t *testing.T) {
 		TxnEvent: TxnEvent{
 			Start:     start,
 			Duration:  123 * time.Second,
+			TotalTime: 200 * time.Second,
 			FinalName: "WebTransaction/Go/hello",
 			Attrs:     attr,
 			BetterCAT: BetterCAT{
@@ -852,7 +1129,7 @@ func TestTxnTraceSegmentThreshold(t *testing.T) {
 				Priority: 0.5,
 			},
 		},
-		Trace: tr.TxnTrace,
+		Trace: txndata.TxnTrace,
 	})
 
 	expect := `["12345",[[
@@ -874,7 +1151,7 @@ func TestTxnTraceSegmentThreshold(t *testing.T) {
 	               0,
 	               123000,
 	               "WebTransaction/Go/hello",
-	               {},
+	               {"exclusive_duration_millis":0},
 	               [
 	                  [
 	                     18000,
@@ -905,6 +1182,7 @@ func TestTxnTraceSegmentThreshold(t *testing.T) {
 	         "agentAttributes":{"request.uri":"/url"},
 	         "userAttributes":{},
 	         "intrinsics":{
+				"totalTime":200,
 				"guid":"txn-id",
 				"traceId":"txn-id",
 				"priority":0.500000,
@@ -927,18 +1205,19 @@ func TestTxnTraceSegmentThreshold(t *testing.T) {
 
 func TestTxnTraceSegmentThresholdOldCAT(t *testing.T) {
 	start := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
-	tr := &TxnData{}
-	tr.TxnTrace.Enabled = true
-	tr.TxnTrace.StackTraceThreshold = 1 * time.Hour
-	tr.TxnTrace.SegmentThreshold = 7 * time.Second
-	tr.TxnTrace.maxNodes = 5
+	txndata := &TxnData{}
+	thread := &Thread{}
+	txndata.TxnTrace.Enabled = true
+	txndata.TxnTrace.StackTraceThreshold = 1 * time.Hour
+	txndata.TxnTrace.SegmentThreshold = 7 * time.Second
+	txndata.TxnTrace.maxNodes = 5
 
 	durations := []int{5, 4, 6, 3, 7, 2, 8, 1, 9}
 	now := start
 	for _, d := range durations {
-		s := StartSegment(tr, now)
+		s := StartSegment(txndata, thread, now)
 		now = now.Add(time.Duration(d) * time.Second)
-		EndBasicSegment(tr, s, now, strconv.Itoa(d))
+		EndBasicSegment(txndata, thread, s, now, strconv.Itoa(d))
 	}
 
 	acfg := CreateAttributeConfig(sampleAttributeConfigInput, true)
@@ -950,10 +1229,11 @@ func TestTxnTraceSegmentThresholdOldCAT(t *testing.T) {
 		TxnEvent: TxnEvent{
 			Start:     start,
 			Duration:  123 * time.Second,
+			TotalTime: 200 * time.Second,
 			FinalName: "WebTransaction/Go/hello",
 			Attrs:     attr,
 		},
-		Trace: tr.TxnTrace,
+		Trace: txndata.TxnTrace,
 	})
 
 	expect := `["12345",[[
@@ -975,7 +1255,7 @@ func TestTxnTraceSegmentThresholdOldCAT(t *testing.T) {
 	               0,
 	               123000,
 	               "WebTransaction/Go/hello",
-	               {},
+	               {"exclusive_duration_millis":0},
 	               [
 	                  [
 	                     18000,
@@ -1005,7 +1285,9 @@ func TestTxnTraceSegmentThresholdOldCAT(t *testing.T) {
 	      {
 	         "agentAttributes":{"request.uri":"/url"},
 	         "userAttributes":{},
-	         "intrinsics":{}
+	         "intrinsics":{
+	            "totalTime":200
+	         }
 	      }
 	   ],
 	   "",
@@ -1032,8 +1314,8 @@ func TestEmptyHarvestTraces(t *testing.T) {
 
 func TestLongestTraceSaved(t *testing.T) {
 	start := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
-	tr := &TxnData{}
-	tr.TxnTrace.Enabled = true
+	txndata := &TxnData{}
+	txndata.TxnTrace.Enabled = true
 
 	acfg := CreateAttributeConfig(sampleAttributeConfigInput, true)
 	attr := NewAttributes(acfg)
@@ -1044,6 +1326,7 @@ func TestLongestTraceSaved(t *testing.T) {
 		TxnEvent: TxnEvent{
 			Start:     start,
 			Duration:  3 * time.Second,
+			TotalTime: 4 * time.Second,
 			FinalName: "WebTransaction/Go/3",
 			Attrs:     attr,
 			BetterCAT: BetterCAT{
@@ -1052,12 +1335,13 @@ func TestLongestTraceSaved(t *testing.T) {
 				Priority: 0.5,
 			},
 		},
-		Trace: tr.TxnTrace,
+		Trace: txndata.TxnTrace,
 	})
 	ht.Witness(HarvestTrace{
 		TxnEvent: TxnEvent{
 			Start:     start,
 			Duration:  5 * time.Second,
+			TotalTime: 6 * time.Second,
 			FinalName: "WebTransaction/Go/5",
 			Attrs:     attr,
 			BetterCAT: BetterCAT{
@@ -1066,12 +1350,13 @@ func TestLongestTraceSaved(t *testing.T) {
 				Priority: 0.5,
 			},
 		},
-		Trace: tr.TxnTrace,
+		Trace: txndata.TxnTrace,
 	})
 	ht.Witness(HarvestTrace{
 		TxnEvent: TxnEvent{
 			Start:     start,
 			Duration:  4 * time.Second,
+			TotalTime: 7 * time.Second,
 			FinalName: "WebTransaction/Go/4",
 			Attrs:     attr,
 			BetterCAT: BetterCAT{
@@ -1080,7 +1365,7 @@ func TestLongestTraceSaved(t *testing.T) {
 				Priority: 0.5,
 			},
 		},
-		Trace: tr.TxnTrace,
+		Trace: txndata.TxnTrace,
 	})
 
 	expect := `
@@ -1092,12 +1377,13 @@ func TestLongestTraceSaved(t *testing.T) {
 			[
 				0,{},{},
 				[0,5000,"ROOT",{},
-					[[0,5000,"WebTransaction/Go/5",{},[]]]
+					[[0,5000,"WebTransaction/Go/5",{"exclusive_duration_millis":0},[]]]
 				],
 				{
 					"agentAttributes":{"request.uri":"/url"},
 					"userAttributes":{},
 					"intrinsics":{
+						"totalTime":6,
 						"guid":"txn-id-5",
 						"traceId":"txn-id-5",
 						"priority":0.500000,
@@ -1118,8 +1404,8 @@ func TestLongestTraceSaved(t *testing.T) {
 
 func TestLongestTraceSavedOldCAT(t *testing.T) {
 	start := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
-	tr := &TxnData{}
-	tr.TxnTrace.Enabled = true
+	txndata := &TxnData{}
+	txndata.TxnTrace.Enabled = true
 
 	acfg := CreateAttributeConfig(sampleAttributeConfigInput, true)
 	attr := NewAttributes(acfg)
@@ -1130,28 +1416,31 @@ func TestLongestTraceSavedOldCAT(t *testing.T) {
 		TxnEvent: TxnEvent{
 			Start:     start,
 			Duration:  3 * time.Second,
+			TotalTime: 4 * time.Second,
 			FinalName: "WebTransaction/Go/3",
 			Attrs:     attr,
 		},
-		Trace: tr.TxnTrace,
+		Trace: txndata.TxnTrace,
 	})
 	ht.Witness(HarvestTrace{
 		TxnEvent: TxnEvent{
 			Start:     start,
 			Duration:  5 * time.Second,
+			TotalTime: 6 * time.Second,
 			FinalName: "WebTransaction/Go/5",
 			Attrs:     attr,
 		},
-		Trace: tr.TxnTrace,
+		Trace: txndata.TxnTrace,
 	})
 	ht.Witness(HarvestTrace{
 		TxnEvent: TxnEvent{
 			Start:     start,
 			Duration:  4 * time.Second,
+			TotalTime: 5 * time.Second,
 			FinalName: "WebTransaction/Go/4",
 			Attrs:     attr,
 		},
-		Trace: tr.TxnTrace,
+		Trace: txndata.TxnTrace,
 	})
 
 	expect := `
@@ -1163,12 +1452,14 @@ func TestLongestTraceSavedOldCAT(t *testing.T) {
 			[
 				0,{},{},
 				[0,5000,"ROOT",{},
-					[[0,5000,"WebTransaction/Go/5",{},[]]]
+					[[0,5000,"WebTransaction/Go/5",{"exclusive_duration_millis":0},[]]]
 				],
 				{
 					"agentAttributes":{"request.uri":"/url"},
 					"userAttributes":{},
-					"intrinsics":{}
+					"intrinsics":{
+						"totalTime":6
+					}
 				}
 			],
 			"",null,false,null,""
@@ -1184,20 +1475,22 @@ func TestLongestTraceSavedOldCAT(t *testing.T) {
 
 func TestTxnTraceStackTraceThreshold(t *testing.T) {
 	start := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
-	tr := &TxnData{}
-	tr.TxnTrace.Enabled = true
-	tr.TxnTrace.StackTraceThreshold = 2 * time.Second
-	tr.TxnTrace.SegmentThreshold = 0
-	tr.TxnTrace.maxNodes = 5
+	txndata := &TxnData{}
+	thread := &Thread{}
+	txndata.TxnTrace.Enabled = true
+	txndata.TxnTrace.StackTraceThreshold = 2 * time.Second
+	txndata.TxnTrace.SegmentThreshold = 0
+	txndata.TxnTrace.maxNodes = 5
 
 	// below stack trace threshold
-	t1 := StartSegment(tr, start.Add(1*time.Second))
-	EndBasicSegment(tr, t1, start.Add(2*time.Second), "t1")
+	t1 := StartSegment(txndata, thread, start.Add(1*time.Second))
+	EndBasicSegment(txndata, thread, t1, start.Add(2*time.Second), "t1")
 
 	// not above stack trace threshold w/out params
-	t2 := StartSegment(tr, start.Add(2*time.Second))
+	t2 := StartSegment(txndata, thread, start.Add(2*time.Second))
 	EndDatastoreSegment(EndDatastoreParams{
-		Tracer:     tr,
+		TxnData:    txndata,
+		Thread:     thread,
 		Start:      t2,
 		Now:        start.Add(4 * time.Second),
 		Product:    "MySQL",
@@ -1206,18 +1499,18 @@ func TestTxnTraceStackTraceThreshold(t *testing.T) {
 	})
 
 	// node above stack trace threshold w/ params
-	t3 := StartSegment(tr, start.Add(4*time.Second))
-	EndExternalSegment(tr, t3, start.Add(6*time.Second), parseURL("http://example.com/zip/zap?secret=shhh"), "", nil)
+	t3 := StartSegment(txndata, thread, start.Add(4*time.Second))
+	EndExternalSegment(txndata, thread, t3, start.Add(6*time.Second), parseURL("http://example.com/zip/zap?secret=shhh"), "", nil)
 
-	p := tr.TxnTrace.nodes[0].params
+	p := txndata.TxnTrace.nodes[0].params
 	if nil != p {
 		t.Error(p)
 	}
-	p = tr.TxnTrace.nodes[1].params
+	p = txndata.TxnTrace.nodes[1].params
 	if nil == p || nil == p.StackTrace || "" != p.CleanURL {
 		t.Error(p)
 	}
-	p = tr.TxnTrace.nodes[2].params
+	p = txndata.TxnTrace.nodes[2].params
 	if nil == p || nil == p.StackTrace || "http://example.com/zip/zap" != p.CleanURL {
 		t.Error(p)
 	}
@@ -1225,8 +1518,8 @@ func TestTxnTraceStackTraceThreshold(t *testing.T) {
 
 func TestTxnTraceSynthetics(t *testing.T) {
 	start := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
-	tr := &TxnData{}
-	tr.TxnTrace.Enabled = true
+	txndata := &TxnData{}
+	txndata.TxnTrace.Enabled = true
 
 	acfg := CreateAttributeConfig(sampleAttributeConfigInput, true)
 	attr := NewAttributes(acfg)
@@ -1237,6 +1530,7 @@ func TestTxnTraceSynthetics(t *testing.T) {
 		TxnEvent: TxnEvent{
 			Start:     start,
 			Duration:  3 * time.Second,
+			TotalTime: 4 * time.Second,
 			FinalName: "WebTransaction/Go/3",
 			Attrs:     attr,
 			CrossProcess: TxnCrossProcess{
@@ -1246,12 +1540,13 @@ func TestTxnTraceSynthetics(t *testing.T) {
 				},
 			},
 		},
-		Trace: tr.TxnTrace,
+		Trace: txndata.TxnTrace,
 	})
 	ht.Witness(HarvestTrace{
 		TxnEvent: TxnEvent{
 			Start:     start,
 			Duration:  5 * time.Second,
+			TotalTime: 6 * time.Second,
 			FinalName: "WebTransaction/Go/5",
 			Attrs:     attr,
 			CrossProcess: TxnCrossProcess{
@@ -1261,12 +1556,13 @@ func TestTxnTraceSynthetics(t *testing.T) {
 				},
 			},
 		},
-		Trace: tr.TxnTrace,
+		Trace: txndata.TxnTrace,
 	})
 	ht.Witness(HarvestTrace{
 		TxnEvent: TxnEvent{
 			Start:     start,
 			Duration:  4 * time.Second,
+			TotalTime: 5 * time.Second,
 			FinalName: "WebTransaction/Go/4",
 			Attrs:     attr,
 			CrossProcess: TxnCrossProcess{
@@ -1276,7 +1572,7 @@ func TestTxnTraceSynthetics(t *testing.T) {
 				},
 			},
 		},
-		Trace: tr.TxnTrace,
+		Trace: txndata.TxnTrace,
 	})
 
 	expect := `
@@ -1288,12 +1584,13 @@ func TestTxnTraceSynthetics(t *testing.T) {
 			[
 				0,{},{},
 				[0,3000,"ROOT",{},
-					[[0,3000,"WebTransaction/Go/3",{},[]]]
+					[[0,3000,"WebTransaction/Go/3",{"exclusive_duration_millis":0},[]]]
 				],
 				{
 					"agentAttributes":{"request.uri":"/url"},
 					"userAttributes":{},
 					"intrinsics":{
+						"totalTime":4,
 						"synthetics_resource_id":"resource"
 					}
 				}
@@ -1305,12 +1602,13 @@ func TestTxnTraceSynthetics(t *testing.T) {
 			[
 				0,{},{},
 				[0,5000,"ROOT",{},
-					[[0,5000,"WebTransaction/Go/5",{},[]]]
+					[[0,5000,"WebTransaction/Go/5",{"exclusive_duration_millis":0},[]]]
 				],
 				{
 					"agentAttributes":{"request.uri":"/url"},
 					"userAttributes":{},
 					"intrinsics":{
+						"totalTime":6,
 						"synthetics_resource_id":"resource"
 					}
 				}
@@ -1322,12 +1620,13 @@ func TestTxnTraceSynthetics(t *testing.T) {
 			[
 				0,{},{},
 				[0,4000,"ROOT",{},
-					[[0,4000,"WebTransaction/Go/4",{},[]]]
+					[[0,4000,"WebTransaction/Go/4",{"exclusive_duration_millis":0},[]]]
 				],
 				{
 					"agentAttributes":{"request.uri":"/url"},
 					"userAttributes":{},
 					"intrinsics":{
+						"totalTime":5,
 						"synthetics_resource_id":"resource"
 					}
 				}

--- a/internal/txn_trace_test.go
+++ b/internal/txn_trace_test.go
@@ -95,7 +95,7 @@ func TestTxnTrace(t *testing.T) {
 	               0,
 	               20000,
 	               "WebTransaction/Go/hello",
-	               {"exclusive_duration_millis":0},
+	               {"exclusive_duration_millis":20000},
 	               [
 	                  [
 	                     1000,
@@ -245,7 +245,7 @@ func TestTxnTraceNoNodes(t *testing.T) {
 	               0,
 	               20000,
 	               "WebTransaction/Go/hello",
-	               {"exclusive_duration_millis":0},
+	               {"exclusive_duration_millis":20000},
 	               [
 	               ]
 	            ]
@@ -380,7 +380,7 @@ func TestTxnTraceAsync(t *testing.T) {
                0,
                20000,
                "WebTransaction/Go/hello",
-               {"exclusive_duration_millis":0},
+               {"exclusive_duration_millis":20000},
                [
                   [
                      1000,
@@ -535,7 +535,7 @@ func TestTxnTraceOldCAT(t *testing.T) {
 	               0,
 	               20000,
 	               "WebTransaction/Go/hello",
-	               {"exclusive_duration_millis":0},
+	               {"exclusive_duration_millis":20000},
 	               [
 	                  [
 	                     1000,
@@ -684,7 +684,7 @@ func TestTxnTraceExcludeURI(t *testing.T) {
 	               0,
 	               20000,
 	               "WebTransaction/Go/hello",
-	               {"exclusive_duration_millis":0},
+	               {"exclusive_duration_millis":20000},
 	               []
 	            ]
 	         ]
@@ -760,7 +760,7 @@ func TestTxnTraceNoSegmentsNoAttributes(t *testing.T) {
 	               0,
 	               20000,
 	               "WebTransaction/Go/hello",
-	               {"exclusive_duration_millis":0},
+	               {"exclusive_duration_millis":20000},
 	               []
 	            ]
 	         ]
@@ -831,7 +831,7 @@ func TestTxnTraceNoSegmentsNoAttributesOldCAT(t *testing.T) {
 	               0,
 	               20000,
 	               "WebTransaction/Go/hello",
-	               {"exclusive_duration_millis":0},
+	               {"exclusive_duration_millis":20000},
 	               []
 	            ]
 	         ]
@@ -914,7 +914,7 @@ func TestTxnTraceSlowestNodesSaved(t *testing.T) {
 	               0,
 	               123000,
 	               "WebTransaction/Go/hello",
-	               {"exclusive_duration_millis":0},
+	               {"exclusive_duration_millis":123000},
 	               [
 	                  [
 	                     0,
@@ -1032,7 +1032,7 @@ func TestTxnTraceSlowestNodesSavedOldCAT(t *testing.T) {
 	               0,
 	               123000,
 	               "WebTransaction/Go/hello",
-	               {"exclusive_duration_millis":0},
+	               {"exclusive_duration_millis":123000},
 	               [
 	                  [
 	                     0,
@@ -1151,7 +1151,7 @@ func TestTxnTraceSegmentThreshold(t *testing.T) {
 	               0,
 	               123000,
 	               "WebTransaction/Go/hello",
-	               {"exclusive_duration_millis":0},
+	               {"exclusive_duration_millis":123000},
 	               [
 	                  [
 	                     18000,
@@ -1255,7 +1255,7 @@ func TestTxnTraceSegmentThresholdOldCAT(t *testing.T) {
 	               0,
 	               123000,
 	               "WebTransaction/Go/hello",
-	               {"exclusive_duration_millis":0},
+	               {"exclusive_duration_millis":123000},
 	               [
 	                  [
 	                     18000,
@@ -1377,7 +1377,7 @@ func TestLongestTraceSaved(t *testing.T) {
 			[
 				0,{},{},
 				[0,5000,"ROOT",{},
-					[[0,5000,"WebTransaction/Go/5",{"exclusive_duration_millis":0},[]]]
+					[[0,5000,"WebTransaction/Go/5",{"exclusive_duration_millis":5000},[]]]
 				],
 				{
 					"agentAttributes":{"request.uri":"/url"},
@@ -1452,7 +1452,7 @@ func TestLongestTraceSavedOldCAT(t *testing.T) {
 			[
 				0,{},{},
 				[0,5000,"ROOT",{},
-					[[0,5000,"WebTransaction/Go/5",{"exclusive_duration_millis":0},[]]]
+					[[0,5000,"WebTransaction/Go/5",{"exclusive_duration_millis":5000},[]]]
 				],
 				{
 					"agentAttributes":{"request.uri":"/url"},
@@ -1584,7 +1584,7 @@ func TestTxnTraceSynthetics(t *testing.T) {
 			[
 				0,{},{},
 				[0,3000,"ROOT",{},
-					[[0,3000,"WebTransaction/Go/3",{"exclusive_duration_millis":0},[]]]
+					[[0,3000,"WebTransaction/Go/3",{"exclusive_duration_millis":3000},[]]]
 				],
 				{
 					"agentAttributes":{"request.uri":"/url"},
@@ -1602,7 +1602,7 @@ func TestTxnTraceSynthetics(t *testing.T) {
 			[
 				0,{},{},
 				[0,5000,"ROOT",{},
-					[[0,5000,"WebTransaction/Go/5",{"exclusive_duration_millis":0},[]]]
+					[[0,5000,"WebTransaction/Go/5",{"exclusive_duration_millis":5000},[]]]
 				],
 				{
 					"agentAttributes":{"request.uri":"/url"},
@@ -1620,7 +1620,7 @@ func TestTxnTraceSynthetics(t *testing.T) {
 			[
 				0,{},{},
 				[0,4000,"ROOT",{},
-					[[0,4000,"WebTransaction/Go/4",{"exclusive_duration_millis":0},[]]]
+					[[0,4000,"WebTransaction/Go/4",{"exclusive_duration_millis":4000},[]]]
 				],
 				{
 					"agentAttributes":{"request.uri":"/url"},

--- a/internal_context_test.go
+++ b/internal_context_test.go
@@ -26,6 +26,8 @@ func TestWrapHandlerContext(t *testing.T) {
 	app.ExpectMetrics(t, []internal.WantMetric{
 		{Name: "WebTransaction/Go/myTxn", Scope: "", Forced: true, Data: nil},
 		{Name: "WebTransaction", Scope: "", Forced: true, Data: nil},
+		{Name: "WebTransactionTotalTime/Go/myTxn", Scope: "", Forced: false, Data: nil},
+		{Name: "WebTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "HttpDispatcher", Scope: "", Forced: true, Data: nil},
 		{Name: "Apdex", Scope: "", Forced: true, Data: nil},
 		{Name: "Apdex/Go/myTxn", Scope: "", Forced: false, Data: nil},
@@ -51,6 +53,8 @@ func TestStartExternalSegmentNilTransaction(t *testing.T) {
 	app.ExpectMetrics(t, []internal.WantMetric{
 		{Name: "OtherTransaction/Go/myTxn", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
+		{Name: "OtherTransactionTotalTime/Go/myTxn", Scope: "", Forced: false, Data: nil},
+		{Name: "OtherTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "External/all", Scope: "", Forced: true, Data: nil},
 		{Name: "External/allOther", Scope: "", Forced: true, Data: nil},
 		{Name: "External/example.com/all", Scope: "", Forced: false, Data: nil},
@@ -78,6 +82,8 @@ func TestNewRoundTripperNilTransaction(t *testing.T) {
 	app.ExpectMetrics(t, []internal.WantMetric{
 		{Name: "OtherTransaction/Go/myTxn", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
+		{Name: "OtherTransactionTotalTime/Go/myTxn", Scope: "", Forced: false, Data: nil},
+		{Name: "OtherTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "External/all", Scope: "", Forced: true, Data: nil},
 		{Name: "External/allOther", Scope: "", Forced: true, Data: nil},
 		{Name: "External/example.com/all", Scope: "", Forced: false, Data: nil},

--- a/internal_distributed_trace_test.go
+++ b/internal_distributed_trace_test.go
@@ -74,6 +74,20 @@ func disableDistributedTracerEnableSpanEvents(cfg *Config) {
 	cfg.SpanEvents.Enabled = true
 }
 
+var (
+	distributedTracingSuccessMetrics = []internal.WantMetric{
+		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
+		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
+		{Name: "OtherTransactionTotalTime/Go/hello", Scope: "", Forced: false, Data: nil},
+		{Name: "OtherTransactionTotalTime", Scope: "", Forced: true, Data: nil},
+		{Name: "DurationByCaller/App/123/456/HTTP/all", Scope: "", Forced: false, Data: nil},
+		{Name: "DurationByCaller/App/123/456/HTTP/allOther", Scope: "", Forced: false, Data: nil},
+		{Name: "TransportDuration/App/123/456/HTTP/all", Scope: "", Forced: false, Data: nil},
+		{Name: "TransportDuration/App/123/456/HTTP/allOther", Scope: "", Forced: false, Data: nil},
+		{Name: "Supportability/DistributedTrace/AcceptPayload/Success", Scope: "", Forced: true, Data: singleCount},
+	}
+)
+
 func TestPayloadConnection(t *testing.T) {
 	app := testApp(distributedTracingReplyFields, enableBetterCAT, t)
 	payload := makePayload(app, nil)
@@ -90,15 +104,7 @@ func TestPayloadConnection(t *testing.T) {
 	if nil != err {
 		t.Error(err)
 	}
-	app.ExpectMetrics(t, []internal.WantMetric{
-		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
-		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
-		{Name: "DurationByCaller/App/123/456/HTTP/all", Scope: "", Forced: false, Data: nil},
-		{Name: "DurationByCaller/App/123/456/HTTP/allOther", Scope: "", Forced: false, Data: nil},
-		{Name: "TransportDuration/App/123/456/HTTP/all", Scope: "", Forced: false, Data: nil},
-		{Name: "TransportDuration/App/123/456/HTTP/allOther", Scope: "", Forced: false, Data: nil},
-		{Name: "Supportability/DistributedTrace/AcceptPayload/Success", Scope: "", Forced: true, Data: singleCount},
-	})
+	app.ExpectMetrics(t, distributedTracingSuccessMetrics)
 	app.ExpectTxnEvents(t, []internal.WantEvent{{
 		Intrinsics: map[string]interface{}{
 			"name":                     "OtherTransaction/Go/hello",
@@ -137,16 +143,9 @@ func TestAcceptMultiple(t *testing.T) {
 	if nil != err {
 		t.Error(err)
 	}
-	app.ExpectMetrics(t, []internal.WantMetric{
-		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
-		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
-		{Name: "DurationByCaller/App/123/456/HTTP/all", Scope: "", Forced: false, Data: nil},
-		{Name: "DurationByCaller/App/123/456/HTTP/allOther", Scope: "", Forced: false, Data: nil},
-		{Name: "TransportDuration/App/123/456/HTTP/all", Scope: "", Forced: false, Data: nil},
-		{Name: "TransportDuration/App/123/456/HTTP/allOther", Scope: "", Forced: false, Data: nil},
-		{Name: "Supportability/DistributedTrace/AcceptPayload/Success", Scope: "", Forced: true, Data: singleCount},
+	app.ExpectMetrics(t, append([]internal.WantMetric{
 		{Name: "Supportability/DistributedTrace/AcceptPayload/Ignored/Multiple", Scope: "", Forced: true, Data: singleCount},
-	})
+	}, distributedTracingSuccessMetrics...))
 	app.ExpectTxnEvents(t, []internal.WantEvent{{
 		Intrinsics: map[string]interface{}{
 			"name":                     "OtherTransaction/Go/hello",
@@ -181,15 +180,7 @@ func TestPayloadConnectionText(t *testing.T) {
 	if nil != err {
 		t.Error(err)
 	}
-	app.ExpectMetrics(t, []internal.WantMetric{
-		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
-		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
-		{Name: "DurationByCaller/App/123/456/HTTP/all", Scope: "", Forced: false, Data: nil},
-		{Name: "DurationByCaller/App/123/456/HTTP/allOther", Scope: "", Forced: false, Data: nil},
-		{Name: "TransportDuration/App/123/456/HTTP/all", Scope: "", Forced: false, Data: nil},
-		{Name: "TransportDuration/App/123/456/HTTP/allOther", Scope: "", Forced: false, Data: nil},
-		{Name: "Supportability/DistributedTrace/AcceptPayload/Success", Scope: "", Forced: true, Data: singleCount},
-	})
+	app.ExpectMetrics(t, distributedTracingSuccessMetrics)
 	app.ExpectTxnEvents(t, []internal.WantEvent{{
 		Intrinsics: map[string]interface{}{
 			"name":                     "OtherTransaction/Go/hello",
@@ -233,15 +224,7 @@ func TestPayloadConnectionHTTPSafe(t *testing.T) {
 	if nil != err {
 		t.Error(err)
 	}
-	app.ExpectMetrics(t, []internal.WantMetric{
-		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
-		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
-		{Name: "DurationByCaller/App/123/456/HTTP/all", Scope: "", Forced: false, Data: nil},
-		{Name: "DurationByCaller/App/123/456/HTTP/allOther", Scope: "", Forced: false, Data: nil},
-		{Name: "TransportDuration/App/123/456/HTTP/all", Scope: "", Forced: false, Data: nil},
-		{Name: "TransportDuration/App/123/456/HTTP/allOther", Scope: "", Forced: false, Data: nil},
-		{Name: "Supportability/DistributedTrace/AcceptPayload/Success", Scope: "", Forced: true, Data: singleCount},
-	})
+	app.ExpectMetrics(t, distributedTracingSuccessMetrics)
 	app.ExpectTxnEvents(t, []internal.WantEvent{{
 		Intrinsics: map[string]interface{}{
 			"name":                     "OtherTransaction/Go/hello",
@@ -495,6 +478,8 @@ func TestPayloadFromApplicationEmptyTransportType(t *testing.T) {
 	app.ExpectMetrics(t, []internal.WantMetric{
 		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
+		{Name: "OtherTransactionTotalTime/Go/hello", Scope: "", Forced: false, Data: nil},
+		{Name: "OtherTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "DurationByCaller/App/123/456/Unknown/all", Scope: "", Forced: false, Data: nil},
 		{Name: "DurationByCaller/App/123/456/Unknown/allOther", Scope: "", Forced: false, Data: nil},
 		{Name: "TransportDuration/App/123/456/Unknown/all", Scope: "", Forced: false, Data: nil},
@@ -598,15 +583,7 @@ func TestPayloadFromFuture(t *testing.T) {
 	if nil != err {
 		t.Error(err)
 	}
-	app.ExpectMetrics(t, []internal.WantMetric{
-		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
-		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
-		{Name: "DurationByCaller/App/123/456/HTTP/all", Scope: "", Forced: false, Data: nil},
-		{Name: "DurationByCaller/App/123/456/HTTP/allOther", Scope: "", Forced: false, Data: nil},
-		{Name: "TransportDuration/App/123/456/HTTP/all", Scope: "", Forced: false, Data: singleCount},
-		{Name: "TransportDuration/App/123/456/HTTP/allOther", Scope: "", Forced: false, Data: singleCount},
-		{Name: "Supportability/DistributedTrace/AcceptPayload/Success", Scope: "", Forced: true, Data: singleCount},
-	})
+	app.ExpectMetrics(t, distributedTracingSuccessMetrics)
 	app.ExpectTxnEvents(t, []internal.WantEvent{{
 		Intrinsics: map[string]interface{}{
 			"name":                     "OtherTransaction/Go/hello",
@@ -794,6 +771,17 @@ func TestTrustedAccountKeyPayloadMissingKeyAndAccountIdDoesNotMatch(t *testing.T
 	}
 }
 
+var (
+	backgroundUnknownCaller = []internal.WantMetric{
+		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
+		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
+		{Name: "OtherTransactionTotalTime/Go/hello", Scope: "", Forced: false, Data: nil},
+		{Name: "OtherTransactionTotalTime", Scope: "", Forced: true, Data: nil},
+		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
+		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
+	}
+)
+
 func TestNilPayload(t *testing.T) {
 	app := testApp(distributedTracingReplyFields, enableBetterCAT, t)
 
@@ -809,13 +797,9 @@ func TestNilPayload(t *testing.T) {
 		t.Error(err)
 	}
 
-	app.ExpectMetrics(t, []internal.WantMetric{
-		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
-		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
+	app.ExpectMetrics(t, append([]internal.WantMetric{
 		{Name: "Supportability/DistributedTrace/AcceptPayload/Ignored/Null", Scope: "", Forced: true, Data: singleCount},
-	})
+	}, backgroundUnknownCaller...))
 }
 
 func TestNoticeErrorPayload(t *testing.T) {
@@ -829,17 +813,13 @@ func TestNoticeErrorPayload(t *testing.T) {
 		t.Error(err)
 	}
 
-	app.ExpectMetrics(t, []internal.WantMetric{
-		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
-		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
+	app.ExpectMetrics(t, append([]internal.WantMetric{
 		{Name: "Errors/all", Scope: "", Forced: true, Data: nil},
 		{Name: "Errors/allOther", Scope: "", Forced: true, Data: nil},
 		{Name: "Errors/OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
 		{Name: "ErrorsByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
 		{Name: "ErrorsByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
-	})
+	}, backgroundUnknownCaller...))
 }
 
 func TestMissingIDsForSupportabilityMetric(t *testing.T) {
@@ -869,13 +849,9 @@ func TestMissingIDsForSupportabilityMetric(t *testing.T) {
 		t.Error(err)
 	}
 
-	app.ExpectMetrics(t, []internal.WantMetric{
-		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
-		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
+	app.ExpectMetrics(t, append([]internal.WantMetric{
 		{Name: "Supportability/DistributedTrace/AcceptPayload/ParseException", Scope: "", Forced: true, Data: nil},
-	})
+	}, backgroundUnknownCaller...))
 }
 
 func TestMissingVersionForSupportabilityMetric(t *testing.T) {
@@ -905,13 +881,9 @@ func TestMissingVersionForSupportabilityMetric(t *testing.T) {
 		t.Error(err)
 	}
 
-	app.ExpectMetrics(t, []internal.WantMetric{
-		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
-		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
+	app.ExpectMetrics(t, append([]internal.WantMetric{
 		{Name: "Supportability/DistributedTrace/AcceptPayload/ParseException", Scope: "", Forced: true, Data: nil},
-	})
+	}, backgroundUnknownCaller...))
 }
 
 func TestMissingFieldForSupportabilityMetric(t *testing.T) {
@@ -941,13 +913,9 @@ func TestMissingFieldForSupportabilityMetric(t *testing.T) {
 		t.Error(err)
 	}
 
-	app.ExpectMetrics(t, []internal.WantMetric{
-		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
-		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
+	app.ExpectMetrics(t, append([]internal.WantMetric{
 		{Name: "Supportability/DistributedTrace/AcceptPayload/ParseException", Scope: "", Forced: true, Data: nil},
-	})
+	}, backgroundUnknownCaller...))
 }
 
 func TestParseExceptionSupportabilityMetric(t *testing.T) {
@@ -977,13 +945,9 @@ func TestParseExceptionSupportabilityMetric(t *testing.T) {
 		t.Error(err)
 	}
 
-	app.ExpectMetrics(t, []internal.WantMetric{
-		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
-		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
+	app.ExpectMetrics(t, append([]internal.WantMetric{
 		{Name: "Supportability/DistributedTrace/AcceptPayload/ParseException", Scope: "", Forced: true, Data: nil},
-	})
+	}, backgroundUnknownCaller...))
 }
 
 func TestErrorsByCaller(t *testing.T) {
@@ -1007,6 +971,8 @@ func TestErrorsByCaller(t *testing.T) {
 	app.ExpectMetrics(t, []internal.WantMetric{
 		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
+		{Name: "OtherTransactionTotalTime/Go/hello", Scope: "", Forced: false, Data: nil},
+		{Name: "OtherTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 
 		{Name: "TransportDuration/App/123/456/HTTP/allOther", Scope: "", Forced: false, Data: nil},
 		{Name: "Supportability/DistributedTrace/AcceptPayload/Success", Scope: "", Forced: true, Data: nil},
@@ -1053,6 +1019,8 @@ func TestCreateDistributedTraceCatDisabled(t *testing.T) {
 	app.ExpectMetrics(t, []internal.WantMetric{
 		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
+		{Name: "OtherTransactionTotalTime/Go/hello", Scope: "", Forced: false, Data: nil},
+		{Name: "OtherTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 	})
 
 }
@@ -1088,6 +1056,8 @@ func TestCreateDistributedTraceBetterCatDisabled(t *testing.T) {
 	app.ExpectMetrics(t, []internal.WantMetric{
 		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
+		{Name: "OtherTransactionTotalTime/Go/hello", Scope: "", Forced: false, Data: nil},
+		{Name: "OtherTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 	})
 
 }
@@ -1118,13 +1088,9 @@ func TestCreateDistributedTraceBetterCatEnabled(t *testing.T) {
 		t.Error(err)
 	}
 
-	app.ExpectMetrics(t, []internal.WantMetric{
-		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
-		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
+	app.ExpectMetrics(t, append([]internal.WantMetric{
 		{Name: "Supportability/DistributedTrace/CreatePayload/Success", Scope: "", Forced: true, Data: nil},
-	})
+	}, backgroundUnknownCaller...))
 }
 
 func isZeroValue(x interface{}) bool {
@@ -1167,13 +1133,9 @@ func TestCreateDistributedTraceRequiredFields(t *testing.T) {
 		t.Error(err)
 	}
 
-	app.ExpectMetrics(t, []internal.WantMetric{
-		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
-		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
+	app.ExpectMetrics(t, append([]internal.WantMetric{
 		{Name: "Supportability/DistributedTrace/CreatePayload/Success", Scope: "", Forced: true, Data: nil},
-	})
+	}, backgroundUnknownCaller...))
 }
 
 func TestCreateDistributedTraceTrustKeyAbsent(t *testing.T) {
@@ -1202,13 +1164,9 @@ func TestCreateDistributedTraceTrustKeyAbsent(t *testing.T) {
 		t.Error(err)
 	}
 
-	app.ExpectMetrics(t, []internal.WantMetric{
-		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
-		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
+	app.ExpectMetrics(t, append([]internal.WantMetric{
 		{Name: "Supportability/DistributedTrace/CreatePayload/Success", Scope: "", Forced: true, Data: nil},
-	})
+	}, backgroundUnknownCaller...))
 }
 
 func TestCreateDistributedTraceTrustKeyNeeded(t *testing.T) {
@@ -1233,13 +1191,9 @@ func TestCreateDistributedTraceTrustKeyNeeded(t *testing.T) {
 		t.Error(err)
 	}
 
-	app.ExpectMetrics(t, []internal.WantMetric{
-		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
-		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
-		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
+	app.ExpectMetrics(t, append([]internal.WantMetric{
 		{Name: "Supportability/DistributedTrace/CreatePayload/Success", Scope: "", Forced: true, Data: nil},
-	})
+	}, backgroundUnknownCaller...))
 }
 
 func TestCreateDistributedTraceAfterAcceptSampledTrue(t *testing.T) {

--- a/internal_errors_test.go
+++ b/internal_errors_test.go
@@ -280,10 +280,11 @@ func TestErrorWithStackTrace(t *testing.T) {
 	}
 	txn.End()
 	app.ExpectErrors(t, []internal.WantError{{
-		TxnName: "OtherTransaction/Go/hello",
-		Msg:     "my msg",
-		Klass:   "newrelic.withStackTrace",
-		Caller:  "go-agent.makeErrorWithStackTrace",
+		TxnName:    "OtherTransaction/Go/hello",
+		Msg:        "my msg",
+		Klass:      "newrelic.withStackTrace",
+		Caller:     "go-agent.makeErrorWithStackTrace",
+		NotNoticed: true,
 	}})
 	app.ExpectErrorEvents(t, []internal.WantEvent{{
 		Intrinsics: map[string]interface{}{

--- a/internal_response_writer.go
+++ b/internal_response_writer.go
@@ -7,21 +7,21 @@ import (
 	"net/http"
 )
 
-func (txn *txn) CloseNotify() <-chan bool {
-	return txn.getWriter().(http.CloseNotifier).CloseNotify()
+func (trd *thread) CloseNotify() <-chan bool {
+	return trd.txn.getWriter().(http.CloseNotifier).CloseNotify()
 }
-func (txn *txn) Flush() {
-	txn.getWriter().(http.Flusher).Flush()
+func (trd *thread) Flush() {
+	trd.txn.getWriter().(http.Flusher).Flush()
 }
-func (txn *txn) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	return txn.getWriter().(http.Hijacker).Hijack()
+func (trd *thread) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return trd.txn.getWriter().(http.Hijacker).Hijack()
 }
-func (txn *txn) ReadFrom(r io.Reader) (int64, error) {
-	return txn.getWriter().(io.ReaderFrom).ReadFrom(r)
+func (trd *thread) ReadFrom(r io.Reader) (int64, error) {
+	return trd.txn.getWriter().(io.ReaderFrom).ReadFrom(r)
 }
 
-func upgradeTxn(txn *txn) Transaction {
-	// Note that txn.getWriter() is not used here.  The transaction is
+func upgradeTxn(trd *thread) Transaction {
+	// Note that trd.txn.getWriter() is not used here.  The transaction is
 	// locked (or under construction) when this function is used.
 
 	// GENERATED CODE DO NOT MODIFY
@@ -33,107 +33,107 @@ func upgradeTxn(txn *txn) Transaction {
 		i3 int32 = 1 << 3
 	)
 	var interfaceSet int32
-	if _, ok := txn.writer.(http.CloseNotifier); ok {
+	if _, ok := trd.txn.writer.(http.CloseNotifier); ok {
 		interfaceSet |= i0
 	}
-	if _, ok := txn.writer.(http.Flusher); ok {
+	if _, ok := trd.txn.writer.(http.Flusher); ok {
 		interfaceSet |= i1
 	}
-	if _, ok := txn.writer.(http.Hijacker); ok {
+	if _, ok := trd.txn.writer.(http.Hijacker); ok {
 		interfaceSet |= i2
 	}
-	if _, ok := txn.writer.(io.ReaderFrom); ok {
+	if _, ok := trd.txn.writer.(io.ReaderFrom); ok {
 		interfaceSet |= i3
 	}
 	switch interfaceSet {
 	default: // No optional interfaces implemented
 		return struct {
 			Transaction
-		}{txn}
+		}{trd}
 	case i0:
 		return struct {
 			Transaction
 			http.CloseNotifier
-		}{txn, txn}
+		}{trd, trd}
 	case i1:
 		return struct {
 			Transaction
 			http.Flusher
-		}{txn, txn}
+		}{trd, trd}
 	case i0 | i1:
 		return struct {
 			Transaction
 			http.CloseNotifier
 			http.Flusher
-		}{txn, txn, txn}
+		}{trd, trd, trd}
 	case i2:
 		return struct {
 			Transaction
 			http.Hijacker
-		}{txn, txn}
+		}{trd, trd}
 	case i0 | i2:
 		return struct {
 			Transaction
 			http.CloseNotifier
 			http.Hijacker
-		}{txn, txn, txn}
+		}{trd, trd, trd}
 	case i1 | i2:
 		return struct {
 			Transaction
 			http.Flusher
 			http.Hijacker
-		}{txn, txn, txn}
+		}{trd, trd, trd}
 	case i0 | i1 | i2:
 		return struct {
 			Transaction
 			http.CloseNotifier
 			http.Flusher
 			http.Hijacker
-		}{txn, txn, txn, txn}
+		}{trd, trd, trd, trd}
 	case i3:
 		return struct {
 			Transaction
 			io.ReaderFrom
-		}{txn, txn}
+		}{trd, trd}
 	case i0 | i3:
 		return struct {
 			Transaction
 			http.CloseNotifier
 			io.ReaderFrom
-		}{txn, txn, txn}
+		}{trd, trd, trd}
 	case i1 | i3:
 		return struct {
 			Transaction
 			http.Flusher
 			io.ReaderFrom
-		}{txn, txn, txn}
+		}{trd, trd, trd}
 	case i0 | i1 | i3:
 		return struct {
 			Transaction
 			http.CloseNotifier
 			http.Flusher
 			io.ReaderFrom
-		}{txn, txn, txn, txn}
+		}{trd, trd, trd, trd}
 	case i2 | i3:
 		return struct {
 			Transaction
 			http.Hijacker
 			io.ReaderFrom
-		}{txn, txn, txn}
+		}{trd, trd, trd}
 	case i0 | i2 | i3:
 		return struct {
 			Transaction
 			http.CloseNotifier
 			http.Hijacker
 			io.ReaderFrom
-		}{txn, txn, txn, txn}
+		}{trd, trd, trd, trd}
 	case i1 | i2 | i3:
 		return struct {
 			Transaction
 			http.Flusher
 			http.Hijacker
 			io.ReaderFrom
-		}{txn, txn, txn, txn}
+		}{trd, trd, trd, trd}
 	case i0 | i1 | i2 | i3:
 		return struct {
 			Transaction
@@ -141,6 +141,6 @@ func upgradeTxn(txn *txn) Transaction {
 			http.Flusher
 			http.Hijacker
 			io.ReaderFrom
-		}{txn, txn, txn, txn, txn}
+		}{trd, trd, trd, trd, trd}
 	}
 }

--- a/internal_response_writer.go
+++ b/internal_response_writer.go
@@ -7,21 +7,21 @@ import (
 	"net/http"
 )
 
-func (trd *thread) CloseNotify() <-chan bool {
-	return trd.txn.getWriter().(http.CloseNotifier).CloseNotify()
+func (thd *thread) CloseNotify() <-chan bool {
+	return thd.txn.getWriter().(http.CloseNotifier).CloseNotify()
 }
-func (trd *thread) Flush() {
-	trd.txn.getWriter().(http.Flusher).Flush()
+func (thd *thread) Flush() {
+	thd.txn.getWriter().(http.Flusher).Flush()
 }
-func (trd *thread) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	return trd.txn.getWriter().(http.Hijacker).Hijack()
+func (thd *thread) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return thd.txn.getWriter().(http.Hijacker).Hijack()
 }
-func (trd *thread) ReadFrom(r io.Reader) (int64, error) {
-	return trd.txn.getWriter().(io.ReaderFrom).ReadFrom(r)
+func (thd *thread) ReadFrom(r io.Reader) (int64, error) {
+	return thd.txn.getWriter().(io.ReaderFrom).ReadFrom(r)
 }
 
-func upgradeTxn(trd *thread) Transaction {
-	// Note that trd.txn.getWriter() is not used here.  The transaction is
+func upgradeTxn(thd *thread) Transaction {
+	// Note that thd.txn.getWriter() is not used here.  The transaction is
 	// locked (or under construction) when this function is used.
 
 	// GENERATED CODE DO NOT MODIFY
@@ -33,107 +33,107 @@ func upgradeTxn(trd *thread) Transaction {
 		i3 int32 = 1 << 3
 	)
 	var interfaceSet int32
-	if _, ok := trd.txn.writer.(http.CloseNotifier); ok {
+	if _, ok := thd.txn.writer.(http.CloseNotifier); ok {
 		interfaceSet |= i0
 	}
-	if _, ok := trd.txn.writer.(http.Flusher); ok {
+	if _, ok := thd.txn.writer.(http.Flusher); ok {
 		interfaceSet |= i1
 	}
-	if _, ok := trd.txn.writer.(http.Hijacker); ok {
+	if _, ok := thd.txn.writer.(http.Hijacker); ok {
 		interfaceSet |= i2
 	}
-	if _, ok := trd.txn.writer.(io.ReaderFrom); ok {
+	if _, ok := thd.txn.writer.(io.ReaderFrom); ok {
 		interfaceSet |= i3
 	}
 	switch interfaceSet {
 	default: // No optional interfaces implemented
 		return struct {
 			Transaction
-		}{trd}
+		}{thd}
 	case i0:
 		return struct {
 			Transaction
 			http.CloseNotifier
-		}{trd, trd}
+		}{thd, thd}
 	case i1:
 		return struct {
 			Transaction
 			http.Flusher
-		}{trd, trd}
+		}{thd, thd}
 	case i0 | i1:
 		return struct {
 			Transaction
 			http.CloseNotifier
 			http.Flusher
-		}{trd, trd, trd}
+		}{thd, thd, thd}
 	case i2:
 		return struct {
 			Transaction
 			http.Hijacker
-		}{trd, trd}
+		}{thd, thd}
 	case i0 | i2:
 		return struct {
 			Transaction
 			http.CloseNotifier
 			http.Hijacker
-		}{trd, trd, trd}
+		}{thd, thd, thd}
 	case i1 | i2:
 		return struct {
 			Transaction
 			http.Flusher
 			http.Hijacker
-		}{trd, trd, trd}
+		}{thd, thd, thd}
 	case i0 | i1 | i2:
 		return struct {
 			Transaction
 			http.CloseNotifier
 			http.Flusher
 			http.Hijacker
-		}{trd, trd, trd, trd}
+		}{thd, thd, thd, thd}
 	case i3:
 		return struct {
 			Transaction
 			io.ReaderFrom
-		}{trd, trd}
+		}{thd, thd}
 	case i0 | i3:
 		return struct {
 			Transaction
 			http.CloseNotifier
 			io.ReaderFrom
-		}{trd, trd, trd}
+		}{thd, thd, thd}
 	case i1 | i3:
 		return struct {
 			Transaction
 			http.Flusher
 			io.ReaderFrom
-		}{trd, trd, trd}
+		}{thd, thd, thd}
 	case i0 | i1 | i3:
 		return struct {
 			Transaction
 			http.CloseNotifier
 			http.Flusher
 			io.ReaderFrom
-		}{trd, trd, trd, trd}
+		}{thd, thd, thd, thd}
 	case i2 | i3:
 		return struct {
 			Transaction
 			http.Hijacker
 			io.ReaderFrom
-		}{trd, trd, trd}
+		}{thd, thd, thd}
 	case i0 | i2 | i3:
 		return struct {
 			Transaction
 			http.CloseNotifier
 			http.Hijacker
 			io.ReaderFrom
-		}{trd, trd, trd, trd}
+		}{thd, thd, thd, thd}
 	case i1 | i2 | i3:
 		return struct {
 			Transaction
 			http.Flusher
 			http.Hijacker
 			io.ReaderFrom
-		}{trd, trd, trd, trd}
+		}{thd, thd, thd, thd}
 	case i0 | i1 | i2 | i3:
 		return struct {
 			Transaction
@@ -141,6 +141,6 @@ func upgradeTxn(trd *thread) Transaction {
 			http.Flusher
 			http.Hijacker
 			io.ReaderFrom
-		}{trd, trd, trd, trd, trd}
+		}{thd, thd, thd, thd, thd}
 	}
 }

--- a/internal_set_web_request_test.go
+++ b/internal_set_web_request_test.go
@@ -72,6 +72,8 @@ func TestSetWebRequestNil(t *testing.T) {
 	app.ExpectMetrics(t, []internal.WantMetric{
 		{Name: "WebTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
 		{Name: "WebTransaction", Scope: "", Forced: true, Data: nil},
+		{Name: "WebTransactionTotalTime/Go/hello", Scope: "", Forced: false, Data: nil},
+		{Name: "WebTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "HttpDispatcher", Scope: "", Forced: true, Data: nil},
 		{Name: "Apdex", Scope: "", Forced: true, Data: nil},
 		{Name: "Apdex/Go/hello", Scope: "", Forced: false, Data: nil},
@@ -104,6 +106,8 @@ func TestSetWebRequestNilPointer(t *testing.T) {
 	app.ExpectMetrics(t, []internal.WantMetric{
 		{Name: "WebTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
 		{Name: "WebTransaction", Scope: "", Forced: true, Data: nil},
+		{Name: "WebTransactionTotalTime/Go/hello", Scope: "", Forced: false, Data: nil},
+		{Name: "WebTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "HttpDispatcher", Scope: "", Forced: true, Data: nil},
 		{Name: "Apdex", Scope: "", Forced: true, Data: nil},
 		{Name: "Apdex/Go/hello", Scope: "", Forced: false, Data: nil},
@@ -136,6 +140,8 @@ func TestSetWebRequestHTTPRequest(t *testing.T) {
 	app.ExpectMetrics(t, []internal.WantMetric{
 		{Name: "WebTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
 		{Name: "WebTransaction", Scope: "", Forced: true, Data: nil},
+		{Name: "WebTransactionTotalTime/Go/hello", Scope: "", Forced: false, Data: nil},
+		{Name: "WebTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "HttpDispatcher", Scope: "", Forced: true, Data: nil},
 		{Name: "Apdex", Scope: "", Forced: true, Data: nil},
 		{Name: "Apdex/Go/hello", Scope: "", Forced: false, Data: nil},
@@ -168,6 +174,8 @@ func TestSetWebRequestCustomRequest(t *testing.T) {
 	app.ExpectMetrics(t, []internal.WantMetric{
 		{Name: "WebTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
 		{Name: "WebTransaction", Scope: "", Forced: true, Data: nil},
+		{Name: "WebTransactionTotalTime/Go/hello", Scope: "", Forced: false, Data: nil},
+		{Name: "WebTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "HttpDispatcher", Scope: "", Forced: true, Data: nil},
 		{Name: "Apdex", Scope: "", Forced: true, Data: nil},
 		{Name: "Apdex/Go/hello", Scope: "", Forced: false, Data: nil},
@@ -200,6 +208,8 @@ func TestSetWebRequestAlreadyEnded(t *testing.T) {
 	app.ExpectMetrics(t, []internal.WantMetric{
 		{Name: "OtherTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
+		{Name: "OtherTransactionTotalTime/Go/hello", Scope: "", Forced: false, Data: nil},
+		{Name: "OtherTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
 		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
 	})
@@ -236,6 +246,8 @@ func TestSetWebRequestWithDistributedTracing(t *testing.T) {
 	app.ExpectMetrics(t, []internal.WantMetric{
 		{Name: "WebTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
 		{Name: "WebTransaction", Scope: "", Forced: true, Data: nil},
+		{Name: "WebTransactionTotalTime/Go/hello", Scope: "", Forced: false, Data: nil},
+		{Name: "WebTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "HttpDispatcher", Scope: "", Forced: true, Data: nil},
 		{Name: "Apdex", Scope: "", Forced: true, Data: nil},
 		{Name: "Apdex/Go/hello", Scope: "", Forced: false, Data: nil},
@@ -288,6 +300,8 @@ func TestSetWebRequestIncompleteRequest(t *testing.T) {
 	app.ExpectMetrics(t, []internal.WantMetric{
 		{Name: "WebTransaction/Go/hello", Scope: "", Forced: true, Data: nil},
 		{Name: "WebTransaction", Scope: "", Forced: true, Data: nil},
+		{Name: "WebTransactionTotalTime/Go/hello", Scope: "", Forced: false, Data: nil},
+		{Name: "WebTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "HttpDispatcher", Scope: "", Forced: true, Data: nil},
 		{Name: "Apdex", Scope: "", Forced: true, Data: nil},
 		{Name: "Apdex/Go/hello", Scope: "", Forced: false, Data: nil},

--- a/internal_txn.go
+++ b/internal_txn.go
@@ -41,13 +41,53 @@ type txn struct {
 	wroteHeader bool
 
 	internal.TxnData
+
+	mainThread   internal.Thread
+	asyncThreads []*internal.Thread
 }
 
-func newTxn(input txnInput, name string) *txn {
+type thread struct {
+	*txn
+	// thread does not have locking because it should only be accessed while
+	// the txn is locked.
+	thread *internal.Thread
+}
+
+func (txn *txn) markStart(now time.Time) {
+	txn.Start = now
+	// The mainThread is considered active now.
+	txn.mainThread.RecordActivity(now)
+
+}
+
+func (txn *txn) markEnd(now time.Time, thread *internal.Thread) {
+	txn.Stop = now
+	// The thread on which End() was called is considered active now.
+	thread.RecordActivity(now)
+	txn.Duration = txn.Stop.Sub(txn.Start)
+
+	// TotalTime is the sum of "active time" across all threads.  A thread
+	// was active when it started the transaction, stopped the transaction,
+	// started a segment, or stopped a segment.
+	txn.TotalTime = txn.mainThread.TotalTime()
+	for _, trd := range txn.asyncThreads {
+		txn.TotalTime += trd.TotalTime()
+	}
+	// Ensure that TotalTime is at least as large as Duration so that the
+	// graphs look sensible.  This can happen under the following situation:
+	// goroutine1: txn.start----|segment1|
+	// goroutine2:                                   |segment2|----txn.end
+	if txn.Duration > txn.TotalTime {
+		txn.TotalTime = txn.Duration
+	}
+}
+
+func newTxn(input txnInput, name string) *thread {
 	txn := &txn{
 		txnInput: input,
 	}
-	txn.Start = time.Now()
+	txn.markStart(time.Now())
+
 	txn.Name = name
 	txn.Attrs = internal.NewAttributes(input.attrConfig)
 
@@ -74,7 +114,10 @@ func newTxn(input txnInput, name string) *txn {
 	noGUID := txn.Config.DistributedTracer.Enabled
 	txn.CrossProcess.Init(doOldCAT, noGUID, input.Reply)
 
-	return txn
+	return &thread{
+		txn:    txn,
+		thread: &txn.mainThread,
+	}
 }
 
 // lazilyCalculateSampled calculates and returns whether or not the transaction
@@ -142,7 +185,8 @@ func (txn *txn) SetWebRequest(r WebRequest) error {
 	return nil
 }
 
-func (txn *txn) SetWebResponse(w http.ResponseWriter) Transaction {
+func (trd *thread) SetWebResponse(w http.ResponseWriter) Transaction {
+	txn := trd.txn
 	txn.Lock()
 	defer txn.Unlock()
 
@@ -151,7 +195,10 @@ func (txn *txn) SetWebResponse(w http.ResponseWriter) Transaction {
 	// data flowing through as expected.
 	txn.writer = w
 
-	return upgradeTxn(txn)
+	return upgradeTxn(&thread{
+		thread: trd.thread,
+		txn:    txn,
+	})
 }
 
 func (txn *txn) slowQueriesEnabled() bool {
@@ -380,7 +427,8 @@ func (txn *txn) WriteHeader(code int) {
 	headersJustWritten(txn, code, hdr)
 }
 
-func (txn *txn) End() error {
+func (trd *thread) End() error {
+	txn := trd.txn
 	txn.Lock()
 	defer txn.Unlock()
 
@@ -397,12 +445,7 @@ func (txn *txn) End() error {
 		txn.noticeErrorInternal(e)
 	}
 
-	txn.Stop = time.Now()
-	txn.Duration = txn.Stop.Sub(txn.Start)
-	if children := internal.TracerRootChildren(&txn.TxnData); txn.Duration > children {
-		txn.Exclusive = txn.Duration - children
-	}
-
+	txn.markEnd(time.Now(), trd.thread)
 	txn.freezeName()
 	// Make a sampling decision if there have been no segments or outbound
 	// payloads.
@@ -589,17 +632,18 @@ func (txn *txn) Ignore() error {
 	return nil
 }
 
-func (txn *txn) StartSegmentNow() SegmentStartTime {
+func (trd *thread) StartSegmentNow() SegmentStartTime {
 	var s internal.SegmentStartTime
+	txn := trd.txn
 	txn.Lock()
 	if !txn.finished {
-		s = internal.StartSegment(&txn.TxnData, time.Now())
+		s = internal.StartSegment(&txn.TxnData, trd.thread, time.Now())
 	}
 	txn.Unlock()
 	return SegmentStartTime{
 		segment: segment{
-			start: s,
-			txn:   txn,
+			start:  s,
+			thread: trd,
 		},
 	}
 }
@@ -672,25 +716,47 @@ func (txn *txn) BrowserTimingHeader() (*BrowserTimingHeader, error) {
 	}, nil
 }
 
+func createThread(txn *txn) *internal.Thread {
+	newThread := internal.NewThread(&txn.TxnData)
+	txn.asyncThreads = append(txn.asyncThreads, newThread)
+	return newThread
+}
+
+func (trd *thread) NewGoroutine() Transaction {
+	txn := trd.txn
+	txn.Lock()
+	defer txn.Unlock()
+
+	if txn.finished {
+		// It the transaction has finished, return the same thread.
+		return upgradeTxn(trd)
+	}
+	return upgradeTxn(&thread{
+		thread: createThread(txn),
+		txn:    txn,
+	})
+}
+
 type segment struct {
-	start internal.SegmentStartTime
-	txn   *txn
+	start  internal.SegmentStartTime
+	thread *thread
 }
 
 func endSegment(s *Segment) error {
 	if nil == s {
 		return nil
 	}
-	txn := s.StartTime.txn
-	if nil == txn {
+	trd := s.StartTime.thread
+	if nil == trd {
 		return nil
 	}
+	txn := trd.txn
 	var err error
 	txn.Lock()
 	if txn.finished {
 		err = errAlreadyEnded
 	} else {
-		err = internal.EndBasicSegment(&txn.TxnData, s.StartTime.start, time.Now(), s.Name)
+		err = internal.EndBasicSegment(&txn.TxnData, trd.thread, s.StartTime.start, time.Now(), s.Name)
 	}
 	txn.Unlock()
 	return err
@@ -700,10 +766,11 @@ func endDatastore(s *DatastoreSegment) error {
 	if nil == s {
 		return nil
 	}
-	txn := s.StartTime.txn
-	if nil == txn {
+	trd := s.StartTime.thread
+	if nil == trd {
 		return nil
 	}
+	txn := trd.txn
 	txn.Lock()
 	defer txn.Unlock()
 
@@ -730,7 +797,8 @@ func endDatastore(s *DatastoreSegment) error {
 		s.PortPathOrID = ""
 	}
 	return internal.EndDatastoreSegment(internal.EndDatastoreParams{
-		Tracer:             &txn.TxnData,
+		TxnData:            &txn.TxnData,
+		Thread:             trd.thread,
 		Start:              s.StartTime.start,
 		Now:                time.Now(),
 		Product:            string(s.Product),
@@ -782,10 +850,11 @@ func endExternal(s *ExternalSegment) error {
 	if nil == s {
 		return nil
 	}
-	txn := s.StartTime.txn
-	if nil == txn {
+	trd := s.StartTime.thread
+	if nil == trd {
 		return nil
 	}
+	txn := trd.txn
 	txn.Lock()
 	defer txn.Unlock()
 
@@ -797,7 +866,7 @@ func endExternal(s *ExternalSegment) error {
 	if nil != err {
 		return err
 	}
-	return internal.EndExternalSegment(&txn.TxnData, s.StartTime.start, time.Now(), u, m, s.Response)
+	return internal.EndExternalSegment(&txn.TxnData, trd.thread, s.StartTime.start, time.Now(), u, m, s.Response)
 }
 
 // oldCATOutboundHeaders generates the Old CAT and Synthetics headers, depending
@@ -826,17 +895,17 @@ func oldCATOutboundHeaders(txn *txn) http.Header {
 }
 
 func outboundHeaders(s *ExternalSegment) http.Header {
-	txn := s.StartTime.txn
+	trd := s.StartTime.thread
 
-	if nil == txn {
+	if nil == trd {
 		return http.Header{}
 	}
-
+	txn := trd.txn
 	hdr := oldCATOutboundHeaders(txn)
 
 	// hdr may be empty, or it may contain headers.  If DistributedTracer
 	// is enabled, add more to the existing hdr
-	if p := txn.CreateDistributedTracePayload().HTTPSafe(); "" != p {
+	if p := trd.CreateDistributedTracePayload().HTTPSafe(); "" != p {
 		hdr.Add(DistributedTracePayloadHeader, p)
 		return hdr
 	}
@@ -853,9 +922,10 @@ type shimPayload struct{}
 func (s shimPayload) Text() string     { return "" }
 func (s shimPayload) HTTPSafe() string { return "" }
 
-func (txn *txn) CreateDistributedTracePayload() (payload DistributedTracePayload) {
+func (trd *thread) CreateDistributedTracePayload() (payload DistributedTracePayload) {
 	payload = shimPayload{}
 
+	txn := trd.txn
 	txn.Lock()
 	defer txn.Unlock()
 
@@ -891,7 +961,7 @@ func (txn *txn) CreateDistributedTracePayload() (payload DistributedTracePayload
 
 	sampled := txn.lazilyCalculateSampled()
 	if sampled && txn.SpanEventsEnabled {
-		p.ID = txn.CurrentSpanIdentifier()
+		p.ID = txn.CurrentSpanIdentifier(trd.thread)
 	}
 
 	// limit the number of outbound sampled=true payloads to prevent too

--- a/internal_txn.go
+++ b/internal_txn.go
@@ -728,7 +728,7 @@ func (thd *thread) NewGoroutine() Transaction {
 	defer txn.Unlock()
 
 	if txn.finished {
-		// It the transaction has finished, return the same thread.
+		// If the transaction has finished, return the same thread.
 		return upgradeTxn(thd)
 	}
 	return upgradeTxn(&thread{

--- a/internal_txn_test.go
+++ b/internal_txn_test.go
@@ -198,3 +198,102 @@ func TestLazilyCalculateSampledCATDisabled(t *testing.T) {
 		t.Error(out, tx.BetterCAT.Sampled, tx.sampledCalculated, tx.BetterCAT.Priority)
 	}
 }
+
+type expectTxnTimes struct {
+	txn       *txn
+	testName  string
+	start     time.Time
+	stop      time.Time
+	duration  time.Duration
+	totalTime time.Duration
+}
+
+func TestTransactionDurationTotalTime(t *testing.T) {
+	// These tests touch internal txn structures rather than the public API:
+	// Testing duration and total time is tough because our API functions do
+	// not take fixed times.
+	start := time.Now()
+	testTxnTimes := func(expect expectTxnTimes) {
+		if expect.txn.Start != expect.start {
+			t.Error("start time", expect.testName, expect.txn.Start, expect.start)
+		}
+		if expect.txn.Stop != expect.stop {
+			t.Error("stop time", expect.testName, expect.txn.Stop, expect.stop)
+		}
+		if expect.txn.Duration != expect.duration {
+			t.Error("duration", expect.testName, expect.txn.Duration, expect.duration)
+		}
+		if expect.txn.TotalTime != expect.totalTime {
+			t.Error("total time", expect.testName, expect.txn.TotalTime, expect.totalTime)
+		}
+	}
+
+	// Basic transaction with no async activity.
+	tx := &txn{}
+	tx.markStart(start)
+	segmentStart := internal.StartSegment(&tx.TxnData, &tx.mainThread, start.Add(1*time.Second))
+	internal.EndBasicSegment(&tx.TxnData, &tx.mainThread, segmentStart, start.Add(2*time.Second), "name")
+	tx.markEnd(start.Add(3*time.Second), &tx.mainThread)
+	testTxnTimes(expectTxnTimes{
+		txn:       tx,
+		testName:  "basic transaction",
+		start:     start,
+		stop:      start.Add(3 * time.Second),
+		duration:  3 * time.Second,
+		totalTime: 3 * time.Second,
+	})
+
+	// Transaction with async activity.
+	tx = &txn{}
+	tx.markStart(start)
+	segmentStart = internal.StartSegment(&tx.TxnData, &tx.mainThread, start.Add(1*time.Second))
+	internal.EndBasicSegment(&tx.TxnData, &tx.mainThread, segmentStart, start.Add(2*time.Second), "name")
+	asyncThread := createThread(tx)
+	asyncSegmentStart := internal.StartSegment(&tx.TxnData, asyncThread, start.Add(1*time.Second))
+	internal.EndBasicSegment(&tx.TxnData, asyncThread, asyncSegmentStart, start.Add(2*time.Second), "name")
+	tx.markEnd(start.Add(3*time.Second), &tx.mainThread)
+	testTxnTimes(expectTxnTimes{
+		txn:       tx,
+		testName:  "transaction with async activity",
+		start:     start,
+		stop:      start.Add(3 * time.Second),
+		duration:  3 * time.Second,
+		totalTime: 4 * time.Second,
+	})
+
+	// Transaction ended on async thread.
+	tx = &txn{}
+	tx.markStart(start)
+	segmentStart = internal.StartSegment(&tx.TxnData, &tx.mainThread, start.Add(1*time.Second))
+	internal.EndBasicSegment(&tx.TxnData, &tx.mainThread, segmentStart, start.Add(2*time.Second), "name")
+	asyncThread = createThread(tx)
+	asyncSegmentStart = internal.StartSegment(&tx.TxnData, asyncThread, start.Add(1*time.Second))
+	internal.EndBasicSegment(&tx.TxnData, asyncThread, asyncSegmentStart, start.Add(2*time.Second), "name")
+	tx.markEnd(start.Add(3*time.Second), asyncThread)
+	testTxnTimes(expectTxnTimes{
+		txn:       tx,
+		testName:  "transaction ended on async thread",
+		start:     start,
+		stop:      start.Add(3 * time.Second),
+		duration:  3 * time.Second,
+		totalTime: 4 * time.Second,
+	})
+
+	// Duration exceeds TotalTime.
+	tx = &txn{}
+	tx.markStart(start)
+	segmentStart = internal.StartSegment(&tx.TxnData, &tx.mainThread, start.Add(0*time.Second))
+	internal.EndBasicSegment(&tx.TxnData, &tx.mainThread, segmentStart, start.Add(1*time.Second), "name")
+	asyncThread = createThread(tx)
+	asyncSegmentStart = internal.StartSegment(&tx.TxnData, asyncThread, start.Add(2*time.Second))
+	internal.EndBasicSegment(&tx.TxnData, asyncThread, asyncSegmentStart, start.Add(3*time.Second), "name")
+	tx.markEnd(start.Add(3*time.Second), asyncThread)
+	testTxnTimes(expectTxnTimes{
+		txn:       tx,
+		testName:  "TotalTime should be at least Duration",
+		start:     start,
+		stop:      start.Add(3 * time.Second),
+		duration:  3 * time.Second,
+		totalTime: 3 * time.Second,
+	})
+}

--- a/transaction.go
+++ b/transaction.go
@@ -114,6 +114,19 @@ type Transaction interface {
 	// Relic's Browser support no longer requires a separate footer. The
 	// naming is for consistency with other New Relic language agents.
 	BrowserTimingHeader() (*BrowserTimingHeader, error)
+
+	// NewGoroutine must be called when passing the Transaction to a new
+	// goroutine.  This new Transaction reference maintains its own segment
+	// stack which allows segment metric exclusive time to be calculated.
+	// The Transaction will end when End() is called in any goroutine.
+	// Example use:
+	//
+	//	go func(txn newrelic.Transaction) {
+	//		defer newrelic.StartSegment(txn, "async").End()
+	//		time.Sleep(100 * time.Millisecond)
+	//	}(txn.NewGoroutine())
+	//
+	NewGoroutine() Transaction
 }
 
 // DistributedTracePayload is used to instrument connections between

--- a/version.go
+++ b/version.go
@@ -6,5 +6,5 @@ const (
 	patch = "0"
 
 	// Version is the full string version of this Go Agent.
-	Version = major + "." + minor + "." + patch
+	Version = major + "." + minor + "." + patch + ".async.0"
 )


### PR DESCRIPTION
Hi All!

We are excited to show you our plans for improved async support!  This PR introduces a new `Transaction.NewGoroutine() Transaction` method which allows transactions to create segments in multiple goroutines!

`NewGoroutine` returns a new reference to the `Transaction`.  This must be called any time you are passing the `Transaction` to another goroutine which makes segments.  Each segment-creating goroutine must have its own `Transaction` reference.  It does not matter if you call this before or after the other goroutine has started.

All `Transaction` methods can be used in any `Transaction` reference.  The `Transaction` will end when `End()` is called in any goroutine.

Example passing a new `Transaction` reference directly to another goroutine:

```go
	go func(txn newrelic.Transaction) {
		defer newrelic.StartSegment(txn, "async").End()
		time.Sleep(100 * time.Millisecond)
	}(txn.NewGoroutine())
```

Example passing a new `Transaction` reference on a channel to another
goroutine:

```go
	ch := make(chan newrelic.Transaction)
	go func() {
		txn := <-ch
		defer newrelic.StartSegment(txn, "async").End()
		time.Sleep(100 * time.Millisecond)
	}()
	ch <- txn.NewGoroutine()
```

We would love your feedback!  Please let us know what you think!  Here are some particular questions we have:

* Ease of API use: Does calling `txn.NewGoroutine()` for each goroutine work for you? Does it function as you’d expect it to do? Is there any change you can suggest to the API that would make it easier for you to use?
* APM UI data. For each chart/graph, does the data displayed explain what is going on in your application? Will it be useful to you in uncovering performance problems?
  * Transaction Traces (summary and details)
  * App server breakdown graph

<img width="1121" alt="screen shot 2019-02-15 at 11 35 55 am" src="https://user-images.githubusercontent.com/20211355/52880125-f53cfd80-3115-11e9-972a-05abb398828e.png">

  * Breakdown table

<img width="1187" alt="screen shot 2019-02-15 at 11 36 21 am" src="https://user-images.githubusercontent.com/20211355/52880135-fd953880-3115-11e9-8e2a-67b1d7ebc7e9.png">

This is a Beta release:

WARNING: THIS CODE IS IN DEVELOPMENT.  IT IS NOT A FINAL NEW RELIC PRODUCT OR
OFFERING. DO NOT USE IN PRODUCTION. USE AT YOUR OWN RISK. TERMS AND CONDITIONS
APPLY - SEE LICENSE FILE.
