### PR TITLE
Implement other segment types.

### DIFF
--- a/v4/newrelic/segments.go
+++ b/v4/newrelic/segments.go
@@ -239,7 +239,14 @@ func (s *ExternalSegment) End() {
 }
 
 func (s *ExternalSegment) name() string {
-	return s.method() + ": " + s.host()
+	return s.library() + " " + s.method() + " " + s.host()
+}
+
+func (s *ExternalSegment) library() string {
+	if s.Library == "" {
+		return "http"
+	}
+	return s.Library
 }
 
 func (s *ExternalSegment) host() string {

--- a/v4/newrelic/segments.go
+++ b/v4/newrelic/segments.go
@@ -284,7 +284,27 @@ func (s *ExternalSegment) method() string {
 func (s *MessageProducerSegment) AddAttribute(key string, val interface{}) {}
 
 // End finishes the message segment.
-func (s *MessageProducerSegment) End() {}
+func (s *MessageProducerSegment) End() {
+	if s == nil {
+		return
+	}
+	if s.StartTime.span == nil {
+		return
+	}
+	if s.StartTime.isEnded() {
+		return
+	}
+	s.StartTime.Span.SetName(s.name())
+	s.StartTime.end()
+}
+
+func (s *MessageProducerSegment) name() string {
+	dest := s.DestinationName
+	if s.DestinationTemporary {
+		dest = "(temporary)"
+	}
+	return dest + " send"
+}
 
 // SetStatusCode sets the status code for the response of this ExternalSegment.
 // This status code will be included as an attribute on Span Events.  If status

--- a/v4/newrelic/segments.go
+++ b/v4/newrelic/segments.go
@@ -190,7 +190,31 @@ func (s *Segment) End() {
 func (s *DatastoreSegment) AddAttribute(key string, val interface{}) {}
 
 // End finishes the datastore segment.
-func (s *DatastoreSegment) End() {}
+func (s *DatastoreSegment) End() {
+	if s == nil {
+		return
+	}
+	if s.StartTime.span == nil {
+		return
+	}
+	if s.StartTime.isEnded() {
+		return
+	}
+	s.StartTime.Span.SetName(s.name())
+	s.StartTime.end()
+}
+
+func (s *DatastoreSegment) name() string {
+	pq := s.ParameterizedQuery
+	if pq == "" {
+		coll := s.Collection
+		if "" == coll {
+			coll = "unknown"
+		}
+		pq = "'" + s.Operation + "' on '" + coll + "' using '" + string(s.Product) + "'"
+	}
+	return pq
+}
 
 // AddAttribute adds a key value pair to the current ExternalSegment.
 //

--- a/v4/newrelic/segments.go
+++ b/v4/newrelic/segments.go
@@ -158,6 +158,9 @@ func (s *span) end() {
 }
 
 func (s *span) isEnded() bool {
+	if s == nil {
+		return true
+	}
 	s.Lock()
 	defer s.Unlock()
 	return s.ended
@@ -172,9 +175,6 @@ func (s *Segment) AddAttribute(key string, val interface{}) {}
 // End finishes the segment.
 func (s *Segment) End() {
 	if s == nil {
-		return
-	}
-	if s.StartTime.span == nil {
 		return
 	}
 	if s.StartTime.isEnded() {
@@ -193,9 +193,6 @@ func (s *DatastoreSegment) AddAttribute(key string, val interface{}) {}
 // End finishes the datastore segment.
 func (s *DatastoreSegment) End() {
 	if s == nil {
-		return
-	}
-	if s.StartTime.span == nil {
 		return
 	}
 	if s.StartTime.isEnded() {
@@ -226,9 +223,6 @@ func (s *ExternalSegment) AddAttribute(key string, val interface{}) {}
 // End finishes the external segment.
 func (s *ExternalSegment) End() {
 	if s == nil {
-		return
-	}
-	if s.StartTime.span == nil {
 		return
 	}
 	if s.StartTime.isEnded() {
@@ -293,9 +287,6 @@ func (s *MessageProducerSegment) AddAttribute(key string, val interface{}) {}
 // End finishes the message segment.
 func (s *MessageProducerSegment) End() {
 	if s == nil {
-		return
-	}
-	if s.StartTime.span == nil {
 		return
 	}
 	if s.StartTime.isEnded() {

--- a/v4/newrelic/segments_test.go
+++ b/v4/newrelic/segments_test.go
@@ -496,37 +496,43 @@ func TestExternalSegmentNaming(t *testing.T) {
 	}{
 		{
 			seg:  &ExternalSegment{},
-			name: "unknown: unknown",
+			name: "http unknown unknown",
 		},
 		{
 			seg: &ExternalSegment{
 				Host: "myhost:1234",
 			},
-			name: "unknown: myhost:1234",
+			name: "http unknown myhost:1234",
 		},
 		{
 			seg: &ExternalSegment{
 				URL: "http://myhost:1234/path",
 			},
-			name: "unknown: myhost:1234",
+			name: "http unknown myhost:1234",
 		},
 		{
 			seg: &ExternalSegment{
 				URL: "this is not a url",
 			},
-			name: "unknown: unknown",
+			name: "http unknown unknown",
 		},
 		{
 			seg: &ExternalSegment{
 				Procedure: "procedure",
 			},
-			name: "procedure: unknown",
+			name: "http procedure unknown",
+		},
+		{
+			seg: &ExternalSegment{
+				Library: "gRPC",
+			},
+			name: "gRPC unknown unknown",
 		},
 		{
 			seg: &ExternalSegment{
 				Request: &http.Request{},
 			},
-			name: "GET: unknown",
+			name: "http GET unknown",
 		},
 		{
 			seg: &ExternalSegment{
@@ -534,7 +540,7 @@ func TestExternalSegmentNaming(t *testing.T) {
 					Method: "POST",
 				},
 			},
-			name: "POST: unknown",
+			name: "http POST unknown",
 		},
 		{
 			seg: &ExternalSegment{
@@ -543,7 +549,7 @@ func TestExternalSegmentNaming(t *testing.T) {
 				},
 				Response: &http.Response{},
 			},
-			name: "POST: unknown",
+			name: "http POST unknown",
 		},
 		{
 			seg: &ExternalSegment{
@@ -556,7 +562,7 @@ func TestExternalSegmentNaming(t *testing.T) {
 					},
 				},
 			},
-			name: "PUT: unknown",
+			name: "http PUT unknown",
 		},
 	}
 


### PR DESCRIPTION
This pull request implements `DatastoreSegment`, `ExternalSegment`, and `MessageProducerSegment`. The biggest challenge here was deciding on the name for each of these span types. I did my best to follow the OpenTelemetry specs for naming.

* [Semantic conventions for database client calls](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/database.md)
* [Semantic conventions for HTTP spans](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md#name)
* [Semantic conventions for messaging systems](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/messaging.md#span-name)