### PR TITLE
Fix parentage of datastore segments

### DIFF
--- a/v3/newrelic/internal_txn.go
+++ b/v3/newrelic/internal_txn.go
@@ -700,10 +700,6 @@ func (txn *txn) Ignore() error {
 	return nil
 }
 
-func (thd *thread) StartSegmentNow() SegmentStartTime {
-	return thd.startSegmentAt(time.Now())
-}
-
 func (thd *thread) startSegmentAt(at time.Time) SegmentStartTime {
 	var s segmentStartTime
 	txn := thd.txn

--- a/v3/newrelic/internal_txn.go
+++ b/v3/newrelic/internal_txn.go
@@ -701,11 +701,15 @@ func (txn *txn) Ignore() error {
 }
 
 func (thd *thread) StartSegmentNow() SegmentStartTime {
+	return thd.startSegmentAt(time.Now())
+}
+
+func (thd *thread) startSegmentAt(at time.Time) SegmentStartTime {
 	var s segmentStartTime
 	txn := thd.txn
 	txn.Lock()
 	if !txn.finished {
-		s = startSegment(&txn.txnData, thd.thread, time.Now())
+		s = startSegment(&txn.txnData, thd.thread, at)
 	}
 	txn.Unlock()
 	return SegmentStartTime{

--- a/v3/newrelic/sql_driver.go
+++ b/v3/newrelic/sql_driver.go
@@ -8,6 +8,7 @@ package newrelic
 import (
 	"context"
 	"database/sql/driver"
+	"time"
 )
 
 // SQLDriverSegmentBuilder populates DatastoreSegments for sql.Driver
@@ -56,8 +57,12 @@ func (bld SQLDriverSegmentBuilder) useQuery(query string) SQLDriverSegmentBuilde
 }
 
 func (bld SQLDriverSegmentBuilder) startSegment(ctx context.Context) DatastoreSegment {
+	return bld.startSegmentAt(ctx, time.Now())
+}
+
+func (bld SQLDriverSegmentBuilder) startSegmentAt(ctx context.Context, at time.Time) DatastoreSegment {
 	segment := bld.BaseSegment
-	segment.StartTime = FromContext(ctx).StartSegmentNow()
+	segment.StartTime = FromContext(ctx).thread.startSegmentAt(at)
 	return segment
 }
 
@@ -163,10 +168,11 @@ func (w *wrapConn) Exec(query string, args []driver.Value) (driver.Result, error
 
 // ExecContext implements ExecerContext.
 func (w *wrapConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-	segment := w.bld.useQuery(query).startSegment(ctx)
+	startTime := time.Now()
 	result, err := w.original.(driver.ExecerContext).ExecContext(ctx, query, args)
 	if err != driver.ErrSkip {
-		segment.End()
+		seg := w.bld.useQuery(query).startSegmentAt(ctx, startTime)
+		seg.End()
 	}
 	return result, err
 }
@@ -187,10 +193,11 @@ func (w *wrapConn) Query(query string, args []driver.Value) (driver.Rows, error)
 
 // QueryContext implements QueryerContext.
 func (w *wrapConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-	segment := w.bld.useQuery(query).startSegment(ctx)
+	startTime := time.Now()
 	rows, err := w.original.(driver.QueryerContext).QueryContext(ctx, query, args)
 	if err != driver.ErrSkip {
-		segment.End()
+		seg := w.bld.useQuery(query).startSegmentAt(ctx, startTime)
+		seg.End()
 	}
 	return rows, err
 }

--- a/v3/newrelic/sql_driver.go
+++ b/v3/newrelic/sql_driver.go
@@ -62,7 +62,7 @@ func (bld SQLDriverSegmentBuilder) startSegment(ctx context.Context) DatastoreSe
 
 func (bld SQLDriverSegmentBuilder) startSegmentAt(ctx context.Context, at time.Time) DatastoreSegment {
 	segment := bld.BaseSegment
-	segment.StartTime = FromContext(ctx).thread.startSegmentAt(at)
+	segment.StartTime = FromContext(ctx).startSegmentAt(at)
 	return segment
 }
 

--- a/v3/newrelic/sql_driver_test.go
+++ b/v3/newrelic/sql_driver_test.go
@@ -271,3 +271,10 @@ func TestQueryContextErrSkipReturned(t *testing.T) {
 		},
 	})
 }
+
+// Ensure we don't panic if the txn is nil
+func TestSQLNoTxnNoCry(t *testing.T) {
+	connector := InstrumentSQLConnector(testConnector{}, testBuilder)
+	conn, _ := connector.Connect(nil)
+	conn.(driver.QueryerContext).QueryContext(context.Background(), "myoperation,mycollection", nil)
+}

