### PR TITLE
Add issues template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report---.md
+++ b/.github/ISSUE_TEMPLATE/bug-report---.md
@@ -1,0 +1,39 @@
+---
+name: "Bug report \U0001F41B"
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+[NOTE]: # ( ^^ Provide a general summary of the issue in the title above. ^^ )
+
+## Description
+
+[NOTE]: # ( Describe the problem you're encountering. )
+[TIP]:  # ( Do NOT give us access or passwords to your New Relic account or API keys! )
+
+## Steps to Reproduce
+
+[NOTE]: # ( Please be as specific as possible. )
+
+## Expected Behavior
+
+[NOTE]: # ( Tell us what you expected to happen. )
+
+## NR Diag results
+
+[NOTE]: # ( Provide any other relevant log data. )
+
+## Your Environment
+
+[TIP]:  # ( Include as many relevant details about your environment as possible including the running version of New Relic software and any relevant configurations. )
+
+## Reproduction case
+
+[TIP]: # ( Link a sample application that demonstrates the issue. )
+
+## Additional context
+
+[TIP]:  # ( Add any other context about the problem here. )

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Troubleshooting
+    url:  https://github.com/newrelic/go-agent/blob/master/README.md#support
+    about: checkout the README for troubleshooting directions

--- a/.github/ISSUE_TEMPLATE/enhancement-request---.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request---.md
@@ -1,0 +1,27 @@
+---
+name: "Enhancement request \U0001F4A1"
+about: Suggest an idea for a future version of this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+[NOTE]: # ( ^^ Provide a general summary of the request in the title above. ^^ )
+
+## Summary
+
+[NOTE]: # ( Provide a brief overview of what the new feature is all about. )
+
+## Desired Behaviour
+
+[NOTE]: # ( Tell us how the new feature should work. Be specific. )
+[TIP]:  # ( Do NOT give us access or passwords to your New Relic account or API keys! )
+
+## Possible Solution
+
+[NOTE]: # ( Not required. Suggest how to implement the addition or change. )
+
+## Additional context
+
+[TIP]:  # ( Why does this feature matter to you? What unique circumstances do you have? )

--- a/.github/ISSUE_TEMPLATE/troubleshooting.md
+++ b/.github/ISSUE_TEMPLATE/troubleshooting.md
@@ -1,0 +1,6 @@
+<!-- ⚠️⚠️STOP⚠️⚠️ -- PLEASE READ! -->
+
+We use GitHub to track feature requests and bug reports. Please **do not** submit issues for questions about how to configure, use features, troubleshoot, or best practices for using New Relic software.
+
+See the README.md troubleshooting section in this repository for more details on self-service troubleshooting tooling, links to our comprehenive documentation, and how to get further support.
+


### PR DESCRIPTION
Following https://github.com/aprilla/github-sandbox/tree/master/.github/ISSUE_TEMPLATE to add templates to how users create new issues.