### PR TITLE
Wait for connection rather than span receive.

### DIFF
--- a/build-script.sh
+++ b/build-script.sh
@@ -36,13 +36,24 @@ for dir in $DIRS; do
   if [ $dir == "." ]; then
     rm -rf v3/
     rm -rf v4/
-  elif [ $dir = v3* ]; then
+  elif [[ $dir =~ "v3" ]]; then
     # Only v3 code version 1.9+ needs GRPC dependencies
     VERSION=$(go version)
     V17="1.7"
     V18="1.8"
+    V19="1.9"
     if [[ "$VERSION" =~ .*"$V17".* || "$VERSION" =~ .*"$V18".* ]]; then
       echo "Not installing GRPC for old versions"
+    elif [[ "$VERSION" =~ .*"$V19" ]]; then
+      # install v3 dependencies that support this go version
+      set +e
+      go get -u google.golang.org/grpc # this go get will fail to build
+      set -e
+      cd $GOPATH/src/google.golang.org/grpc
+      git checkout v1.31.0
+      cd -
+
+      go get -u github.com/golang/protobuf/protoc-gen-go
     else
       # install v3 dependencies
       go get -u github.com/golang/protobuf/protoc-gen-go


### PR DESCRIPTION
There are two fixes in this Pull Request.

First is the fix for the flakey failing infinite tracing test. That test is ensuring that when reconnecting to the trace observer host after receiving an OK response does not use a backoff. To test that we want to ensure that we connect once, disconnect, then immediately reconnect a second time. We do not really care if the spans are actually received or not. So, I changed the check to ensure we are connecting, not receiving spans. This seems to have fixed the issue as I ran the tests at least 3-4 times and they never failed.

Second is an update grpc made this very morning in deprecating go1.9. According to their documentation they only support go1.11 and above (or maybe go1.12 and above?), however, it seems that go1.10 builds just fine. I want to make sure that we still run the trace observer tests for go1.9 and above since customers could still be using these versions. To do so, I make sure we are running the tests against grpc v1.31.0 which is the last version that works for go1.9.