--- a/v3/newrelic/sql_driver_test.go
+++ b/v3/newrelic/sql_driver_test.go
@@ -185,3 +185,89 @@ func TestConnectorToDriver(t *testing.T) {
 	txn.End()
 	app.ExpectMetrics(t, driverTestMetrics)
 }
+
+type testConnectorErr struct {
+	testConnector
+}
+
+func (c testConnectorErr) Connect(context.Context) (driver.Conn, error) { return testConnErr{}, nil }
+
+type testConnErr struct {
+	testConn
+}
+
+func (c testConnErr) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	return nil, driver.ErrSkip
+}
+
+func (c testConnErr) ExecContext(context.Context, string, []driver.NamedValue) (driver.Result, error) {
+	return nil, driver.ErrSkip
+}
+
+// Ensure that if the driver used returns driver.ErrSkip that spans still have correct parentage
+func TestExecContextErrSkipReturned(t *testing.T) {
+	app := testApp(distributedTracingReplyFields, enableBetterCAT, t)
+	connector := InstrumentSQLConnector(testConnectorErr{}, testBuilder)
+	txn := app.StartTransaction("hello")
+	conn, _ := connector.Connect(nil)
+	ctx := NewContext(context.Background(), txn)
+
+	conn.(driver.ExecerContext).ExecContext(ctx, "myoperation,mycollection", nil)
+	txn.StartSegment("second").End()
+	txn.End()
+
+	parentGUID := "4981855ad8681d0d"
+	app.ExpectSpanEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"name":     "Custom/second",
+				"parentId": parentGUID,
+				"category": "generic",
+			},
+			AgentAttributes: map[string]interface{}{},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"name":             "OtherTransaction/Go/hello",
+				"guid":             parentGUID,
+				"nr.entryPoint":    true,
+				"category":         "generic",
+				"transaction.name": "OtherTransaction/Go/hello",
+			},
+			AgentAttributes: map[string]interface{}{},
+		},
+	})
+}
+
+// Ensure that if the driver used returns driver.ErrSkip that spans still have correct parentage
+func TestQueryContextErrSkipReturned(t *testing.T) {
+	app := testApp(distributedTracingReplyFields, enableBetterCAT, t)
+	connector := InstrumentSQLConnector(testConnectorErr{}, testBuilder)
+	txn := app.StartTransaction("hello")
+	conn, _ := connector.Connect(nil)
+	ctx := NewContext(context.Background(), txn)
+	conn.(driver.QueryerContext).QueryContext(ctx, "myoperation,mycollection", nil)
+	txn.StartSegment("second").End()
+	txn.End()
+	parentGUID := "4981855ad8681d0d"
+	app.ExpectSpanEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"name":     "Custom/second",
+				"parentId": parentGUID,
+				"category": "generic",
+			},
+			AgentAttributes: map[string]interface{}{},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"name":             "OtherTransaction/Go/hello",
+				"guid":             parentGUID,
+				"nr.entryPoint":    true,
+				"category":         "generic",
+				"transaction.name": "OtherTransaction/Go/hello",
+			},
+			AgentAttributes: map[string]interface{}{},
+		},
+	})
+}

--- a/v3/newrelic/transaction.go
+++ b/v3/newrelic/transaction.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 // Transaction instruments one logical unit of work: either an inbound web
@@ -190,13 +191,17 @@ func (txn *Transaction) SetWebResponse(w http.ResponseWriter) http.ResponseWrite
 // ExternalSegment.  The returned SegmentStartTime is safe to use even  when the
 // Transaction receiver is nil.  In this case, the segment will have no effect.
 func (txn *Transaction) StartSegmentNow() SegmentStartTime {
+	return txn.startSegmentAt(time.Now())
+}
+
+func (txn *Transaction) startSegmentAt(at time.Time) SegmentStartTime {
 	if nil == txn {
 		return SegmentStartTime{}
 	}
 	if nil == txn.thread {
 		return SegmentStartTime{}
 	}
-	return txn.thread.StartSegmentNow()
+	return txn.thread.startSegmentAt(at)
 }
 
 // StartSegment makes it easy to instrument segments.  To time a function, do


### PR DESCRIPTION
Addressing https://github.com/newrelic/go-agent/issues/138

If a SQL driver returned `driver.ErrSkip`, we were ending up with with orphaned datastore spans. This change conditionally creates the spans only if `driver.ErrSkip` is not returned.