### PR TITLE
Correct nrgorilla's description

### DIFF
--- a/_integrations/nrgorilla/v1/README.md
+++ b/_integrations/nrgorilla/v1/README.md
@@ -1,6 +1,6 @@
 # _integrations/nrgorilla/v1 [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/_integrations/nrgorilla/v1?status.svg)](https://godoc.org/github.com/newrelic/go-agent/_integrations/nrgorilla/v1)
 
-Package `nrgorilla` instruments https://github.com/gin-gonic/gin applications.
+Package `nrgorilla` instruments https://github.com/gorilla/mux applications.
 
 ```go
 import "github.com/newrelic/go-agent/_integrations/nrgorilla/v1"


### PR DESCRIPTION
Since it currently refers to gin rather than mux - which is presumably a leftover from when the READMEs were mass-added in 7664285.