### PR TITLE
Add stack frame lookup based on runtime.CallersFrames for supported g…

### DIFF
--- a/internal/stackframes.go
+++ b/internal/stackframes.go
@@ -1,0 +1,36 @@
+// +build !go1.7
+
+package internal
+
+import (
+	"runtime"
+)
+
+func (st StackTrace) frames() []stacktraceFrame {
+	fs := make([]stacktraceFrame, len(st))
+	for idx, pc := range st {
+		fs[idx] = lookupFrame(pc)
+	}
+	return fs
+}
+
+func lookupFrame(pc uintptr) stacktraceFrame {
+	// The Golang runtime package documentation says "To look up the file
+	// and line number of the call itself, use pc[i]-1. As an exception to
+	// this rule, if pc[i-1] corresponds to the function runtime.sigpanic,
+	// then pc[i] is the program counter of a faulting instruction and
+	// should be used without any subtraction."
+	//
+	// TODO: Fully understand when this subtraction is necessary.
+	place := pc - 1
+	f := runtime.FuncForPC(place)
+	if nil == f {
+		return stacktraceFrame{}
+	}
+	file, line := f.FileLine(place)
+	return stacktraceFrame{
+		Name: f.Name(),
+		File: file,
+		Line: int64(line),
+	}
+}

--- a/internal/stackframes_go17.go
+++ b/internal/stackframes_go17.go
@@ -1,0 +1,24 @@
+// +build go1.7
+
+package internal
+
+import (
+	"runtime"
+)
+
+func (st StackTrace) frames() []stacktraceFrame {
+	frames := make([]stacktraceFrame, 0, len(st))
+	cf := runtime.CallersFrames(st)
+	for {
+		f, more := cf.Next()
+		if !more {
+			break
+		}
+		frames = append(frames, stacktraceFrame{
+			Name: f.Func.Name(),
+			File: f.File,
+			Line: int64(f.Line),
+		})
+	}
+	return frames
+}

--- a/internal/stacktrace.go
+++ b/internal/stacktrace.go
@@ -24,14 +24,6 @@ type stacktraceFrame struct {
 	Line int64
 }
 
-func (st StackTrace) frames() []stacktraceFrame {
-	fs := make([]stacktraceFrame, len(st))
-	for idx, pc := range st {
-		fs[idx] = lookupFrame(pc)
-	}
-	return fs
-}
-
 func (f stacktraceFrame) formattedName() string {
 	if strings.HasPrefix(f.Name, "go.") {
 		// This indicates an anonymous struct. eg.
@@ -62,27 +54,6 @@ func (f stacktraceFrame) WriteJSON(buf *bytes.Buffer) {
 		w.intField("line", f.Line)
 	}
 	buf.WriteByte('}')
-}
-
-func lookupFrame(pc uintptr) stacktraceFrame {
-	// The Golang runtime package documentation says "To look up the file
-	// and line number of the call itself, use pc[i]-1. As an exception to
-	// this rule, if pc[i-1] corresponds to the function runtime.sigpanic,
-	// then pc[i] is the program counter of a faulting instruction and
-	// should be used without any subtraction."
-	//
-	// TODO: Fully understand when this subtraction is necessary.
-	place := pc - 1
-	f := runtime.FuncForPC(place)
-	if nil == f {
-		return stacktraceFrame{}
-	}
-	file, line := f.FileLine(place)
-	return stacktraceFrame{
-		Name: f.Name(),
-		File: file,
-		Line: int64(line),
-	}
 }
 
 func writeFrames(buf *bytes.Buffer, frames []stacktraceFrame) {


### PR DESCRIPTION
Part of the work required for #100 

Does not remove the dependency on runtime.Callers but it simplifies the implementation and removes the need for FuncForPC on Go 1.7+