### PR TITLE
Implement ExpectSpanEvents.

### DIFF
--- a/v4/integrations/nrecho-v3/nrecho_test.go
+++ b/v4/integrations/nrecho-v3/nrecho_test.go
@@ -37,19 +37,17 @@ func TestBasicRoute(t *testing.T) {
 		Name:  "GET /hello",
 		IsWeb: true,
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"name":             "WebTransaction/Go/GET /hello",
-			"nr.apdexPerfZone": "S",
-		},
-		AgentAttributes: map[string]interface{}{
+	app.ExpectSpanEvents(t, []internal.WantSpan{{
+		Name:     "GET /hello",
+		ParentID: internal.MatchNoParent,
+		Attributes: map[string]interface{}{
+			"nr.apdexPerfZone":             "S",
 			"httpResponseCode":             "200",
 			"http.statusCode":              "200",
 			"request.method":               "GET",
 			"response.headers.contentType": "text/html",
 			"request.uri":                  "/hello",
 		},
-		UserAttributes: map[string]interface{}{},
 	}})
 }
 
@@ -163,18 +161,16 @@ func TestReturnsHTTPError(t *testing.T) {
 		IsWeb:     true,
 		NumErrors: 1,
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"name":             "WebTransaction/Go/GET /hello",
+	app.ExpectSpanEvents(t, []internal.WantSpan{{
+		Name:     "GET /hello",
+		ParentID: internal.MatchNoParent,
+		Attributes: map[string]interface{}{
 			"nr.apdexPerfZone": "F",
-		},
-		AgentAttributes: map[string]interface{}{
 			"httpResponseCode": "418",
 			"http.statusCode":  "418",
 			"request.method":   "GET",
 			"request.uri":      "/hello",
 		},
-		UserAttributes: map[string]interface{}{},
 	}})
 }
 
@@ -199,18 +195,16 @@ func TestReturnsError(t *testing.T) {
 		IsWeb:     true,
 		NumErrors: 1,
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"name":             "WebTransaction/Go/GET /hello",
+	app.ExpectSpanEvents(t, []internal.WantSpan{{
+		Name:     "GET /hello",
+		ParentID: internal.MatchNoParent,
+		Attributes: map[string]interface{}{
 			"nr.apdexPerfZone": "F",
-		},
-		AgentAttributes: map[string]interface{}{
 			"httpResponseCode": "500",
 			"http.statusCode":  "500",
 			"request.method":   "GET",
 			"request.uri":      "/hello",
 		},
-		UserAttributes: map[string]interface{}{},
 	}})
 }
 
@@ -235,18 +229,16 @@ func TestResponseCode(t *testing.T) {
 		IsWeb:     true,
 		NumErrors: 1,
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"name":             "WebTransaction/Go/GET /hello",
-			"nr.apdexPerfZone": "F",
-		},
-		AgentAttributes: map[string]interface{}{
+	app.ExpectSpanEvents(t, []internal.WantSpan{{
+		Name:     "GET /hello",
+		ParentID: internal.MatchNoParent,
+		Attributes: map[string]interface{}{
+			"nr.apdexPerfZone":             "F",
 			"httpResponseCode":             "418",
 			"http.statusCode":              "418",
 			"request.method":               "GET",
 			"response.headers.contentType": "text/html",
 			"request.uri":                  "/hello",
 		},
-		UserAttributes: map[string]interface{}{},
 	}})
 }

--- a/v4/integrations/nrecho-v4/nrecho_test.go
+++ b/v4/integrations/nrecho-v4/nrecho_test.go
@@ -37,19 +37,17 @@ func TestBasicRoute(t *testing.T) {
 		Name:  "GET /hello",
 		IsWeb: true,
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"name":             "WebTransaction/Go/GET /hello",
-			"nr.apdexPerfZone": "S",
-		},
-		AgentAttributes: map[string]interface{}{
+	app.ExpectSpanEvents(t, []internal.WantSpan{{
+		Name:     "GET /hello",
+		ParentID: internal.MatchNoParent,
+		Attributes: map[string]interface{}{
+			"nr.apdexPerfZone":             "S",
 			"httpResponseCode":             "200",
 			"http.statusCode":              "200",
 			"request.method":               "GET",
 			"response.headers.contentType": "text/html",
 			"request.uri":                  "/hello",
 		},
-		UserAttributes: map[string]interface{}{},
 	}})
 }
 
@@ -163,18 +161,16 @@ func TestReturnsHTTPError(t *testing.T) {
 		IsWeb:     true,
 		NumErrors: 1,
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"name":             "WebTransaction/Go/GET /hello",
+	app.ExpectSpanEvents(t, []internal.WantSpan{{
+		Name:     "GET /hello",
+		ParentID: internal.MatchNoParent,
+		Attributes: map[string]interface{}{
 			"nr.apdexPerfZone": "F",
-		},
-		AgentAttributes: map[string]interface{}{
 			"httpResponseCode": "418",
 			"http.statusCode":  "418",
 			"request.method":   "GET",
 			"request.uri":      "/hello",
 		},
-		UserAttributes: map[string]interface{}{},
 	}})
 }
 
@@ -199,18 +195,16 @@ func TestReturnsError(t *testing.T) {
 		IsWeb:     true,
 		NumErrors: 1,
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"name":             "WebTransaction/Go/GET /hello",
+	app.ExpectSpanEvents(t, []internal.WantSpan{{
+		Name:     "GET /hello",
+		ParentID: internal.MatchNoParent,
+		Attributes: map[string]interface{}{
 			"nr.apdexPerfZone": "F",
-		},
-		AgentAttributes: map[string]interface{}{
 			"httpResponseCode": "500",
 			"http.statusCode":  "500",
 			"request.method":   "GET",
 			"request.uri":      "/hello",
 		},
-		UserAttributes: map[string]interface{}{},
 	}})
 }
 
@@ -235,18 +229,16 @@ func TestResponseCode(t *testing.T) {
 		IsWeb:     true,
 		NumErrors: 1,
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"name":             "WebTransaction/Go/GET /hello",
-			"nr.apdexPerfZone": "F",
-		},
-		AgentAttributes: map[string]interface{}{
+	app.ExpectSpanEvents(t, []internal.WantSpan{{
+		Name:     "GET /hello",
+		ParentID: internal.MatchNoParent,
+		Attributes: map[string]interface{}{
+			"nr.apdexPerfZone":             "F",
 			"httpResponseCode":             "418",
 			"http.statusCode":              "418",
 			"request.method":               "GET",
 			"response.headers.contentType": "text/html",
 			"request.uri":                  "/hello",
 		},
-		UserAttributes: map[string]interface{}{},
 	}})
 }

