### PR TITLE
Use c.FullPath() to name Gin transactions

### DIFF
--- a/v3/integrations/nrgin/nrgin.go
+++ b/v3/integrations/nrgin/nrgin.go
@@ -100,7 +100,7 @@ func Transaction(c Context) *newrelic.Transaction {
 func Middleware(app *newrelic.Application) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if app != nil {
-			name := c.Request.Method + " " + c.HandlerName()
+			name := c.Request.Method + " " + c.FullPath()
 			w := &headerResponseWriter{w: c.Writer}
 			txn := app.StartTransaction(name)
 			txn.SetWebRequestHTTP(c.Request)

--- a/v3/integrations/nrgin/nrgin.go
+++ b/v3/integrations/nrgin/nrgin.go
@@ -100,7 +100,12 @@ func Transaction(c Context) *newrelic.Transaction {
 func Middleware(app *newrelic.Application) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if app != nil {
-			name := c.Request.Method + " " + c.FullPath()
+			fullPath := c.FullPath()
+			if len(fullPath) == 0 {
+				fullPath = "/*"
+			}
+
+			name := c.Request.Method + " " + fullPath
 			w := &headerResponseWriter{w: c.Writer}
 			txn := app.StartTransaction(name)
 			txn.SetWebRequestHTTP(c.Request)


### PR DESCRIPTION
The `c.FullPath()` function has recently been added to the Gin API (https://godoc.org/github.com/gin-gonic/gin#Context.FullPath).

It allows for more expressive transaction naming, and also prevent to use reflection in the hot path.

It changes the current behavior for existing users, so we might want to make this available behind some flag until the next major release.