### PR TITLE
Add DT support to the shim

### DIFF
--- a/v4/newrelic/application.go
+++ b/v4/newrelic/application.go
@@ -30,6 +30,7 @@ func (app *Application) StartTransaction(name string) *Transaction {
 		thread: &thread{
 			currentSpan: s,
 		},
+		name: name,
 	}
 }
 

--- a/v4/newrelic/application.go
+++ b/v4/newrelic/application.go
@@ -8,13 +8,15 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/api/global"
+	"go.opentelemetry.io/otel/api/propagation"
 	"go.opentelemetry.io/otel/api/trace"
 )
 
 // Application represents your application.  All methods on Application are nil
 // safe.  Therefore, a nil Application pointer can be safely used as a mock.
 type Application struct {
-	tracer trace.Tracer
+	tracer      trace.Tracer
+	propagators propagation.Propagators
 }
 
 // StartTransaction begins a Transaction with the given name.
@@ -30,6 +32,7 @@ func (app *Application) StartTransaction(name string) *Transaction {
 		thread: &thread{
 			currentSpan: s,
 		},
+		app: app,
 	}
 }
 
@@ -104,5 +107,9 @@ func NewApplication(opts ...ConfigOption) (*Application, error) {
 	if nil == tracer {
 		tracer = global.Tracer("traceName")
 	}
-	return &Application{tracer: tracer}, nil
+	propagators := propagation.New(
+		propagation.WithInjectors(trace.TraceContext{}),
+		propagation.WithExtractors(trace.TraceContext{}))
+
+	return &Application{tracer: tracer, propagators: propagators}, nil
 }

--- a/v4/newrelic/application.go
+++ b/v4/newrelic/application.go
@@ -30,7 +30,6 @@ func (app *Application) StartTransaction(name string) *Transaction {
 		thread: &thread{
 			currentSpan: s,
 		},
-		name: name,
 	}
 }
 

--- a/v4/newrelic/application.go
+++ b/v4/newrelic/application.go
@@ -30,8 +30,8 @@ func (app *Application) StartTransaction(name string) *Transaction {
 	return &Transaction{
 		rootSpan: s,
 		thread: &thread{
-			currentSpan: s,
-			spanCount:   1,
+			currentSpan:  s,
+			isSingleSpan: true,
 		},
 		app:  app,
 		name: name,

--- a/v4/newrelic/application.go
+++ b/v4/newrelic/application.go
@@ -31,8 +31,10 @@ func (app *Application) StartTransaction(name string) *Transaction {
 		rootSpan: s,
 		thread: &thread{
 			currentSpan: s,
+			spanCount:   1,
 		},
-		app: app,
+		app:  app,
+		name: name,
 	}
 }
 

--- a/v4/newrelic/application.go
+++ b/v4/newrelic/application.go
@@ -30,8 +30,7 @@ func (app *Application) StartTransaction(name string) *Transaction {
 	return &Transaction{
 		rootSpan: s,
 		thread: &thread{
-			currentSpan:  s,
-			isSingleSpan: true,
+			currentSpan: s,
 		},
 		app:  app,
 		name: name,
@@ -109,9 +108,11 @@ func NewApplication(opts ...ConfigOption) (*Application, error) {
 	if nil == tracer {
 		tracer = global.Tracer("traceName")
 	}
-	propagators := propagation.New(
-		propagation.WithInjectors(trace.TraceContext{}),
-		propagation.WithExtractors(trace.TraceContext{}))
-
+	propagators := c.OpenTelemetry.Propagators
+	if nil == propagators {
+		propagators = propagation.New(
+			propagation.WithInjectors(trace.TraceContext{}),
+			propagation.WithExtractors(trace.TraceContext{}))
+	}
 	return &Application{tracer: tracer, propagators: propagators}, nil
 }

--- a/v4/newrelic/config.go
+++ b/v4/newrelic/config.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"go.opentelemetry.io/otel/api/propagation"
 	"go.opentelemetry.io/otel/api/trace"
 )
 
@@ -340,6 +341,8 @@ type Config struct {
 	OpenTelemetry struct {
 		// Tracer TODO
 		Tracer trace.Tracer
+		// Propagator TODO
+		Propagators propagation.Propagators
 	}
 }
 

--- a/v4/newrelic/config.go
+++ b/v4/newrelic/config.go
@@ -341,7 +341,7 @@ type Config struct {
 	OpenTelemetry struct {
 		// Tracer TODO
 		Tracer trace.Tracer
-		// Propagator TODO
+		// Propagators TODO
 		Propagators propagation.Propagators
 	}
 }

--- a/v4/newrelic/segments.go
+++ b/v4/newrelic/segments.go
@@ -331,7 +331,9 @@ func StartExternalSegment(txn *Transaction, request *http.Request) *ExternalSegm
 		Request:   request,
 	}
 
-	txn.InsertDistributedTraceHeaders(request.Header)
+	if nil != request && nil != request.Header {
+		txn.InsertDistributedTraceHeaders(request.Header)
+	}
 
 	return s
 }

