### PR TITLE
Set SpanKind to internal for all spans.

### DIFF
--- a/build-script.sh
+++ b/build-script.sh
@@ -36,7 +36,7 @@ for dir in $DIRS; do
   if [ $dir == "." ]; then
     rm -rf v3/
     rm -rf v4/
-  elif [ $dir = v3* ]; then
+  elif [[ $dir =~ v3 ]]; then
     # Only v3 code version 1.9+ needs GRPC dependencies
     VERSION=$(go version)
     V17="1.7"
@@ -50,7 +50,7 @@ for dir in $DIRS; do
     fi
   else
     # install v4 dependencies
-    go get ./...
+    go get -u go.opentelemetry.io/otel
   fi
 
   go test -race -benchtime=1ms -bench=. ./...

--- a/build-script.sh
+++ b/build-script.sh
@@ -50,7 +50,7 @@ for dir in $DIRS; do
     fi
   else
     # install v4 dependencies
-    go get -u go.opentelemetry.io/otel
+    go get ./...
   fi
 
   go test -race -benchtime=1ms -bench=. ./...

--- a/v4/go.mod
+++ b/v4/go.mod
@@ -4,5 +4,5 @@ go 1.13
 
 require (
 	github.com/newrelic/opentelemetry-exporter-go v0.1.0
-	go.opentelemetry.io/otel v0.5.0
+	go.opentelemetry.io/otel v0.10.0
 )

--- a/v4/newrelic/application.go
+++ b/v4/newrelic/application.go
@@ -19,7 +19,8 @@ type Application struct {
 
 // StartTransaction begins a Transaction with the given name.
 func (app *Application) StartTransaction(name string) *Transaction {
-	ctx, sp := app.tracer.Start(context.Background(), name)
+	ctx, sp := app.tracer.Start(context.Background(), name,
+		trace.WithSpanKind(trace.SpanKindInternal))
 	s := &span{
 		Span: sp,
 		ctx:  ctx,

--- a/v4/newrelic/transaction.go
+++ b/v4/newrelic/transaction.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+
+	"go.opentelemetry.io/otel/api/trace"
 )
 
 // Transaction instruments one logical unit of work: either an inbound web
@@ -142,7 +144,8 @@ func (txn *Transaction) StartSegmentNow() SegmentStartTime {
 		return SegmentStartTime{}
 	}
 	parent := txn.thread.getCurrentSpan()
-	ctx, sp := txn.rootSpan.Span.Tracer().Start(parent.ctx, "")
+	ctx, sp := txn.rootSpan.Span.Tracer().Start(parent.ctx, "",
+		trace.WithSpanKind(trace.SpanKindInternal))
 	span := &span{
 		Span:   sp,
 		ctx:    ctx,


### PR DESCRIPTION
With every span we need to also include the [Span Kind](https://pkg.go.dev/go.opentelemetry.io/otel@v0.9.0/api/trace?tab=doc#SpanKind). Unfortunately right now, OTel's Go implementation only supports setting the `SpanKind` at span start time. Since we cannot know which type of segment `txn.StartSegmentNow` is being called for, this will not work for us. This PR sets all the spans we create to be "internal" spans.

I spoke with @MrAlias about this and he opened an issue https://github.com/open-telemetry/opentelemetry-go/issues/988 that would mean we could set the `SpanKind` at either start _or_ end. Once that work is done, we need to circle back and implement the span kind for each span. We'll need to be sure to set the root span to the "server" type iff the `txn.SetWebRequest` API has been called, otherwise it should be left as "internal".

Lastly, this PR is reliant on https://github.com/open-telemetry/opentelemetry-go/pull/987 being merged into OpenTelemetry. The tests will fail until that happens. In the meantime, it is still ready for your review.