--- a/v4/integrations/nrgin/nrgin_test.go
+++ b/v4/integrations/nrgin/nrgin_test.go
@@ -243,9 +243,9 @@ func TestStatusCodes(t *testing.T) {
 	router.Use(Middleware(app.Application))
 	router.GET("/err", errorStatus)
 
-	txnName := "WebTransaction/Go/GET " + pkg + ".errorStatus"
+	txnName := "GET " + pkg + ".errorStatus"
 	if useFullPathVersion(gin.Version) {
-		txnName = "WebTransaction/Go/GET /err"
+		txnName = "GET /err"
 	}
 
 	response := httptest.NewRecorder()
@@ -260,13 +260,11 @@ func TestStatusCodes(t *testing.T) {
 	if response.Code != 500 {
 		t.Error("wrong response code", response.Code)
 	}
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"name":             txnName,
-			"nr.apdexPerfZone": internal.MatchAnything,
-		},
-		UserAttributes: map[string]interface{}{},
-		AgentAttributes: map[string]interface{}{
+	app.ExpectSpanEvents(t, []internal.WantSpan{{
+		Name:     txnName,
+		ParentID: internal.MatchNoParent,
+		Attributes: map[string]interface{}{
+			"nr.apdexPerfZone":             internal.MatchAnything,
 			"httpResponseCode":             expectCode,
 			"http.statusCode":              expectCode,
 			"request.method":               "GET",
@@ -292,9 +290,9 @@ func TestNoResponseBody(t *testing.T) {
 	router.Use(Middleware(app.Application))
 	router.GET("/nobody", noBody)
 
-	txnName := "WebTransaction/Go/GET " + pkg + ".noBody"
+	txnName := "GET " + pkg + ".noBody"
 	if useFullPathVersion(gin.Version) {
-		txnName = "WebTransaction/Go/GET /nobody"
+		txnName = "GET /nobody"
 	}
 
 	response := httptest.NewRecorder()
@@ -309,13 +307,11 @@ func TestNoResponseBody(t *testing.T) {
 	if response.Code != 500 {
 		t.Error("wrong response code", response.Code)
 	}
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"name":             txnName,
+	app.ExpectSpanEvents(t, []internal.WantSpan{{
+		Name:     txnName,
+		ParentID: internal.MatchNoParent,
+		Attributes: map[string]interface{}{
 			"nr.apdexPerfZone": internal.MatchAnything,
-		},
-		UserAttributes: map[string]interface{}{},
-		AgentAttributes: map[string]interface{}{
 			"httpResponseCode": expectCode,
 			"http.statusCode":  expectCode,
 			"request.method":   "GET",

--- a/v4/integrations/nrgorilla/nrgorilla_test.go
+++ b/v4/integrations/nrgorilla/nrgorilla_test.go
@@ -191,9 +191,10 @@ func TestMiddlewareAndInstrumentRoutes(t *testing.T) {
 	if respBody := response.Body.String(); respBody != "alpha response" {
 		t.Error("wrong response body", respBody)
 	}
-	app.ExpectTxnEvents(t, []internal.WantEvent{
-		{},
-	})
+	app.ExpectSpanEvents(t, []internal.WantSpan{{
+		Name:     "GET /alpha",
+		ParentID: internal.MatchNoParent,
+	}})
 }
 
 func TestMiddlewareNotFoundHandler(t *testing.T) {
@@ -219,7 +220,7 @@ func TestMiddlewareNotFoundHandler(t *testing.T) {
 		t.Error("wrong response code", response.Code)
 	}
 	// make sure no txn events were created
-	app.ExpectTxnEvents(t, []internal.WantEvent{})
+	app.ExpectSpanEvents(t, []internal.WantSpan{})
 }
 
 func TestMiddlewareMethodNotAllowedHandler(t *testing.T) {
@@ -246,5 +247,5 @@ func TestMiddlewareMethodNotAllowedHandler(t *testing.T) {
 		t.Error("wrong response code", response.Code)
 	}
 	// make sure no txn events were created
-	app.ExpectTxnEvents(t, []internal.WantEvent{})
+	app.ExpectSpanEvents(t, []internal.WantSpan{})
 }

--- a/v4/integrations/nrgrpc/nrgrpc_client_test.go
+++ b/v4/integrations/nrgrpc/nrgrpc_client_test.go
@@ -115,27 +115,25 @@ func TestUnaryClientInterceptor(t *testing.T) {
 		{Name: "Supportability/DistributedTrace/CreatePayload/Success", Scope: "", Forced: true, Data: nil},
 		{Name: "Supportability/TraceContext/Create/Success", Scope: "", Forced: true, Data: nil},
 	})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "gRPC TestApplication/DoUnaryUnary bufnet",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
 				"category":  "http",
 				"component": "gRPC",
-				"name":      "External/bufnet/gRPC/TestApplication/DoUnaryUnary",
 				"parentId":  internal.MatchAnything,
 				"span.kind": "client",
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "UnaryUnary",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"category":         "generic",
-				"name":             "OtherTransaction/Go/UnaryUnary",
 				"transaction.name": "OtherTransaction/Go/UnaryUnary",
 				"nr.entryPoint":    true,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 	})
 	app.ExpectTxnTraces(t, []internal.WantTxnTrace{{
@@ -209,27 +207,25 @@ func TestUnaryStreamClientInterceptor(t *testing.T) {
 		{Name: "Supportability/DistributedTrace/CreatePayload/Success", Scope: "", Forced: true, Data: nil},
 		{Name: "Supportability/TraceContext/Create/Success", Scope: "", Forced: true, Data: nil},
 	})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "gRPC TestApplication/DoUnaryStream bufnet",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
 				"category":  "http",
 				"component": "gRPC",
-				"name":      "External/bufnet/gRPC/TestApplication/DoUnaryStream",
 				"parentId":  internal.MatchAnything,
 				"span.kind": "client",
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "UnaryStream",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"category":         "generic",
-				"name":             "OtherTransaction/Go/UnaryStream",
 				"transaction.name": "OtherTransaction/Go/UnaryStream",
 				"nr.entryPoint":    true,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 	})
 	app.ExpectTxnTraces(t, []internal.WantTxnTrace{{
@@ -301,27 +297,25 @@ func TestStreamUnaryClientInterceptor(t *testing.T) {
 		{Name: "Supportability/DistributedTrace/CreatePayload/Success", Scope: "", Forced: true, Data: nil},
 		{Name: "Supportability/TraceContext/Create/Success", Scope: "", Forced: true, Data: nil},
 	})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "gRPC TestApplication/DoStreamUnary bufnet",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
 				"category":  "http",
 				"component": "gRPC",
-				"name":      "External/bufnet/gRPC/TestApplication/DoStreamUnary",
 				"parentId":  internal.MatchAnything,
 				"span.kind": "client",
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "StreamUnary",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"category":         "generic",
-				"name":             "OtherTransaction/Go/StreamUnary",
 				"transaction.name": "OtherTransaction/Go/StreamUnary",
 				"nr.entryPoint":    true,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 	})
 	app.ExpectTxnTraces(t, []internal.WantTxnTrace{{
@@ -406,27 +400,25 @@ func TestStreamStreamClientInterceptor(t *testing.T) {
 		{Name: "Supportability/DistributedTrace/CreatePayload/Success", Scope: "", Forced: true, Data: nil},
 		{Name: "Supportability/TraceContext/Create/Success", Scope: "", Forced: true, Data: nil},
 	})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "gRPC TestApplication/DoStreamStream bufnet",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
 				"category":  "http",
 				"component": "gRPC",
-				"name":      "External/bufnet/gRPC/TestApplication/DoStreamStream",
 				"parentId":  internal.MatchAnything,
 				"span.kind": "client",
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "StreamStream",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"category":         "generic",
-				"name":             "OtherTransaction/Go/StreamStream",
 				"transaction.name": "OtherTransaction/Go/StreamStream",
 				"nr.entryPoint":    true,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 	})
 	app.ExpectTxnTraces(t, []internal.WantTxnTrace{{
@@ -565,16 +557,15 @@ func TestClientStreamingError(t *testing.T) {
 		{Name: "Supportability/DistributedTrace/CreatePayload/Success", Scope: "", Forced: true, Data: nil},
 		{Name: "Supportability/TraceContext/Create/Success", Scope: "", Forced: true, Data: nil},
 	})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "UnaryStream",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"category":         "generic",
-				"name":             "OtherTransaction/Go/UnaryStream",
 				"transaction.name": "OtherTransaction/Go/UnaryStream",
 				"nr.entryPoint":    true,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 	})
 	app.ExpectTxnTraces(t, []internal.WantTxnTrace{{

--- a/v4/integrations/nrgrpc/nrgrpc_server_test.go
+++ b/v4/integrations/nrgrpc/nrgrpc_server_test.go
@@ -82,52 +82,47 @@ func TestUnaryServerInterceptor(t *testing.T) {
 		{Name: "WebTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "WebTransactionTotalTime/Go/TestApplication/DoUnaryUnary", Scope: "", Forced: false, Data: nil},
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"guid":                     internal.MatchAnything,
-			"name":                     "WebTransaction/Go/TestApplication/DoUnaryUnary",
-			"nr.apdexPerfZone":         internal.MatchAnything,
-			"parent.account":           123,
-			"parent.app":               456,
-			"parent.transportDuration": internal.MatchAnything,
-			"parent.transportType":     "HTTP",
-			"parent.type":              "App",
-			"parentId":                 internal.MatchAnything,
-			"parentSpanId":             internal.MatchAnything,
-			"priority":                 internal.MatchAnything,
-			"sampled":                  internal.MatchAnything,
-			"traceId":                  internal.MatchAnything,
-		},
-		UserAttributes: map[string]interface{}{},
-		AgentAttributes: map[string]interface{}{
-			"httpResponseCode":            0,
-			"http.statusCode":             0,
-			"request.headers.contentType": "application/grpc",
-			"request.method":              "TestApplication/DoUnaryUnary",
-			"request.uri":                 "grpc://bufnet/TestApplication/DoUnaryUnary",
-		},
-	}})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "DoUnaryUnary",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
+				"guid":                        internal.MatchAnything,
+				"nr.apdexPerfZone":            internal.MatchAnything,
+				"parent.account":              123,
+				"parent.app":                  456,
+				"parent.transportDuration":    internal.MatchAnything,
+				"parent.transportType":        "HTTP",
+				"parent.type":                 "App",
+				"parentId":                    internal.MatchAnything,
+				"parentSpanId":                internal.MatchAnything,
+				"priority":                    internal.MatchAnything,
+				"sampled":                     internal.MatchAnything,
+				"traceId":                     internal.MatchAnything,
+				"httpResponseCode":            0,
+				"http.statusCode":             0,
+				"request.headers.contentType": "application/grpc",
+				"request.method":              "TestApplication/DoUnaryUnary",
+				"request.uri":                 "grpc://bufnet/TestApplication/DoUnaryUnary",
+			},
+		},
+		{
+			Name:     "TestApplication/DoUnaryUnary",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"category": "generic",
-				"name":     "Custom/DoUnaryUnary",
 				"parentId": internal.MatchAnything,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 		{
-			Intrinsics: map[string]interface{}{
-				"category":         "generic",
-				"name":             "WebTransaction/Go/TestApplication/DoUnaryUnary",
-				"transaction.name": "WebTransaction/Go/TestApplication/DoUnaryUnary",
-				"nr.entryPoint":    true,
-				"parentId":         internal.MatchAnything,
-				"trustedParentId":  internal.MatchAnything,
-			},
-			UserAttributes: map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{
+			Name:     "gRPC TestApplication/DoUnaryUnary bufnet",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
+				"category":                    "generic",
+				"transaction.name":            "WebTransaction/Go/TestApplication/DoUnaryUnary",
+				"nr.entryPoint":               true,
+				"parentId":                    internal.MatchAnything,
+				"trustedParentId":             internal.MatchAnything,
 				"httpResponseCode":            0,
 				"http.statusCode":             0,
 				"parent.account":              "123",
@@ -172,17 +167,15 @@ func TestUnaryServerInterceptorError(t *testing.T) {
 		{Name: "WebTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "WebTransactionTotalTime/Go/TestApplication/DoUnaryUnaryError", Scope: "", Forced: false, Data: nil},
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"guid":             internal.MatchAnything,
-			"name":             "WebTransaction/Go/TestApplication/DoUnaryUnaryError",
-			"nr.apdexPerfZone": internal.MatchAnything,
-			"priority":         internal.MatchAnything,
-			"sampled":          internal.MatchAnything,
-			"traceId":          internal.MatchAnything,
-		},
-		UserAttributes: map[string]interface{}{},
-		AgentAttributes: map[string]interface{}{
+	app.ExpectSpanEvents(t, []internal.WantSpan{{
+		Name:     "TestApplication/DoUnaryUnaryError",
+		ParentID: internal.MatchNoParent,
+		Attributes: map[string]interface{}{
+			"guid":                        internal.MatchAnything,
+			"nr.apdexPerfZone":            internal.MatchAnything,
+			"priority":                    internal.MatchAnything,
+			"sampled":                     internal.MatchAnything,
+			"traceId":                     internal.MatchAnything,
 			"httpResponseCode":            15,
 			"http.statusCode":             15,
 			"request.headers.contentType": "application/grpc",
@@ -259,52 +252,47 @@ func TestUnaryStreamServerInterceptor(t *testing.T) {
 		{Name: "WebTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "WebTransactionTotalTime/Go/TestApplication/DoUnaryStream", Scope: "", Forced: false, Data: nil},
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"guid":                     internal.MatchAnything,
-			"name":                     "WebTransaction/Go/TestApplication/DoUnaryStream",
-			"nr.apdexPerfZone":         internal.MatchAnything,
-			"parent.account":           123,
-			"parent.app":               456,
-			"parent.transportDuration": internal.MatchAnything,
-			"parent.transportType":     "HTTP",
-			"parent.type":              "App",
-			"parentId":                 internal.MatchAnything,
-			"parentSpanId":             internal.MatchAnything,
-			"priority":                 internal.MatchAnything,
-			"sampled":                  internal.MatchAnything,
-			"traceId":                  internal.MatchAnything,
-		},
-		UserAttributes: map[string]interface{}{},
-		AgentAttributes: map[string]interface{}{
-			"httpResponseCode":            0,
-			"http.statusCode":             0,
-			"request.headers.contentType": "application/grpc",
-			"request.method":              "TestApplication/DoUnaryStream",
-			"request.uri":                 "grpc://bufnet/TestApplication/DoUnaryStream",
-		},
-	}})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "DoUnaryStream",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
+				"guid":                        internal.MatchAnything,
+				"nr.apdexPerfZone":            internal.MatchAnything,
+				"parent.account":              123,
+				"parent.app":                  456,
+				"parent.transportDuration":    internal.MatchAnything,
+				"parent.transportType":        "HTTP",
+				"parent.type":                 "App",
+				"parentId":                    internal.MatchAnything,
+				"parentSpanId":                internal.MatchAnything,
+				"priority":                    internal.MatchAnything,
+				"sampled":                     internal.MatchAnything,
+				"traceId":                     internal.MatchAnything,
+				"httpResponseCode":            0,
+				"http.statusCode":             0,
+				"request.headers.contentType": "application/grpc",
+				"request.method":              "TestApplication/DoUnaryStream",
+				"request.uri":                 "grpc://bufnet/TestApplication/DoUnaryStream",
+			},
+		},
+		{
+			Name:     "TestApplication/DoUnaryStream",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"category": "generic",
-				"name":     "Custom/DoUnaryStream",
 				"parentId": internal.MatchAnything,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 		{
-			Intrinsics: map[string]interface{}{
-				"category":         "generic",
-				"name":             "WebTransaction/Go/TestApplication/DoUnaryStream",
-				"transaction.name": "WebTransaction/Go/TestApplication/DoUnaryStream",
-				"nr.entryPoint":    true,
-				"parentId":         internal.MatchAnything,
-				"trustedParentId":  internal.MatchAnything,
-			},
-			UserAttributes: map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{
+			Name:     "gRPC TestApplication/DoUnaryStream bufnet",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
+				"category":                    "generic",
+				"transaction.name":            "WebTransaction/Go/TestApplication/DoUnaryStream",
+				"nr.entryPoint":               true,
+				"parentId":                    internal.MatchAnything,
+				"trustedParentId":             internal.MatchAnything,
 				"httpResponseCode":            0,
 				"http.statusCode":             0,
 				"parent.account":              "123",
@@ -363,52 +351,47 @@ func TestStreamUnaryServerInterceptor(t *testing.T) {
 		{Name: "WebTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "WebTransactionTotalTime/Go/TestApplication/DoStreamUnary", Scope: "", Forced: false, Data: nil},
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"guid":                     internal.MatchAnything,
-			"name":                     "WebTransaction/Go/TestApplication/DoStreamUnary",
-			"nr.apdexPerfZone":         internal.MatchAnything,
-			"parent.account":           123,
-			"parent.app":               456,
-			"parent.transportDuration": internal.MatchAnything,
-			"parent.transportType":     "HTTP",
-			"parent.type":              "App",
-			"parentId":                 internal.MatchAnything,
-			"parentSpanId":             internal.MatchAnything,
-			"priority":                 internal.MatchAnything,
-			"sampled":                  internal.MatchAnything,
-			"traceId":                  internal.MatchAnything,
-		},
-		UserAttributes: map[string]interface{}{},
-		AgentAttributes: map[string]interface{}{
-			"httpResponseCode":            0,
-			"http.statusCode":             0,
-			"request.headers.contentType": "application/grpc",
-			"request.method":              "TestApplication/DoStreamUnary",
-			"request.uri":                 "grpc://bufnet/TestApplication/DoStreamUnary",
-		},
-	}})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "DoStreamUnary",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
+				"guid":                        internal.MatchAnything,
+				"nr.apdexPerfZone":            internal.MatchAnything,
+				"parent.account":              123,
+				"parent.app":                  456,
+				"parent.transportDuration":    internal.MatchAnything,
+				"parent.transportType":        "HTTP",
+				"parent.type":                 "App",
+				"parentId":                    internal.MatchAnything,
+				"parentSpanId":                internal.MatchAnything,
+				"priority":                    internal.MatchAnything,
+				"sampled":                     internal.MatchAnything,
+				"traceId":                     internal.MatchAnything,
+				"httpResponseCode":            0,
+				"http.statusCode":             0,
+				"request.headers.contentType": "application/grpc",
+				"request.method":              "TestApplication/DoStreamUnary",
+				"request.uri":                 "grpc://bufnet/TestApplication/DoStreamUnary",
+			},
+		},
+		{
+			Name:     "TestApplication/DoStreamUnary",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"category": "generic",
-				"name":     "Custom/DoStreamUnary",
 				"parentId": internal.MatchAnything,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 		{
-			Intrinsics: map[string]interface{}{
-				"category":         "generic",
-				"name":             "WebTransaction/Go/TestApplication/DoStreamUnary",
-				"transaction.name": "WebTransaction/Go/TestApplication/DoStreamUnary",
-				"nr.entryPoint":    true,
-				"parentId":         internal.MatchAnything,
-				"trustedParentId":  internal.MatchAnything,
-			},
-			UserAttributes: map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{
+			Name:     "gRPC TestApplication/DoStreamUnary bufnet",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
+				"category":                    "generic",
+				"transaction.name":            "WebTransaction/Go/TestApplication/DoStreamUnary",
+				"nr.entryPoint":               true,
+				"parentId":                    internal.MatchAnything,
+				"trustedParentId":             internal.MatchAnything,
 				"httpResponseCode":            0,
 				"http.statusCode":             0,
 				"parent.account":              "123",
@@ -480,52 +463,47 @@ func TestStreamStreamServerInterceptor(t *testing.T) {
 		{Name: "WebTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "WebTransactionTotalTime/Go/TestApplication/DoStreamStream", Scope: "", Forced: false, Data: nil},
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"guid":                     internal.MatchAnything,
-			"name":                     "WebTransaction/Go/TestApplication/DoStreamStream",
-			"nr.apdexPerfZone":         internal.MatchAnything,
-			"parent.account":           123,
-			"parent.app":               456,
-			"parent.transportDuration": internal.MatchAnything,
-			"parent.transportType":     "HTTP",
-			"parent.type":              "App",
-			"parentId":                 internal.MatchAnything,
-			"parentSpanId":             internal.MatchAnything,
-			"priority":                 internal.MatchAnything,
-			"sampled":                  internal.MatchAnything,
-			"traceId":                  internal.MatchAnything,
-		},
-		UserAttributes: map[string]interface{}{},
-		AgentAttributes: map[string]interface{}{
-			"httpResponseCode":            0,
-			"http.statusCode":             0,
-			"request.headers.contentType": "application/grpc",
-			"request.method":              "TestApplication/DoStreamStream",
-			"request.uri":                 "grpc://bufnet/TestApplication/DoStreamStream",
-		},
-	}})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "DoStreamStream",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
+				"guid":                        internal.MatchAnything,
+				"nr.apdexPerfZone":            internal.MatchAnything,
+				"parent.account":              123,
+				"parent.app":                  456,
+				"parent.transportDuration":    internal.MatchAnything,
+				"parent.transportType":        "HTTP",
+				"parent.type":                 "App",
+				"parentId":                    internal.MatchAnything,
+				"parentSpanId":                internal.MatchAnything,
+				"priority":                    internal.MatchAnything,
+				"sampled":                     internal.MatchAnything,
+				"traceId":                     internal.MatchAnything,
+				"httpResponseCode":            0,
+				"http.statusCode":             0,
+				"request.headers.contentType": "application/grpc",
+				"request.method":              "TestApplication/DoStreamStream",
+				"request.uri":                 "grpc://bufnet/TestApplication/DoStreamStream",
+			},
+		},
+		{
+			Name:     "TestApplication/DoStreamStream",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"category": "generic",
-				"name":     "Custom/DoStreamStream",
 				"parentId": internal.MatchAnything,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 		{
-			Intrinsics: map[string]interface{}{
-				"category":         "generic",
-				"name":             "WebTransaction/Go/TestApplication/DoStreamStream",
-				"transaction.name": "WebTransaction/Go/TestApplication/DoStreamStream",
-				"nr.entryPoint":    true,
-				"parentId":         internal.MatchAnything,
-				"trustedParentId":  internal.MatchAnything,
-			},
-			UserAttributes: map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{
+			Name:     "gRPC TestApplication/DoStreamStream bufnet",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
+				"category":                    "generic",
+				"transaction.name":            "WebTransaction/Go/TestApplication/DoStreamStream",
+				"nr.entryPoint":               true,
+				"parentId":                    internal.MatchAnything,
+				"trustedParentId":             internal.MatchAnything,
 				"httpResponseCode":            0,
 				"http.statusCode":             0,
 				"parent.account":              "123",
@@ -574,17 +552,15 @@ func TestStreamServerInterceptorError(t *testing.T) {
 		{Name: "WebTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "WebTransactionTotalTime/Go/TestApplication/DoUnaryStreamError", Scope: "", Forced: false, Data: nil},
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"guid":             internal.MatchAnything,
-			"name":             "WebTransaction/Go/TestApplication/DoUnaryStreamError",
-			"nr.apdexPerfZone": internal.MatchAnything,
-			"priority":         internal.MatchAnything,
-			"sampled":          internal.MatchAnything,
-			"traceId":          internal.MatchAnything,
-		},
-		UserAttributes: map[string]interface{}{},
-		AgentAttributes: map[string]interface{}{
+	app.ExpectSpanEvents(t, []internal.WantSpan{{
+		Name:     "TestApplication/DoUnaryStreamError",
+		ParentID: internal.MatchNoParent,
+		Attributes: map[string]interface{}{
+			"guid":                        internal.MatchAnything,
+			"nr.apdexPerfZone":            internal.MatchAnything,
+			"priority":                    internal.MatchAnything,
+			"sampled":                     internal.MatchAnything,
+			"traceId":                     internal.MatchAnything,
 			"httpResponseCode":            15,
 			"http.statusCode":             15,
 			"request.headers.contentType": "application/grpc",

--- a/v4/integrations/nrhttprouter/nrhttprouter_test.go
+++ b/v4/integrations/nrhttprouter/nrhttprouter_test.go
@@ -97,16 +97,13 @@ func TestHandle(t *testing.T) {
 		IsWeb:     true,
 		NumErrors: 1,
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
-				"name":             "WebTransaction/Go/GET /hello/:name",
+			Name:     "GET /hello/:name",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"nr.apdexPerfZone": internal.MatchAnything,
-			},
-			UserAttributes: map[string]interface{}{
-				"color": "purple",
-			},
-			AgentAttributes: map[string]interface{}{
+				"color":            "purple",
 				"httpResponseCode": 500,
 				"http.statusCode":  500,
 				"request.method":   "GET",
@@ -141,16 +138,13 @@ func TestHandler(t *testing.T) {
 		IsWeb:     true,
 		NumErrors: 1,
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
-				"name":             "WebTransaction/Go/GET /hello/",
+			Name:     "GET /hello/",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"nr.apdexPerfZone": internal.MatchAnything,
-			},
-			UserAttributes: map[string]interface{}{
-				"color": "purple",
-			},
-			AgentAttributes: map[string]interface{}{
+				"color":            "purple",
 				"httpResponseCode": 500,
 				"http.statusCode":  500,
 				"request.method":   "GET",
@@ -228,16 +222,13 @@ func TestNotFound(t *testing.T) {
 		IsWeb:     true,
 		NumErrors: 1,
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
-				"name":             "WebTransaction/Go/NotFound",
+			Name:     "NotFound",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"nr.apdexPerfZone": internal.MatchAnything,
-			},
-			UserAttributes: map[string]interface{}{
-				"color": "purple",
-			},
-			AgentAttributes: map[string]interface{}{
+				"color":            "purple",
 				"httpResponseCode": 500,
 				"http.statusCode":  500,
 				"request.method":   "GET",

--- a/v4/integrations/nrmicro/nrmicro_test.go
+++ b/v4/integrations/nrmicro/nrmicro_test.go
@@ -188,27 +188,25 @@ func testClientCallWithTransaction(c client.Client, t *testing.T) {
 		{Name: "Supportability/TraceContext/Create/Success", Scope: "", Forced: true, Data: nil},
 		{Name: "Supportability/DistributedTrace/CreatePayload/Success", Scope: "", Forced: true, Data: nil},
 	})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "Micro TestHandler.Method testing",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
 				"category":  "http",
 				"component": "Micro",
-				"name":      "External/testing/Micro/TestHandler.Method",
 				"parentId":  internal.MatchAnything,
 				"span.kind": "client",
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "name",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"category":         "generic",
-				"name":             "OtherTransaction/Go/name",
 				"transaction.name": "OtherTransaction/Go/name",
 				"nr.entryPoint":    true,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 	})
 	app.ExpectTxnTraces(t, []internal.WantTxnTrace{{
@@ -344,25 +342,23 @@ func TestClientPublishWithTransaction(t *testing.T) {
 		{Name: "Supportability/DistributedTrace/CreatePayload/Success", Scope: "", Forced: true, Data: nil},
 		{Name: "Supportability/TraceContext/Create/Success", Scope: "", Forced: true, Data: nil},
 	})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "topic send",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
 				"category": "generic",
-				"name":     "MessageBroker/Micro/Topic/Produce/Named/topic",
 				"parentId": internal.MatchAnything,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "name",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"category":         "generic",
-				"name":             "OtherTransaction/Go/name",
 				"transaction.name": "OtherTransaction/Go/name",
 				"nr.entryPoint":    true,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 	})
 	app.ExpectTxnTraces(t, []internal.WantTxnTrace{{
@@ -510,27 +506,25 @@ func TestClientStreamWrapperWithTransaction(t *testing.T) {
 		{Name: "Supportability/DistributedTrace/CreatePayload/Success", Scope: "", Forced: true, Data: nil},
 		{Name: "Supportability/TraceContext/Create/Success", Scope: "", Forced: true, Data: nil},
 	})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "Micro TestHandler.StreamingMethod testing",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
 				"category":  "http",
 				"component": "Micro",
-				"name":      "External/testing/Micro/TestHandler.StreamingMethod",
 				"parentId":  internal.MatchAnything,
 				"span.kind": "client",
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "name",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"category":         "generic",
-				"name":             "OtherTransaction/Go/name",
 				"transaction.name": "OtherTransaction/Go/name",
 				"nr.entryPoint":    true,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 	})
 	app.ExpectTxnTraces(t, []internal.WantTxnTrace{{
@@ -595,27 +589,24 @@ func TestServerWrapperWithApp(t *testing.T) {
 		{Name: "Custom/Method", Scope: "", Forced: false, Data: nil},
 		{Name: "Custom/Method", Scope: "WebTransaction/Go/TestHandler.Method", Forced: false, Data: nil},
 	})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "Method",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
 				"category": "generic",
-				"name":     "Custom/Method",
 				"parentId": internal.MatchAnything,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 		{
-			Intrinsics: map[string]interface{}{
-				"category":         "generic",
-				"name":             "WebTransaction/Go/TestHandler.Method",
-				"transaction.name": "WebTransaction/Go/TestHandler.Method",
-				"nr.entryPoint":    true,
-				"parentId":         internal.MatchAnything,
-				"trustedParentId":  internal.MatchAnything,
-			},
-			UserAttributes: map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{
+			Name:     "TestHandler.Method",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
+				"category":                      "generic",
+				"transaction.name":              "WebTransaction/Go/TestHandler.Method",
+				"nr.entryPoint":                 true,
+				"parentId":                      internal.MatchAnything,
+				"trustedParentId":               internal.MatchAnything,
 				"parent.account":                "123",
 				"parent.app":                    "456",
 				"parent.transportDuration":      internal.MatchAnything,
@@ -627,6 +618,31 @@ func TestServerWrapperWithApp(t *testing.T) {
 				"request.headers.contentType":   "application/json",
 				"request.headers.contentLength": 3,
 				"httpResponseCode":              "200",
+				"http.statusCode":               200,
+			},
+		},
+		{
+			Name:     "Micro TestHandler.Method testing",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
+				"guid":                          internal.MatchAnything,
+				"priority":                      internal.MatchAnything,
+				"sampled":                       internal.MatchAnything,
+				"traceId":                       internal.MatchAnything,
+				"nr.apdexPerfZone":              "S",
+				"parent.account":                123,
+				"parent.transportType":          "HTTP",
+				"parent.app":                    456,
+				"parentId":                      internal.MatchAnything,
+				"parent.type":                   "App",
+				"parent.transportDuration":      internal.MatchAnything,
+				"parentSpanId":                  internal.MatchAnything,
+				"request.method":                "TestHandler.Method",
+				"request.uri":                   "micro://testing/TestHandler.Method",
+				"request.headers.accept":        "application/json",
+				"request.headers.contentType":   "application/json",
+				"request.headers.contentLength": 3,
+				"httpResponseCode":              200,
 				"http.statusCode":               200,
 			},
 		},
@@ -646,33 +662,6 @@ func TestServerWrapperWithApp(t *testing.T) {
 					},
 				},
 			}},
-		},
-	}})
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"name":                     "WebTransaction/Go/TestHandler.Method",
-			"guid":                     internal.MatchAnything,
-			"priority":                 internal.MatchAnything,
-			"sampled":                  internal.MatchAnything,
-			"traceId":                  internal.MatchAnything,
-			"nr.apdexPerfZone":         "S",
-			"parent.account":           123,
-			"parent.transportType":     "HTTP",
-			"parent.app":               456,
-			"parentId":                 internal.MatchAnything,
-			"parent.type":              "App",
-			"parent.transportDuration": internal.MatchAnything,
-			"parentSpanId":             internal.MatchAnything,
-		},
-		UserAttributes: map[string]interface{}{},
-		AgentAttributes: map[string]interface{}{
-			"request.method":                "TestHandler.Method",
-			"request.uri":                   "micro://testing/TestHandler.Method",
-			"request.headers.accept":        "application/json",
-			"request.headers.contentType":   "application/json",
-			"request.headers.contentLength": 3,
-			"httpResponseCode":              200,
-			"http.statusCode":               200,
 		},
 	}})
 }
@@ -703,16 +692,14 @@ func TestServerWrapperWithAppReturnsError(t *testing.T) {
 		{Name: "WebTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "Apdex", Scope: "", Forced: true, Data: nil},
 	})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
-				"category":         "generic",
-				"name":             "WebTransaction/Go/TestHandlerWithError.Method",
-				"transaction.name": "WebTransaction/Go/TestHandlerWithError.Method",
-				"nr.entryPoint":    true,
-			},
-			UserAttributes: map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{
+			Name:     "TestHandlerWithError.Method",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
+				"category":                         "generic",
+				"transaction.name":                 "WebTransaction/Go/TestHandlerWithError.Method",
+				"nr.entryPoint":                    true,
 				newrelic.SpanAttributeErrorClass:   "401",
 				newrelic.SpanAttributeErrorMessage: "Unauthorized",
 				"request.method":                   "TestHandlerWithError.Method",
@@ -737,17 +724,15 @@ func TestServerWrapperWithAppReturnsError(t *testing.T) {
 			}},
 		},
 	}})
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"name":             "WebTransaction/Go/TestHandlerWithError.Method",
-			"guid":             internal.MatchAnything,
-			"priority":         internal.MatchAnything,
-			"sampled":          internal.MatchAnything,
-			"traceId":          internal.MatchAnything,
-			"nr.apdexPerfZone": internal.MatchAnything,
-		},
-		UserAttributes: map[string]interface{}{},
-		AgentAttributes: map[string]interface{}{
+	app.ExpectSpanEvents(t, []internal.WantSpan{{
+		Name:     "TestHandlerWithError.Method",
+		ParentID: internal.MatchNoParent,
+		Attributes: map[string]interface{}{
+			"guid":                          internal.MatchAnything,
+			"priority":                      internal.MatchAnything,
+			"sampled":                       internal.MatchAnything,
+			"traceId":                       internal.MatchAnything,
+			"nr.apdexPerfZone":              internal.MatchAnything,
 			"request.method":                "TestHandlerWithError.Method",
 			"request.uri":                   "micro://testing/TestHandlerWithError.Method",
 			"request.headers.accept":        "application/json",
@@ -802,17 +787,15 @@ func TestServerWrapperWithAppReturnsNonMicroError(t *testing.T) {
 		{Name: "WebTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "Apdex", Scope: "", Forced: true, Data: nil},
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{{
-		Intrinsics: map[string]interface{}{
-			"name":             "WebTransaction/Go/TestHandlerWithNonMicroError.Method",
-			"guid":             internal.MatchAnything,
-			"priority":         internal.MatchAnything,
-			"sampled":          internal.MatchAnything,
-			"traceId":          internal.MatchAnything,
-			"nr.apdexPerfZone": internal.MatchAnything,
-		},
-		UserAttributes: map[string]interface{}{},
-		AgentAttributes: map[string]interface{}{
+	app.ExpectSpanEvents(t, []internal.WantSpan{{
+		Name:     "TestHandlerWithNonMicroError.Method",
+		ParentID: internal.MatchNoParent,
+		Attributes: map[string]interface{}{
+			"guid":                          internal.MatchAnything,
+			"priority":                      internal.MatchAnything,
+			"sampled":                       internal.MatchAnything,
+			"traceId":                       internal.MatchAnything,
+			"nr.apdexPerfZone":              internal.MatchAnything,
 			"request.method":                "TestHandlerWithNonMicroError.Method",
 			"request.uri":                   "micro://testing/TestHandlerWithNonMicroError.Method",
 			"request.headers.accept":        "application/json",
@@ -913,27 +896,25 @@ func TestServerSubscribe(t *testing.T) {
 		{Name: "DurationByCaller/App/123/456/HTTP/allOther", Scope: "", Forced: false, Data: nil},
 		{Name: "TransportDuration/App/123/456/HTTP/all", Scope: "", Forced: false, Data: nil},
 	})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "segment",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
 				"category": "generic",
 				"name":     "Custom/segment",
 				"parentId": internal.MatchAnything,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 		{
-			Intrinsics: map[string]interface{}{
-				"category":         "generic",
-				"name":             "OtherTransaction/Go/Message/Micro/Topic/Named/topic",
-				"transaction.name": "OtherTransaction/Go/Message/Micro/Topic/Named/topic",
-				"nr.entryPoint":    true,
-				"parentId":         internal.MatchAnything,
-				"trustedParentId":  internal.MatchAnything,
-			},
-			UserAttributes: map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{
+			Name:     "topic receive",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
+				"category":                 "generic",
+				"transaction.name":         "OtherTransaction/Go/Message/Micro/Topic/Named/topic",
+				"nr.entryPoint":            true,
+				"parentId":                 internal.MatchAnything,
+				"trustedParentId":          internal.MatchAnything,
 				"message.routingKey":       "topic",
 				"parent.account":           "123",
 				"parent.app":               "456",
@@ -942,12 +923,11 @@ func TestServerSubscribe(t *testing.T) {
 				"parent.type":              "App",
 			},
 		},
-	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "topic send",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
 				"guid":                     internal.MatchAnything,
-				"name":                     "OtherTransaction/Go/Message/Micro/Topic/Named/topic",
 				"parent.account":           123,
 				"parent.app":               456,
 				"parent.transportDuration": internal.MatchAnything,
@@ -958,11 +938,8 @@ func TestServerSubscribe(t *testing.T) {
 				"priority":                 internal.MatchAnything,
 				"sampled":                  internal.MatchAnything,
 				"traceId":                  internal.MatchAnything,
+				"message.routingKey":       "topic",
 			},
-			AgentAttributes: map[string]interface{}{
-				"message.routingKey": "topic",
-			},
-			UserAttributes: map[string]interface{}{},
 		},
 	})
 	app.ExpectTxnTraces(t, []internal.WantTxnTrace{{
@@ -1021,16 +998,15 @@ func TestServerSubscribeWithError(t *testing.T) {
 		{Name: "ErrorsByCaller/Unknown/Unknown/Unknown/HTTP/allOther", Scope: "", Forced: false, Data: nil},
 		{Name: "Errors/OtherTransaction/Go/Message/Micro/Topic/Named/topic", Scope: "", Forced: true, Data: nil},
 	})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
-				"category":         "generic",
-				"name":             "OtherTransaction/Go/Message/Micro/Topic/Named/topic",
-				"transaction.name": "OtherTransaction/Go/Message/Micro/Topic/Named/topic",
-				"nr.entryPoint":    true,
-			},
-			UserAttributes: map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{
+			Name:     "topic receive",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
+				"category":                         "generic",
+				"name":                             "OtherTransaction/Go/Message/Micro/Topic/Named/topic",
+				"transaction.name":                 "OtherTransaction/Go/Message/Micro/Topic/Named/topic",
+				"nr.entryPoint":                    true,
 				newrelic.SpanAttributeErrorClass:   "*errors.errorString",
 				newrelic.SpanAttributeErrorMessage: "subscriber error",
 				"message.routingKey":               "topic",

--- a/v4/integrations/nrmongo/nrmongo_test.go
+++ b/v4/integrations/nrmongo/nrmongo_test.go
@@ -148,18 +148,16 @@ func TestMonitor(t *testing.T) {
 		{Name: "Datastore/statement/MongoDB/collName/commName", Scope: "", Forced: false, Data: []float64{1.0}},
 		{Name: "Datastore/statement/MongoDB/collName/commName", Scope: "OtherTransaction/Go/txnName", Forced: false, Data: []float64{1.0}},
 	})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
-				"name":      "Datastore/statement/MongoDB/collName/commName",
-				"sampled":   true,
-				"category":  "datastore",
-				"component": "MongoDB",
-				"span.kind": "client",
-				"parentId":  internal.MatchAnything,
-			},
-			UserAttributes: map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{
+			Name:     "'commName' on 'collName' using 'MongoDB'",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
+				"sampled":       true,
+				"category":      "datastore",
+				"component":     "MongoDB",
+				"span.kind":     "client",
+				"parentId":      internal.MatchAnything,
 				"peer.address":  thisHost + ":27017",
 				"peer.hostname": thisHost,
 				"db.statement":  "'commName' on 'collName' using 'MongoDB'",
@@ -168,15 +166,14 @@ func TestMonitor(t *testing.T) {
 			},
 		},
 		{
-			Intrinsics: map[string]interface{}{
-				"name":             "OtherTransaction/Go/txnName",
+			Name:     "txnName",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"transaction.name": "OtherTransaction/Go/txnName",
 				"sampled":          true,
 				"category":         "generic",
 				"nr.entryPoint":    true,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 	})
 

--- a/v4/integrations/nrnats/test/nrnats_test.go
+++ b/v4/integrations/nrnats/test/nrnats_test.go
@@ -88,25 +88,23 @@ func TestStartPublishSegmentBasic(t *testing.T) {
 		{Name: "OtherTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransactionTotalTime/Go/testing", Scope: "", Forced: false, Data: nil},
 	})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "mysubject send",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
 				"category": "generic",
-				"name":     "MessageBroker/NATS/Topic/Produce/Named/mysubject",
 				"parentId": internal.MatchAnything,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 		{
-			Intrinsics: map[string]interface{}{
+			Name:     "testing",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"category":         "generic",
-				"name":             "OtherTransaction/Go/testing",
 				"transaction.name": "OtherTransaction/Go/testing",
 				"nr.entryPoint":    true,
 			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{},
 		},
 	})
 	app.ExpectTxnTraces(t, []internal.WantTxnTrace{{
@@ -163,21 +161,19 @@ func TestSubWrapper(t *testing.T) {
 		{Name: "OtherTransaction/Go/Message/NATS/Topic/Named/subject2", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransactionTotalTime/Go/Message/NATS/Topic/Named/subject2", Scope: "", Forced: false, Data: nil},
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
-				"name":     "OtherTransaction/Go/Message/NATS/Topic/Named/subject2",
-				"guid":     internal.MatchAnything,
-				"priority": internal.MatchAnything,
-				"sampled":  internal.MatchAnything,
-				"traceId":  internal.MatchAnything,
-			},
-			AgentAttributes: map[string]interface{}{
+			Name:     "subject2 receive",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
+				"guid":               internal.MatchAnything,
+				"priority":           internal.MatchAnything,
+				"sampled":            internal.MatchAnything,
+				"traceId":            internal.MatchAnything,
 				"message.replyTo":    internal.MatchAnything, // starts with _INBOX
 				"message.routingKey": "subject2",
 				"message.queueName":  "queue1",
 			},
-			UserAttributes: map[string]interface{}{},
 		},
 	})
 }

--- a/v4/integrations/nrstan/test/nrstan_test.go
+++ b/v4/integrations/nrstan/test/nrstan_test.go
@@ -85,19 +85,17 @@ func TestSubWrapper(t *testing.T) {
 		{Name: "OtherTransaction/Go/Message/STAN/Topic/Named/sample.subject2", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransactionTotalTime/Go/Message/STAN/Topic/Named/sample.subject2", Scope: "", Forced: false, Data: nil},
 	})
-	app.ExpectTxnEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Intrinsics: map[string]interface{}{
-				"name":     "OtherTransaction/Go/Message/STAN/Topic/Named/sample.subject2",
-				"guid":     internal.MatchAnything,
-				"priority": internal.MatchAnything,
-				"sampled":  internal.MatchAnything,
-				"traceId":  internal.MatchAnything,
-			},
-			AgentAttributes: map[string]interface{}{
+			Name:     "sample.subject2 receive",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
+				"guid":               internal.MatchAnything,
+				"priority":           internal.MatchAnything,
+				"sampled":            internal.MatchAnything,
+				"traceId":            internal.MatchAnything,
 				"message.routingKey": "sample.subject2",
 			},
-			UserAttributes: map[string]interface{}{},
 		},
 	})
 }

--- a/v4/internal/expect.go
+++ b/v4/internal/expect.go
@@ -6,6 +6,8 @@ package internal
 // Validator is used for testing.
 type Validator interface {
 	Error(...interface{})
+	Errorf(string, ...interface{})
+	Helper()
 }
 
 // WantMetric is a metric expectation.  If Data is nil, then any data values are
@@ -34,8 +36,12 @@ func uniquePointer() *struct{} {
 var (
 	// MatchAnything is for use when matching attributes.
 	MatchAnything = uniquePointer()
-	// MatchAnyString is a placeholder for matching any string
-	MatchAnyString = "xxANY-STRINGxx"
+	// MatchNoParent is for use when matching ParentID on spans.  It only
+	// matches for spans with no parent.
+	MatchNoParent = "0000000000000000"
+	// MatchAnyParent is for use when matching ParentID on spans.  It matches
+	// any ParentID value except for the no parent value.
+	MatchAnyParent = "💜💜xxANY-PARENTxx💜💜"
 )
 
 // WantEvent is a transaction or error event expectation.
@@ -91,21 +97,25 @@ type WantTxn struct {
 	NumErrors int
 }
 
+// WantSpan is a span or transaction expectation.
+type WantSpan struct {
+	Name       string
+	SpanID     string
+	TraceID    string
+	ParentID   string
+	Attributes map[string]interface{}
+}
+
 // Expect exposes methods that allow for testing whether the correct data was
 // captured.
 type Expect interface {
 	ExpectCustomEvents(t Validator, want []WantEvent)
 	ExpectErrors(t Validator, want []WantError)
 	ExpectErrorEvents(t Validator, want []WantEvent)
-
-	ExpectTxnEvents(t Validator, want []WantEvent)
-
 	ExpectMetrics(t Validator, want []WantMetric)
 	ExpectMetricsPresent(t Validator, want []WantMetric)
 	ExpectTxnMetrics(t Validator, want WantTxn)
-
 	ExpectTxnTraces(t Validator, want []WantTxnTrace)
 	ExpectSlowQueries(t Validator, want []WantSlowQuery)
-
-	ExpectSpanEvents(t Validator, want []WantEvent)
+	ExpectSpanEvents(t Validator, want []WantSpan)
 }

--- a/v4/internal/integrationsupport/integrationsupport.go
+++ b/v4/internal/integrationsupport/integrationsupport.go
@@ -38,8 +38,9 @@ func ConfigFullTraces(cfg *newrelic.Config) {
 
 // NewTestApp creates an ExpectApp with the given ConnectReply function and Config function
 func NewTestApp(cfgFn ...newrelic.ConfigOption) ExpectApp {
-	tr := testtrace.NewProvider().Tracer("go-agent-test")
+	sr := new(testtrace.StandardSpanRecorder)
 	cfgFn = append(cfgFn, func(cfg *newrelic.Config) {
+		tr := testtrace.NewProvider(testtrace.WithSpanRecorder(sr)).Tracer("go-agent-test")
 		cfg.OpenTelemetry.Tracer = tr
 	})
 
@@ -50,7 +51,7 @@ func NewTestApp(cfgFn ...newrelic.ConfigOption) ExpectApp {
 
 	return ExpectApp{
 		Expect: &internal.OpenTelemetryExpect{
-			Tracer: tr.(*testtrace.Tracer),
+			Spans: sr,
 		},
 		Application: app,
 	}

--- a/v4/internal/integrationsupport/integrationsupport_test.go
+++ b/v4/internal/integrationsupport/integrationsupport_test.go
@@ -34,32 +34,23 @@ func TestSuccess(t *testing.T) {
 	segment.End()
 	txn.End()
 
-	app.ExpectTxnEvents(t, []internal.WantEvent{
+	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			AgentAttributes: map[string]interface{}{
-				newrelic.AttributeHostDisplayName: "hostname",
-			},
-		},
-	})
-	app.ExpectSpanEvents(t, []internal.WantEvent{
-		{
-			Intrinsics: map[string]interface{}{
-				"name":     "Custom/mySegment",
-				"parentId": internal.MatchAnything,
-				"category": "generic",
-			},
-			AgentAttributes: map[string]interface{}{
+			Name:     "mySegment",
+			ParentID: internal.MatchAnyParent,
+			Attributes: map[string]interface{}{
+				"parentId":                         internal.MatchAnything,
+				"category":                         "generic",
 				newrelic.SpanAttributeAWSOperation: "operation",
 			},
 		},
 		{
-			Intrinsics: map[string]interface{}{
-				"name":             "OtherTransaction/Go/hello",
+			Name:     "hello",
+			ParentID: internal.MatchNoParent,
+			Attributes: map[string]interface{}{
 				"transaction.name": "OtherTransaction/Go/hello",
 				"category":         "generic",
 				"nr.entryPoint":    true,
-			},
-			AgentAttributes: map[string]interface{}{
 				"host.displayName": "hostname",
 			},
 		},

--- a/v4/internal/otel_expect.go
+++ b/v4/internal/otel_expect.go
@@ -6,14 +6,62 @@ import (
 
 // OpenTelemetryExpect implements internal.Expect for use in testing.
 type OpenTelemetryExpect struct {
-	*testtrace.Tracer
+	Spans *testtrace.StandardSpanRecorder
 }
 
-// ExpectTxnEvents TODO
-func (e *OpenTelemetryExpect) ExpectTxnEvents(t Validator, want []WantEvent) {}
+func expectSpan(t Validator, want WantSpan, span *testtrace.Span) {
+	t.Helper()
+	name := span.Name()
+	if want.Name != "" {
+		if name != want.Name {
+			t.Errorf("Incorrect span name:\n\texpect=%s actual=%s",
+				want.Name, name)
+		}
+	}
+	spanCtx := span.SpanContext()
+	if want.SpanID != "" {
+		if id := spanCtx.SpanID.String(); id != want.SpanID {
+			t.Errorf("Incorrect id for span '%s':\n\texpect=%s actual=%s",
+				name, want.SpanID, id)
+		}
+	}
+	if want.TraceID != "" {
+		if id := spanCtx.TraceID.String(); id != want.TraceID {
+			t.Errorf("Incorrect trace id for span '%s':\n\texpect=%s actual=%s",
+				name, want.TraceID, id)
+		}
+	}
+	if want.ParentID != "" {
+		id := span.ParentSpanID().String()
+		if want.ParentID == MatchAnyParent {
+			if id == MatchNoParent {
+				t.Errorf("Incorrect parent id for span '%s': expected a parent but found none",
+					name)
+			}
+		} else if id != want.ParentID {
+			t.Errorf("Incorrect parent id for span '%s':\n\texpect=%s actual=%s",
+				name, want.ParentID, id)
+		}
+	}
+}
+
+func (e *OpenTelemetryExpect) spans() []*testtrace.Span {
+	return e.Spans.Completed()
+}
 
 // ExpectSpanEvents TODO
-func (e *OpenTelemetryExpect) ExpectSpanEvents(t Validator, want []WantEvent) {}
+func (e *OpenTelemetryExpect) ExpectSpanEvents(t Validator, want []WantSpan) {
+	t.Helper()
+	spans := e.spans()
+	if len(want) != len(spans) {
+		t.Errorf("Incorrect number of recorded spans: expect=%d actual=%d",
+			len(want), len(spans))
+		return
+	}
+	for i := 0; i < len(want); i++ {
+		expectSpan(t, want[i], spans[i])
+	}
+}
 
 // ExpectCustomEvents TODO
 func (e *OpenTelemetryExpect) ExpectCustomEvents(t Validator, want []WantEvent) {}


### PR DESCRIPTION
This pull request implements `ExpectSpanEvents` for use when testing integration packages. It also removes `ExpectTxnEvents` because those are essentially just span events anyway, so the APIs have been combined.

I'd love your feedback on the use of all the `internal.Match*` fields. I'd like your thoughts on what the best user experience of these would be.