### PR TITLE
Implement ExpectTxnMetrics.

### DIFF
--- a/v4/internal/otel_expect.go
+++ b/v4/internal/otel_expect.go
@@ -79,7 +79,18 @@ func (e *OpenTelemetryExpect) ExpectMetrics(t Validator, want []WantMetric) {}
 func (e *OpenTelemetryExpect) ExpectMetricsPresent(t Validator, want []WantMetric) {}
 
 // ExpectTxnMetrics TODO
-func (e *OpenTelemetryExpect) ExpectTxnMetrics(t Validator, want WantTxn) {}
+func (e *OpenTelemetryExpect) ExpectTxnMetrics(t Validator, want WantTxn) {
+	t.Helper()
+	spans := e.spans()
+	if len(spans) == 0 {
+		t.Error("No spans recorded")
+		return
+	}
+	expectSpan(t, WantSpan{
+		Name:     want.Name,
+		ParentID: MatchNoParent,
+	}, spans[0])
+}
 
 // ExpectTxnTraces TODO
 func (e *OpenTelemetryExpect) ExpectTxnTraces(t Validator, want []WantTxnTrace) {}


### PR DESCRIPTION
This pull request implements `ExpectTxnMetrics`. We will not be implementing any metrics during this current project. However, there is still information that we can infer from the usage of this expecter. We know that there will be a root span with the given name that has no span parent. In the future when we implement span kind, we can use the `IsWeb` field to determine the span kind of the root span.