### PR TITLE
Update dependecy versions for nrmysql

### DIFF
--- a/v3/integrations/nrmysql/go.mod
+++ b/v3/integrations/nrmysql/go.mod
@@ -1,14 +1,10 @@
 module github.com/newrelic/go-agent/v3/integrations/nrmysql
 
-// As of Dec 2019, 1.9 is the Go version in mysql's go.mod:
+// As of Dec 2019, 1.10 is the Go version in mysql's go.mod:
 // https://github.com/go-sql-driver/mysql/blob/master/go.mod
-go 1.9
+go 1.10
 
 require (
-	// As of Nov 2019, the latest go-sql-driver/mysql release (v1.4.1) does
-	// not support modules, though there is an unreleased go.mod on master.
-	// v1.3.0 is required for ParseDSN.
-	github.com/go-sql-driver/mysql v1.3.0
-	// v3.3.0 includes the new location of ParseQuery
-	github.com/newrelic/go-agent/v3 v3.3.0
+	github.com/go-sql-driver/mysql v1.5.0
+	github.com/newrelic/go-agent/v3 v3.4.0
 )


### PR DESCRIPTION
* match `go` version to `mysql` driver version (1.10)
* bump `github.com/go-sql-driver/mysql` to `v1.5.0` (now supports modules)
* bump `github.com/newrelic/go-agent/v3` to `v3.4.0`