### PR TITLE
Improve experience when sending data times out.

### DIFF
--- a/v3/newrelic/internal_app.go
+++ b/v3/newrelic/internal_app.go
@@ -379,6 +379,10 @@ func (app *app) WaitForConnection(timeout time.Duration) error {
 }
 
 func newApp(c config) *app {
+	transport := c.Transport
+	if nil == transport {
+		transport = collectorDefaultTransport
+	}
 	app := &app{
 		Logger:         c.Logger,
 		config:         c,
@@ -396,7 +400,7 @@ func newApp(c config) *app {
 		rpmControls: rpmControls{
 			License: c.License,
 			Client: &http.Client{
-				Transport: c.Transport,
+				Transport: transport,
 				Timeout:   collectorTimeout,
 			},
 			Logger: c.Logger,

--- a/v3/newrelic/transport.go
+++ b/v3/newrelic/transport.go
@@ -1,0 +1,29 @@
+// +build go1.13
+
+package newrelic
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+var (
+	// collectorDefaultTransport is the http.Transport to be used with
+	// communication to the collector backend if a Transport is not set on the
+	// Config.
+	collectorDefaultTransport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		ForceAttemptHTTP2:     true, // added in go 1.13
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   100, // note: different from default global transport
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+)

--- a/v3/newrelic/transport_1_12.go
+++ b/v3/newrelic/transport_1_12.go
@@ -1,0 +1,28 @@
+// +build !go1.13
+
+package newrelic
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+var (
+	// collectorDefaultTransport is the http.Transport to be used with
+	// communication to the collector backend if a Transport is not set on the
+	// Config.
+	collectorDefaultTransport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   100, // note: different from default global transport
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+)


### PR DESCRIPTION
This pre-release branch does two things to improve the agent experience when sending data to the New Relic backend times out.

First, instead of dropping data on the floor, we will save it and attempt to resend it with the next harvest cycle. Note that because the agent has internal limits to the amount of data it holds, if the timeouts happen for a prolonged period and your application is collecting a lot of events, some could still get dropped.

Second, the agent will stop using the `http.DefaultTransport` for communication with the New Relic backend. This change will help address https://github.com/golang/go/issues/33006 which can cause all outbound requests using the same transport to hang, irregardless of the host they are attempting to connect with.