### PR TITLE
Using strings.EqualFold() for efficient string comparison

### DIFF
--- a/_integrations/nrawssdk/internal/internal.go
+++ b/_integrations/nrawssdk/internal/internal.go
@@ -65,7 +65,7 @@ func StartSegment(input StartSegmentInputs) *http.Request {
 
 	var segment endable
 	// Service name capitalization is different for v1 and v2.
-	if strings.ToLower(input.ServiceName) == "dynamodb" {
+	if strings.EqualFold(input.ServiceName, "dynamodb") {
 		segment = &newrelic.DatastoreSegment{
 			Product:            newrelic.DatastoreDynamoDB,
 			Collection:         getTableName(input.Params),


### PR DESCRIPTION
Improved efficiency compared to previous implementation, which uses `strings.ToLower()`