--- a/v4/newrelic/segments.go
+++ b/v4/newrelic/segments.go
@@ -323,5 +323,15 @@ func (s *ExternalSegment) SetStatusCode(code int) {}
 // NewRoundTripper: You may not need to use StartExternalSegment at all!
 //
 func StartExternalSegment(txn *Transaction, request *http.Request) *ExternalSegment {
-	return nil
+	if nil == txn && nil != request {
+		txn = FromContext(request.Context())
+	}
+	s := &ExternalSegment{
+		StartTime: txn.StartSegmentNow(),
+		Request:   request,
+	}
+
+	txn.InsertDistributedTraceHeaders(request.Header)
+
+	return s
 }

--- a/v4/newrelic/segments_test.go
+++ b/v4/newrelic/segments_test.go
@@ -665,6 +665,23 @@ func TestSpanKind(t *testing.T) {
 	}
 }
 
+func TestStartExternalSegmentInvalid(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://request.com/", nil)
+
+	var txn *Transaction
+	StartExternalSegment(txn, req)
+
+	txn = &Transaction{}
+	StartExternalSegment(txn, req)
+
+	app := newTestApp(t)
+	txn = app.StartTransaction("transaction")
+	defer txn.End()
+
+	StartExternalSegment(txn, nil)
+	StartExternalSegment(txn, &http.Request{})
+}
+
 func TestStartExternalSegment(t *testing.T) {
 	app := newTestApp(t)
 	txn := app.StartTransaction("transaction")

--- a/v4/newrelic/segments_test.go
+++ b/v4/newrelic/segments_test.go
@@ -698,17 +698,13 @@ func TestStartExternalSegmentWithTxnContext(t *testing.T) {
 
 	txn.End()
 
-	// This will currently fail, as seg1.StartTime is nil. It can be
-	// activated context support is implemented.
-	if false {
-		traceID := getTraceID(txn.rootSpan.Span)
-		seg1ID := getSpanID(seg1.StartTime.Span)
+	traceID := getTraceID(txn.rootSpan.Span)
+	seg1ID := getSpanID(seg1.StartTime.Span)
 
-		traceparent := req.Header.Get("traceparent")
-		expectedTraceparent := fmt.Sprintf("00-%s-%s-00", traceID, seg1ID)
+	traceparent := req.Header.Get("traceparent")
+	expectedTraceparent := fmt.Sprintf("00-%s-%s-00", traceID, seg1ID)
 
-		if traceparent != expectedTraceparent {
-			t.Errorf("expected traceparent '%s', got '%s'", expectedTraceparent, traceparent)
-		}
+	if traceparent != expectedTraceparent {
+		t.Errorf("expected traceparent '%s', got '%s'", expectedTraceparent, traceparent)
 	}
 }

--- a/v4/newrelic/transaction.go
+++ b/v4/newrelic/transaction.go
@@ -250,7 +250,7 @@ func (txn *Transaction) AcceptDistributedTraceHeaders(t TransportType, hdrs http
 
 // Application returns the Application which started the transaction.
 func (txn *Transaction) Application() *Application {
-	return nil
+	return txn.app
 }
 
 // BrowserTimingHeader generates the JavaScript required to enable New

--- a/v4/newrelic/transaction.go
+++ b/v4/newrelic/transaction.go
@@ -166,7 +166,7 @@ func (txn *Transaction) StartSegmentNow() SegmentStartTime {
 func (thd *thread) setCurrentSpan(s *span) {
 	thd.Lock()
 	thd.currentSpan = s
-	thd.spanCount += 1
+	thd.spanCount++
 	thd.Unlock()
 }
 

--- a/v4/newrelic/transaction.go
+++ b/v4/newrelic/transaction.go
@@ -248,7 +248,7 @@ func (txn *Transaction) AcceptDistributedTraceHeaders(t TransportType, hdrs http
 	// have the remote trace id as trace id and the remote span id as the
 	// parent span id.
 	//
-	// If no more than the root segment where yet created for this
+	// If no more than the root segment were yet created for this
 	// transaction, we discard the root segment and replace it with a new
 	// root segment that has the proper remote parent and trace id.
 	remoteCtx := propagation.ExtractHTTP(context.Background(), txn.app.propagators, hdrs)

--- a/v4/newrelic/transaction.go
+++ b/v4/newrelic/transaction.go
@@ -231,7 +231,7 @@ func (txn *Transaction) AcceptDistributedTraceHeaders(t TransportType, hdrs http
 
 	// Here we create an OpenTelemetry context that is detached from the
 	// current trace. All segments (spans) subsequently started with this
-	// context will be detached from the transaction trace, but rather will
+	// context will be detached from the distributed trace, but rather will
 	// have the remote trace id as trace id and the remote span id as the
 	// parent span id.
 	remoteCtx := propagation.ExtractHTTP(context.Background(), props, hdrs)

--- a/v4/newrelic/transaction.go
+++ b/v4/newrelic/transaction.go
@@ -229,7 +229,7 @@ func (txn *Transaction) InsertDistributedTraceHeaders(hdrs http.Header) {
 func (txn *Transaction) AcceptDistributedTraceHeaders(t TransportType, hdrs http.Header) {
 	props := propagation.New(propagation.WithExtractors(trace.TraceContext{}))
 
-	// Here we create a OpenTelemetry context that is detached from the
+	// Here we create an OpenTelemetry context that is detached from the
 	// current trace. All segments (spans) subsequently started with this
 	// context will be detached from the transaction trace, but rather will
 	// have the remote trace id as trace id and the remote span id as the

--- a/v4/newrelic/transaction.go
+++ b/v4/newrelic/transaction.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/otel/api/propagation"
+	"go.opentelemetry.io/otel/api/trace"
 )
 
 // Transaction instruments one logical unit of work: either an inbound web
@@ -303,6 +304,7 @@ func (txn *Transaction) NewGoroutine() *Transaction {
 	newTxn := *txn
 	newTxn.thread = &thread{
 		currentSpan: txn.thread.currentSpan,
+		spanCount:   1,
 	}
 	return &newTxn
 }

--- a/v4/newrelic/transaction.go
+++ b/v4/newrelic/transaction.go
@@ -312,7 +312,7 @@ func (txn *Transaction) NewGoroutine() *Transaction {
 	newTxn := *txn
 	newTxn.thread = &thread{
 		currentSpan: txn.thread.currentSpan,
-		isMultiSpan: txn.thread.isMultiSpan,
+		isMultiSpan: true,
 	}
 	return &newTxn
 }

--- a/v4/newrelic/transaction.go
+++ b/v4/newrelic/transaction.go
@@ -22,7 +22,6 @@ import (
 type Transaction struct {
 	rootSpan *span
 	thread   *thread
-	name     string
 	ended    bool
 }
 

--- a/v4/newrelic/transaction.go
+++ b/v4/newrelic/transaction.go
@@ -31,7 +31,7 @@ type thread struct {
 	sync.Mutex
 	currentSpan *span
 	// isMultiSpan is set to true of the associated transaction has more
-	// than one span.
+	// than one span or crosses multiple goroutines.
 	isMultiSpan bool
 }
 

--- a/v4/newrelic/transaction.go
+++ b/v4/newrelic/transaction.go
@@ -309,6 +309,8 @@ func (txn *Transaction) NewGoroutine() *Transaction {
 	txn.thread.Lock()
 	defer txn.thread.Unlock()
 
+	txn.thread.isMultiSpan = true
+
 	newTxn := *txn
 	newTxn.thread = &thread{
 		currentSpan: txn.thread.currentSpan,

--- a/v4/newrelic/transaction_test.go
+++ b/v4/newrelic/transaction_test.go
@@ -1,0 +1,62 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package newrelic
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"go.opentelemetry.io/otel/api/trace"
+)
+
+func getTraceID(s trace.Span) string {
+	return s.SpanContext().TraceID.String()
+}
+
+func TestInsertDistributedTraceHeadersTracestate(t *testing.T) {
+	app := newTestApp(t)
+	txn := app.StartTransaction("transaction")
+	seg1 := txn.StartSegment("seg1")
+
+	hdrs := http.Header{}
+	txn.InsertDistributedTraceHeaders(hdrs)
+
+	seg1.End()
+	txn.End()
+
+	traceID := getTraceID(txn.rootSpan.Span)
+	seg1ID := getSpanID(seg1.StartTime.Span)
+
+	traceparent := hdrs.Get("traceparent")
+	expectedTraceparent := fmt.Sprintf("00-%s-%s-00", traceID, seg1ID)
+
+	if traceparent != expectedTraceparent {
+		t.Errorf("expected traceparent '%s', got '%s'", expectedTraceparent, traceparent)
+	}
+}
+
+func TestAcceptDistributedTraceHeadersTracestate(t *testing.T) {
+	remoteTraceID := "aaaa0000000000000000000000000001"
+	remoteSpanID := "bbbb000000000002"
+
+	app := newTestApp(t)
+	txn := app.StartTransaction("transaction")
+
+	hdrs := http.Header{}
+	hdrs.Set("traceparent", fmt.Sprintf("00-%s-%s-01", remoteTraceID, remoteSpanID))
+
+	txn.AcceptDistributedTraceHeaders("HTTP", hdrs)
+
+	seg1 := txn.StartSegment("seg1")
+	seg1.End()
+	txn.End()
+
+	seg1TraceID := getTraceID(seg1.StartTime.Span)
+
+	if seg1TraceID != remoteTraceID {
+		t.Errorf("seg1 is does not have remote trace id: seg1TracdID=%s, remoteTraceID=%s",
+			seg1TraceID, remoteTraceID)
+	}
+}

--- a/v4/newrelic/transaction_test.go
+++ b/v4/newrelic/transaction_test.go
@@ -142,6 +142,7 @@ func TestAcceptDistributedTraceHeadersNewGoroutineNoSwitchRoot(t *testing.T) {
 	hdrs.Set("traceparent", fmt.Sprintf("00-%s-%s-01", remoteTraceID, remoteSpanID))
 
 	txnNew.AcceptDistributedTraceHeaders("HTTP", hdrs)
+	txn.AcceptDistributedTraceHeaders("HTTP", hdrs)
 
 	seg1 := txnNew.StartSegment("seg1")
 	seg1.End()

--- a/v4/newrelic/transaction_test.go
+++ b/v4/newrelic/transaction_test.go
@@ -130,7 +130,7 @@ func TestAcceptDistributedTraceHeadersNewGoroutine(t *testing.T) {
 	}
 }
 
-func TestAcceptDistributedTraceHeadersNewGoroutineSwitchRoot(t *testing.T) {
+func TestAcceptDistributedTraceHeadersNewGoroutineNoSwitchRoot(t *testing.T) {
 	remoteTraceID := "aaaa0000000000000000000000000001"
 	remoteSpanID := "bbbb000000000002"
 
@@ -156,8 +156,8 @@ func TestAcceptDistributedTraceHeadersNewGoroutineSwitchRoot(t *testing.T) {
 		t.Errorf("txn root does have remote trace id: rootTraceID=%s, remoteTraceID=%s",
 			txnRootTraceID, remoteTraceID)
 	}
-	if txnNewRootTraceID != remoteTraceID {
-		t.Errorf("txn root does not have remote trace id: rootTraceID=%s, remoteTraceID=%s",
+	if txnNewRootTraceID == remoteTraceID {
+		t.Errorf("txn root does have remote trace id: rootTraceID=%s, remoteTraceID=%s",
 			txnNewRootTraceID, remoteTraceID)
 	}
 }

--- a/v4/newrelic/transaction_test.go
+++ b/v4/newrelic/transaction_test.go
@@ -53,10 +53,15 @@ func TestAcceptDistributedTraceHeadersTracestate(t *testing.T) {
 	seg1.End()
 	txn.End()
 
+	seg1ParentID := getParentID(seg1.StartTime.Span)
 	seg1TraceID := getTraceID(seg1.StartTime.Span)
 
 	if seg1TraceID != remoteTraceID {
 		t.Errorf("seg1 is does not have remote trace id: seg1TracdID=%s, remoteTraceID=%s",
 			seg1TraceID, remoteTraceID)
+	}
+	if seg1ParentID != remoteSpanID {
+		t.Errorf("seg1 is not a child of remote segment: seg1ParentID=%s, remoteSpanID=%s",
+			seg1ParentID, remoteSpanID)
 	}
 }

--- a/v4/newrelic/transaction_test.go
+++ b/v4/newrelic/transaction_test.go
@@ -15,6 +15,13 @@ func getTraceID(s trace.Span) string {
 	return s.SpanContext().TraceID.String()
 }
 
+func TestInsertDistributedTraceHeadersNil(t *testing.T) {
+	hdrs := http.Header{}
+
+	var txn *Transaction
+	txn.InsertDistributedTraceHeaders(hdrs)
+}
+
 func TestInsertDistributedTraceHeadersTracestate(t *testing.T) {
 	app := newTestApp(t)
 	txn := app.StartTransaction("transaction")
@@ -35,6 +42,13 @@ func TestInsertDistributedTraceHeadersTracestate(t *testing.T) {
 	if traceparent != expectedTraceparent {
 		t.Errorf("expected traceparent '%s', got '%s'", expectedTraceparent, traceparent)
 	}
+}
+
+func TestAcceptDistributedTraceHeadersNil(t *testing.T) {
+	hdrs := http.Header{}
+
+	var txn *Transaction
+	txn.AcceptDistributedTraceHeaders("HTTP", hdrs)
 }
 
 func TestAcceptDistributedTraceHeadersTracestate(t *testing.T) {

--- a/v4/newrelic/transaction_test.go
+++ b/v4/newrelic/transaction_test.go
@@ -247,13 +247,13 @@ func TestInsertDistributedTraceHeadersB3(t *testing.T) {
 	traceID := getTraceID(txn.rootSpan.Span)
 	seg1ID := getSpanID(seg1.StartTime.Span)
 
-	b3TraceId := hdrs.Get("X-B3-Traceid")
-	b3SpanId := hdrs.Get("X-B3-Spanid")
+	b3TraceID := hdrs.Get("X-B3-Traceid")
+	b3SpanID := hdrs.Get("X-B3-Spanid")
 
-	if b3TraceId != traceID {
-		t.Errorf("expected X-B3-Traceid '%s', got '%s'", traceID, b3TraceId)
+	if b3TraceID != traceID {
+		t.Errorf("expected X-B3-Traceid '%s', got '%s'", traceID, b3TraceID)
 	}
-	if b3SpanId != seg1ID {
-		t.Errorf("expected X-B3-Spanid '%s', got '%s'", seg1ID, b3SpanId)
+	if b3SpanID != seg1ID {
+		t.Errorf("expected X-B3-Spanid '%s', got '%s'", seg1ID, b3SpanID)
 	}
 }


### PR DESCRIPTION
This adds DT support to the shim by implementing the functions `InsertDistributedTraceHeaders` and `AcceptDistributedTraceHeaders`, using the TraceContext injector and extractor OpenTelemetry provides.

The implementation for `InsertDistributedTraceHeaders` is straight-forward and uncontroversial.

### Problem

Things get a bit messy with `AcceptDistributedTraceHeaders` though. OpenTelemetry requires that the inbound headers were received _before_ the trace was started, whereas the Go agent requires the opposite, namely that a transaction was started _before_ inbound headers were received. We cannot call `AcceptDistributedTraceHeaders` before a transaction was started. I don't see a possibility to do a 1:1 mapping of one solution to another.

### Solution

The best solution I could come up with is starting a new trace after a call to `AcceptDistributedTraceHeaders`. A call to `AcceptDistributedTraceHeaders` creates a new context that will have the inbound trace id and the inbound span id, this context will then be used to start the next segment/span. With this approach, we'll end up with two (or more) traces for one transaction: one trace starting with the root transaction segment and now remote parent, another trace starting after a call to `AcceptDistributedTraceHeaders`, parented to the remote span and having the remote trace id.

Based on good feedback from @purple4reina I added special treatment for transactions for which no segments (besides the root segment) were started before the `AcceptDistributedTraceHeaders` call: in that case, during the call of `AcceptDistributedTraceHeaders` the root segment will be replaced with a new segment that is parented to the remote span context.