### PR TITLE
Add txn to req context on nrhttprouter

### DIFF
--- a/_integrations/nrhttprouter/nrhttprouter.go
+++ b/_integrations/nrhttprouter/nrhttprouter.go
@@ -73,6 +73,8 @@ func (r *Router) handle(method string, path string, original httprouter.Handle) 
 			txn := r.application.StartTransaction(txnName(method, path), w, req)
 			defer txn.End()
 
+			req = newrelic.RequestWithTransactionContext(req, txn)
+
 			original(txn, req, ps)
 		}
 	}

--- a/_integrations/nrhttprouter/nrhttprouter_test.go
+++ b/_integrations/nrhttprouter/nrhttprouter_test.go
@@ -102,6 +102,10 @@ func TestHandle(t *testing.T) {
 		IsWeb:     true,
 		NumErrors: 1,
 	})
+
+	if newrelic.FromContext(req.Context()) == nil {
+		t.Error("transaction was not found in request context")
+	}
 }
 
 func TestHandler(t *testing.T) {
@@ -127,6 +131,10 @@ func TestHandler(t *testing.T) {
 		IsWeb:     true,
 		NumErrors: 1,
 	})
+
+	if newrelic.FromContext(req.Context()) == nil {
+		t.Error("transaction was not found in request context")
+	}
 }
 
 func TestHandlerMissingApplication(t *testing.T) {


### PR DESCRIPTION
The transaction is not being pushed into the Request Context.

This would make segments not work when using the recommended way of fetching the transaction from the context.