### PR TITLE
Fix all integrations imports for v4.

### DIFF
--- a/build-script.sh
+++ b/build-script.sh
@@ -33,7 +33,7 @@ for dir in $DIRS; do
   if [ $dir == "." ]; then
     rm -rf v3/
     rm -rf v4/
-  elif [[ $dir =~ "v3" ]]; then
+  elif [[ $dir =~ "v3/" ]]; then
     # for integrations test with the local agent instead of downloading
     if [ -f "go.mod" ]; then
       go mod edit -replace github.com/newrelic/go-agent/v3=$pwd/v3

--- a/v4/integrations/nrecho-v3/README.md
+++ b/v4/integrations/nrecho-v3/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrecho-v3 [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrecho-v3?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrecho-v3)
+# v4/integrations/nrecho-v3 [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrecho-v3?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrecho-v3)
 
 Package `nrecho` instruments applications using https://github.com/labstack/echo v3.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrecho-v3"
+import "github.com/newrelic/go-agent/v4/integrations/nrecho-v3"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrecho-v3).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrecho-v3).

--- a/v4/integrations/nrecho-v3/example/main.go
+++ b/v4/integrations/nrecho-v3/example/main.go
@@ -9,8 +9,8 @@ import (
 	"os"
 
 	"github.com/labstack/echo"
-	"github.com/newrelic/go-agent/v3/integrations/nrecho-v3"
-	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrecho-v3"
+	"github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func getUser(c echo.Context) error {

--- a/v4/integrations/nrecho-v3/go.mod
+++ b/v4/integrations/nrecho-v3/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/nrecho-v3
+module github.com/newrelic/go-agent/v4/integrations/nrecho-v3
 
 // 1.7 is the earliest version of Go tested by v3.1.0:
 // https://github.com/labstack/echo/blob/v3.1.0/.travis.yml
@@ -9,6 +9,6 @@ require (
 	// to the github.com/rsc/letsencrypt import of v3.0.0.
 	github.com/labstack/echo v3.1.0+incompatible
 	github.com/labstack/gommon v0.3.0 // indirect
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 	golang.org/x/crypto v0.0.0-20191119213627-4f8c1d86b1ba // indirect
 )

--- a/v4/integrations/nrecho-v3/nrecho.go
+++ b/v4/integrations/nrecho-v3/nrecho.go
@@ -11,7 +11,7 @@
 //	// Add the nrecho middleware before other middlewares or routes:
 //	e.Use(nrecho.Middleware(app))
 //
-// Example: https://github.com/newrelic/go-agent/tree/master/v3/integrations/nrecho-v3/example/main.go
+// Example: https://github.com/newrelic/go-agent/tree/master/v4/integrations/nrecho-v3/example/main.go
 package nrecho
 
 import (
@@ -19,8 +19,8 @@ import (
 	"reflect"
 
 	"github.com/labstack/echo"
-	"github.com/newrelic/go-agent/v3/internal"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func init() { internal.TrackUsage("integration", "framework", "echo") }

--- a/v4/integrations/nrecho-v3/nrecho_test.go
+++ b/v4/integrations/nrecho-v3/nrecho_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/labstack/echo"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
 )
 
 func TestBasicRoute(t *testing.T) {

--- a/v4/integrations/nrecho-v4/README.md
+++ b/v4/integrations/nrecho-v4/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrecho-v4 [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrecho-v4?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrecho-v4)
+# v4/integrations/nrecho-v4 [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrecho-v4?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrecho-v4)
 
 Package `nrecho` instruments applications using  https://github.com/labstack/echo v4.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrecho-v4"
+import "github.com/newrelic/go-agent/v4/integrations/nrecho-v4"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrecho-v4).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrecho-v4).

--- a/v4/integrations/nrelasticsearch-v7/README.md
+++ b/v4/integrations/nrelasticsearch-v7/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrelasticsearch-v7 [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrelasticsearch-v7?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrelasticsearch-v7)
+# v4/integrations/nrelasticsearch-v7 [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrelasticsearch-v7?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrelasticsearch-v7)
 
 Package `nrelasticsearch` instruments `"github.com/elastic/go-elasticsearch/v7"`.
 
 ```go
-import nrelasticsearch "github.com/newrelic/go-agent/v3/integrations/nrelasticsearch-v7"
+import nrelasticsearch "github.com/newrelic/go-agent/v4/integrations/nrelasticsearch-v7"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrelasticsearch-v7).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrelasticsearch-v7).

--- a/v4/integrations/nrelasticsearch-v7/example/main.go
+++ b/v4/integrations/nrelasticsearch-v7/example/main.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	elasticsearch "github.com/elastic/go-elasticsearch/v7"
-	nrelasticsearch "github.com/newrelic/go-agent/v3/integrations/nrelasticsearch-v7"
-	"github.com/newrelic/go-agent/v3/newrelic"
+	nrelasticsearch "github.com/newrelic/go-agent/v4/integrations/nrelasticsearch-v7"
+	"github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func main() {

--- a/v4/integrations/nrelasticsearch-v7/example_test.go
+++ b/v4/integrations/nrelasticsearch-v7/example_test.go
@@ -7,8 +7,8 @@ import (
 	"context"
 
 	elasticsearch "github.com/elastic/go-elasticsearch/v7"
-	nrelasticsearch "github.com/newrelic/go-agent/v3/integrations/nrelasticsearch-v7"
-	"github.com/newrelic/go-agent/v3/newrelic"
+	nrelasticsearch "github.com/newrelic/go-agent/v4/integrations/nrelasticsearch-v7"
+	"github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func getTransaction() *newrelic.Transaction { return nil }

--- a/v4/integrations/nrelasticsearch-v7/go.mod
+++ b/v4/integrations/nrelasticsearch-v7/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/nrelasticsearch-v7
+module github.com/newrelic/go-agent/v4/integrations/nrelasticsearch-v7
 
 // As of Jan 2020, the v7 elasticsearch go.mod uses 1.11:
 // https://github.com/elastic/go-elasticsearch/blob/7.x/go.mod
@@ -6,5 +6,5 @@ go 1.11
 
 require (
 	github.com/elastic/go-elasticsearch/v7 v7.5.0
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 )

--- a/v4/integrations/nrelasticsearch-v7/nrelastic.go
+++ b/v4/integrations/nrelasticsearch-v7/nrelastic.go
@@ -11,8 +11,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/newrelic/go-agent/v3/internal"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func init() { internal.TrackUsage("integration", "datastore", "elasticsearch") }

--- a/v4/integrations/nrelasticsearch-v7/nrelastic_test.go
+++ b/v4/integrations/nrelasticsearch-v7/nrelastic_test.go
@@ -13,9 +13,9 @@ import (
 
 	elasticsearch "github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func TestParseRequest(t *testing.T) {

--- a/v4/integrations/nrgin/README.md
+++ b/v4/integrations/nrgin/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrgin [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgin?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgin)
+# v4/integrations/nrgin [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrgin?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrgin)
 
 Package `nrgin` instruments https://github.com/gin-gonic/gin applications.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrgin"
+import "github.com/newrelic/go-agent/v4/integrations/nrgin"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgin).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrgin).

--- a/v4/integrations/nrgin/example/main.go
+++ b/v4/integrations/nrgin/example/main.go
@@ -8,8 +8,8 @@ import (
 	"os"
 
 	"github.com/gin-gonic/gin"
-	nrgin "github.com/newrelic/go-agent/v3/integrations/nrgin"
-	"github.com/newrelic/go-agent/v3/newrelic"
+	nrgin "github.com/newrelic/go-agent/v4/integrations/nrgin"
+	"github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func makeGinEndpoint(s string) func(*gin.Context) {

--- a/v4/integrations/nrgin/go.mod
+++ b/v4/integrations/nrgin/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/nrgin
+module github.com/newrelic/go-agent/v4/integrations/nrgin
 
 // As of Dec 2019, the gin go.mod file uses 1.12:
 // https://github.com/gin-gonic/gin/blob/master/go.mod
@@ -6,5 +6,5 @@ go 1.12
 
 require (
 	github.com/gin-gonic/gin v1.4.0
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 )

--- a/v4/integrations/nrgin/go.mod
+++ b/v4/integrations/nrgin/go.mod
@@ -5,6 +5,6 @@ module github.com/newrelic/go-agent/v4/integrations/nrgin
 go 1.12
 
 require (
-	github.com/gin-gonic/gin v1.4.0
+	github.com/gin-gonic/gin v1.5.0
 	github.com/newrelic/go-agent/v4 v4.0.0
 )

--- a/v4/integrations/nrgin/nrgin.go
+++ b/v4/integrations/nrgin/nrgin.go
@@ -11,15 +11,15 @@
 //	// Add the nrgin middleware before other middlewares or routes:
 //	router.Use(nrgin.Middleware(app))
 //
-// Example: https://github.com/newrelic/go-agent/tree/master/v3/integrations/nrgin/example/main.go
+// Example: https://github.com/newrelic/go-agent/tree/master/v4/integrations/nrgin/example/main.go
 package nrgin
 
 import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/newrelic/go-agent/v3/internal"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func init() { internal.TrackUsage("integration", "framework", "gin", "v1") }

--- a/v4/integrations/nrgin/nrgin_context_test.go
+++ b/v4/integrations/nrgin/nrgin_context_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func accessTransactionContextContext(c *gin.Context) {

--- a/v4/integrations/nrgin/nrgin_test.go
+++ b/v4/integrations/nrgin/nrgin_test.go
@@ -11,13 +11,13 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
-	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
+	"github.com/newrelic/go-agent/v4/newrelic"
 )
 
 var (
-	pkg = "github.com/newrelic/go-agent/v3/integrations/nrgin"
+	pkg = "github.com/newrelic/go-agent/v4/integrations/nrgin"
 )
 
 func hello(c *gin.Context) {

--- a/v4/integrations/nrgorilla/README.md
+++ b/v4/integrations/nrgorilla/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrgorilla [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgorilla?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgorilla)
+# v4/integrations/nrgorilla [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrgorilla?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrgorilla)
 
 Package `nrgorilla` instruments https://github.com/gorilla/mux applications.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrgorilla"
+import "github.com/newrelic/go-agent/v4/integrations/nrgorilla"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgorilla).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrgorilla).

--- a/v4/integrations/nrgorilla/example/main.go
+++ b/v4/integrations/nrgorilla/example/main.go
@@ -9,8 +9,8 @@ import (
 	"os"
 
 	"github.com/gorilla/mux"
-	"github.com/newrelic/go-agent/v3/integrations/nrgorilla"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrgorilla"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func makeHandler(text string) http.Handler {

--- a/v4/integrations/nrgorilla/example_test.go
+++ b/v4/integrations/nrgorilla/example_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	"github.com/newrelic/go-agent/v3/integrations/nrgorilla"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrgorilla"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 var (

--- a/v4/integrations/nrgorilla/go.mod
+++ b/v4/integrations/nrgorilla/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/nrgorilla
+module github.com/newrelic/go-agent/v4/integrations/nrgorilla
 
 // As of Dec 2019, the gorilla/mux go.mod file uses 1.12:
 // https://github.com/gorilla/mux/blob/master/go.mod
@@ -7,5 +7,5 @@ go 1.12
 require (
 	// v1.7.0 is the earliest version of Gorilla using modules.
 	github.com/gorilla/mux v1.7.0
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 )

--- a/v4/integrations/nrgorilla/nrgorilla.go
+++ b/v4/integrations/nrgorilla/nrgorilla.go
@@ -8,15 +8,15 @@
 // with your router.
 //
 // Complete example:
-// https://github.com/newrelic/go-agent/tree/master/v3/integrations/nrgorilla/example/main.go
+// https://github.com/newrelic/go-agent/tree/master/v4/integrations/nrgorilla/example/main.go
 package nrgorilla
 
 import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	"github.com/newrelic/go-agent/v3/internal"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func init() { internal.TrackUsage("integration", "framework", "gorilla", "v1") }
@@ -91,7 +91,7 @@ func InstrumentRoutes(r *mux.Router, app *newrelic.Application) *mux.Router {
 // Note that mux.MiddlewareFuncs are not called for the NotFoundHandler or
 // MethodNotAllowedHandler.  To instrument these handlers, use
 // newrelic.WrapHandle
-// (https://godoc.org/github.com/newrelic/go-agent/v3/newrelic#WrapHandle).
+// (https://godoc.org/github.com/newrelic/go-agent/v4/newrelic#WrapHandle).
 //
 // Note that if you are moving from the now deprecated InstrumentRoutes to this
 // Middleware, the reported time of your transactions may increase.  This is

--- a/v4/integrations/nrgorilla/nrgorilla_test.go
+++ b/v4/integrations/nrgorilla/nrgorilla_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func makeHandler(text string) http.Handler {

--- a/v4/integrations/nrgraphgophers/README.md
+++ b/v4/integrations/nrgraphgophers/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrgraphgophers [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgraphgophers?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgraphgophers)
+# v4/integrations/nrgraphgophers [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrgraphgophers?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrgraphgophers)
 
 Package `nrgraphgophers` instruments https://github.com/graph-gophers/graphql-go applications.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrgraphgophers"
+import "github.com/newrelic/go-agent/v4/integrations/nrgraphgophers"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgraphgophers).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrgraphgophers).

--- a/v4/integrations/nrgraphgophers/example/main.go
+++ b/v4/integrations/nrgraphgophers/example/main.go
@@ -10,8 +10,8 @@ import (
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
-	"github.com/newrelic/go-agent/v3/integrations/nrgraphgophers"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrgraphgophers"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 type query struct{}

--- a/v4/integrations/nrgraphgophers/go.mod
+++ b/v4/integrations/nrgraphgophers/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/nrgraphgophers
+module github.com/newrelic/go-agent/v4/integrations/nrgraphgophers
 
 // As of Jan 2020, the graphql-go go.mod file uses 1.13:
 // https://github.com/graph-gophers/graphql-go/blob/master/go.mod
@@ -7,5 +7,5 @@ go 1.13
 require (
 	// graphql-go has no tagged releases as of Jan 2020.
 	github.com/graph-gophers/graphql-go v0.0.0-20200207002730-8334863f2c8b
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 )

--- a/v4/integrations/nrgraphgophers/nrgraphgophers.go
+++ b/v4/integrations/nrgraphgophers/nrgraphgophers.go
@@ -15,8 +15,8 @@ import (
 	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/introspection"
 	"github.com/graph-gophers/graphql-go/trace"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func init() { internal.TrackUsage("integration", "framework", "graph-gophers") }

--- a/v4/integrations/nrgraphgophers/nrgraphgophers_example_test.go
+++ b/v4/integrations/nrgraphgophers/nrgraphgophers_example_test.go
@@ -10,8 +10,8 @@ import (
 
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
-	"github.com/newrelic/go-agent/v3/integrations/nrgraphgophers"
-	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrgraphgophers"
+	"github.com/newrelic/go-agent/v4/newrelic"
 )
 
 type query struct{}

--- a/v4/integrations/nrgraphgophers/nrgraphgophers_test.go
+++ b/v4/integrations/nrgraphgophers/nrgraphgophers_test.go
@@ -14,9 +14,9 @@ import (
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/introspection"
 	"github.com/graph-gophers/graphql-go/relay"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
-	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
+	"github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func TestFieldManagementSync(t *testing.T) {

--- a/v4/integrations/nrgraphqlgo/README.md
+++ b/v4/integrations/nrgraphqlgo/README.md
@@ -1,9 +1,9 @@
-# v3/integrations/nrgraphqlgo [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgraphqlgo?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgraphqlgo)
+# v4/integrations/nrgraphqlgo [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrgraphqlgo?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrgraphqlgo)
 
 Package `nrgraphql` instruments https://github.com/graphql-go/graphql applications.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrgraphqlgo"
+import "github.com/newrelic/go-agent/v4/integrations/nrgraphqlgo"
 ```
 
 Note that New Relic has support for more than one GraphQL framework, and both
@@ -11,4 +11,4 @@ packages are named `nrgraphql`, so please ensure you are using the
 integration for the correct framework.
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgraphqlgo).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrgraphqlgo).

--- a/v4/integrations/nrgrpc/README.md
+++ b/v4/integrations/nrgrpc/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrgrpc [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgrpc?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgrpc)
+# v4/integrations/nrgrpc [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrgrpc?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrgrpc)
 
 Package `nrgrpc` instruments https://github.com/grpc/grpc-go.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrgrpc"
+import "github.com/newrelic/go-agent/v4/integrations/nrgrpc"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgrpc).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrgrpc).

--- a/v4/integrations/nrgrpc/go.mod
+++ b/v4/integrations/nrgrpc/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/nrgrpc
+module github.com/newrelic/go-agent/v4/integrations/nrgrpc
 
 // As of Dec 2019, the grpc go.mod file uses 1.11:
 // https://github.com/grpc/grpc-go/blob/master/go.mod
@@ -8,7 +8,7 @@ require (
 	// protobuf v1.3.0 is the earliest version using modules, we use v1.3.1
 	// because all dependencies were removed in this version.
 	github.com/golang/protobuf v1.3.1
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 	// v1.15.0 is the earliest version of grpc using modules.
 	google.golang.org/grpc v1.15.0
 )

--- a/v4/integrations/nrgrpc/nrgrpc_client.go
+++ b/v4/integrations/nrgrpc/nrgrpc_client.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"strings"
 
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -79,7 +79,7 @@ func startClientSegment(ctx context.Context, method, target string) (*newrelic.E
 // which contains a newrelic.Transaction.
 //
 // Full example:
-// https://github.com/newrelic/go-agent/blob/master/v3/integrations/nrgrpc/example/client/client.go
+// https://github.com/newrelic/go-agent/blob/master/v4/integrations/nrgrpc/example/client/client.go
 //
 // This interceptor only instruments unary calls.  You must use both
 // UnaryClientInterceptor and StreamClientInterceptor to instrument unary and
@@ -121,7 +121,7 @@ func (s wrappedClientStream) RecvMsg(m interface{}) error {
 // which contains a newrelic.Transaction.
 //
 // Full example:
-// https://github.com/newrelic/go-agent/blob/master/v3/integrations/nrgrpc/example/client/client.go
+// https://github.com/newrelic/go-agent/blob/master/v4/integrations/nrgrpc/example/client/client.go
 //
 // This interceptor only instruments streaming calls.  You must use both
 // UnaryClientInterceptor and StreamClientInterceptor to instrument unary and

--- a/v4/integrations/nrgrpc/nrgrpc_client_test.go
+++ b/v4/integrations/nrgrpc/nrgrpc_client_test.go
@@ -9,10 +9,10 @@ import (
 	"io"
 	"testing"
 
-	"github.com/newrelic/go-agent/v3/integrations/nrgrpc/testapp"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrgrpc/testapp"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 	"google.golang.org/grpc/metadata"
 )
 

--- a/v4/integrations/nrgrpc/nrgrpc_doc.go
+++ b/v4/integrations/nrgrpc/nrgrpc_doc.go
@@ -38,7 +38,7 @@
 // 	}
 //
 // Full server example:
-// https://github.com/newrelic/go-agent/blob/master/v3/integrations/nrgrpc/example/server/server.go
+// https://github.com/newrelic/go-agent/blob/master/v4/integrations/nrgrpc/example/server/server.go
 //
 // Client
 //
@@ -62,9 +62,9 @@
 //	msg, err := client.handler(ctx, &pb.Message{"Hello World"})
 //
 // Full client example:
-// https://github.com/newrelic/go-agent/blob/master/v3/integrations/nrgrpc/example/client/client.go
+// https://github.com/newrelic/go-agent/blob/master/v4/integrations/nrgrpc/example/client/client.go
 package nrgrpc
 
-import "github.com/newrelic/go-agent/v3/internal"
+import "github.com/newrelic/go-agent/v4/internal"
 
 func init() { internal.TrackUsage("integration", "framework", "grpc") }

--- a/v4/integrations/nrgrpc/nrgrpc_server.go
+++ b/v4/integrations/nrgrpc/nrgrpc_server.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/newrelic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -66,7 +66,7 @@ func startTransaction(ctx context.Context, app *newrelic.Application, fullMethod
 // accessed in your method handlers using newrelic.FromContext.
 //
 // Full example:
-// https://github.com/newrelic/go-agent/blob/master/v3/integrations/nrgrpc/example/server/server.go
+// https://github.com/newrelic/go-agent/blob/master/v4/integrations/nrgrpc/example/server/server.go
 //
 func UnaryServerInterceptor(app *newrelic.Application) grpc.UnaryServerInterceptor {
 	if nil == app {
@@ -127,7 +127,7 @@ func newWrappedServerStream(stream grpc.ServerStream, txn *newrelic.Transaction)
 // accessed in your method handlers using newrelic.FromContext.
 //
 // Full example:
-// https://github.com/newrelic/go-agent/blob/master/v3/integrations/nrgrpc/example/server/server.go
+// https://github.com/newrelic/go-agent/blob/master/v4/integrations/nrgrpc/example/server/server.go
 //
 func StreamServerInterceptor(app *newrelic.Application) grpc.StreamServerInterceptor {
 	if nil == app {

--- a/v4/integrations/nrgrpc/nrgrpc_server_test.go
+++ b/v4/integrations/nrgrpc/nrgrpc_server_test.go
@@ -13,9 +13,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 
-	"github.com/newrelic/go-agent/v3/integrations/nrgrpc/testapp"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrgrpc/testapp"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/newrelic"
 )
 
 // newTestServerAndConn creates a new *grpc.Server and *grpc.ClientConn for use

--- a/v4/integrations/nrgrpc/testapp/README.md
+++ b/v4/integrations/nrgrpc/testapp/README.md
@@ -2,7 +2,7 @@
 
 This directory contains a testing application for validating the New Relic gRPC
 integration.  The code in `testapp.pb.go` is generated using the following
-command (to be run from the `v3/integrations/nrgrpc` directory).  This command
+command (to be run from the `v4/integrations/nrgrpc` directory).  This command
 should be rerun every time the `testapp.proto` file has changed for any reason.
 
 ```bash

--- a/v4/integrations/nrgrpc/testapp/server.go
+++ b/v4/integrations/nrgrpc/testapp/server.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"io"
 
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 	codes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	status "google.golang.org/grpc/status"

--- a/v4/integrations/nrhttprouter/README.md
+++ b/v4/integrations/nrhttprouter/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrhttprouter [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrhttprouter?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrhttprouter)
+# v4/integrations/nrhttprouter [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrhttprouter?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrhttprouter)
 
 Package `nrhttprouter` instruments https://github.com/julienschmidt/httprouter applications.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrhttprouter"
+import "github.com/newrelic/go-agent/v4/integrations/nrhttprouter"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrhttprouter).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrhttprouter).

--- a/v4/integrations/nrhttprouter/example/main.go
+++ b/v4/integrations/nrhttprouter/example/main.go
@@ -9,8 +9,8 @@ import (
 	"os"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/newrelic/go-agent/v3/integrations/nrhttprouter"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrhttprouter"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {

--- a/v4/integrations/nrhttprouter/go.mod
+++ b/v4/integrations/nrhttprouter/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/nrhttprouter
+module github.com/newrelic/go-agent/v4/integrations/nrhttprouter
 
 // As of Dec 2019, the httprouter go.mod file uses 1.7:
 // https://github.com/julienschmidt/httprouter/blob/master/go.mod
@@ -7,5 +7,5 @@ go 1.7
 require (
 	// v1.3.0 is the earliest version of httprouter using modules.
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 )

--- a/v4/integrations/nrhttprouter/nrhttprouter.go
+++ b/v4/integrations/nrhttprouter/nrhttprouter.go
@@ -16,8 +16,8 @@
 //   	"os"
 //
 //   	"github.com/julienschmidt/httprouter"
-//   	newrelic "github.com/newrelic/go-agent/v3/newrelic"
-//   	"github.com/newrelic/go-agent/v3/integrations/nrhttprouter"
+//   	newrelic "github.com/newrelic/go-agent/v4/newrelic"
+//   	"github.com/newrelic/go-agent/v4/integrations/nrhttprouter"
 //   )
 //
 //   func main() {
@@ -36,15 +36,15 @@
 //   	http.ListenAndServe(":8000", router)
 //   }
 //
-// Runnable example: https://github.com/newrelic/go-agent/tree/master/v3/integrations/nrhttprouter/example/main.go
+// Runnable example: https://github.com/newrelic/go-agent/tree/master/v4/integrations/nrhttprouter/example/main.go
 package nrhttprouter
 
 import (
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/newrelic/go-agent/v3/internal"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func init() { internal.TrackUsage("integration", "framework", "httprouter") }

--- a/v4/integrations/nrhttprouter/nrhttprouter_test.go
+++ b/v4/integrations/nrhttprouter/nrhttprouter_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func TestMethodFunctions(t *testing.T) {

--- a/v4/integrations/nrlambda/README.md
+++ b/v4/integrations/nrlambda/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrlambda [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrlambda?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrlambda)
+# v4/integrations/nrlambda [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrlambda?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrlambda)
 
 Package `nrlambda` adds support for AWS Lambda.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrlambda"
+import "github.com/newrelic/go-agent/v4/integrations/nrlambda"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrlambda).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrlambda).

--- a/v4/integrations/nrlambda/config.go
+++ b/v4/integrations/nrlambda/config.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 // ConfigOption populates a newrelic.Config with correct default settings for a

--- a/v4/integrations/nrlambda/config_test.go
+++ b/v4/integrations/nrlambda/config_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func TestNewConfig(t *testing.T) {

--- a/v4/integrations/nrlambda/events.go
+++ b/v4/integrations/nrlambda/events.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func getEventSourceARN(event interface{}) string {

--- a/v4/integrations/nrlambda/events_test.go
+++ b/v4/integrations/nrlambda/events_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func TestGetEventAttributes(t *testing.T) {

--- a/v4/integrations/nrlambda/example/main.go
+++ b/v4/integrations/nrlambda/example/main.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/newrelic/go-agent/v3/integrations/nrlambda"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrlambda"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func handler(ctx context.Context) {

--- a/v4/integrations/nrlambda/go.mod
+++ b/v4/integrations/nrlambda/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/nrlambda
+module github.com/newrelic/go-agent/v4/integrations/nrlambda
 
 // As of Dec 2019, the aws-lambda-go go.mod uses 1.12:
 // https://github.com/aws/aws-lambda-go/blob/master/go.mod
@@ -6,5 +6,5 @@ go 1.12
 
 require (
 	github.com/aws/aws-lambda-go v1.11.0
-	github.com/newrelic/go-agent/v3 v3.4.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 )

--- a/v4/integrations/nrlambda/handler.go
+++ b/v4/integrations/nrlambda/handler.go
@@ -11,7 +11,7 @@
 // Monitoring AWS Lambda requires several steps shown here:
 // https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-new-relic-monitoring-aws-lambda
 //
-// Example: https://github.com/newrelic/go-agent/tree/master/v3/integrations/nrlambda/example/main.go
+// Example: https://github.com/newrelic/go-agent/tree/master/v4/integrations/nrlambda/example/main.go
 package nrlambda
 
 import (
@@ -24,9 +24,9 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-lambda-go/lambda/handlertrace"
 	"github.com/aws/aws-lambda-go/lambdacontext"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 type response struct {

--- a/v4/integrations/nrlambda/handler_test.go
+++ b/v4/integrations/nrlambda/handler_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambdacontext"
-	"github.com/newrelic/go-agent/v3/internal"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func testApp(getenv func(string) string, t *testing.T) *newrelic.Application {

--- a/v4/integrations/nrlogrus/README.md
+++ b/v4/integrations/nrlogrus/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrlogrus [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrlogrus?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrlogrus)
+# v4/integrations/nrlogrus [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrlogrus?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrlogrus)
 
 Package `nrlogrus` sends go-agent log messages to https://github.com/sirupsen/logrus.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrlogrus"
+import "github.com/newrelic/go-agent/v4/integrations/nrlogrus"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrlogrus).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrlogrus).

--- a/v4/integrations/nrlogrus/example/main.go
+++ b/v4/integrations/nrlogrus/example/main.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/newrelic/go-agent/v3/integrations/nrlogrus"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrlogrus"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 	"github.com/sirupsen/logrus"
 )
 

--- a/v4/integrations/nrlogrus/go.mod
+++ b/v4/integrations/nrlogrus/go.mod
@@ -1,11 +1,11 @@
-module github.com/newrelic/go-agent/v3/integrations/nrlogrus
+module github.com/newrelic/go-agent/v4/integrations/nrlogrus
 
 // As of Dec 2019, the logrus go.mod file uses 1.13:
 // https://github.com/sirupsen/logrus/blob/master/go.mod
 go 1.13
 
 require (
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 	// v1.1.0 is required for the Logger.GetLevel method, and is the earliest
 	// version of logrus using modules.
 	github.com/sirupsen/logrus v1.1.0

--- a/v4/integrations/nrlogrus/nrlogrus.go
+++ b/v4/integrations/nrlogrus/nrlogrus.go
@@ -27,8 +27,8 @@
 package nrlogrus
 
 import (
-	"github.com/newrelic/go-agent/v3/internal"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 	"github.com/sirupsen/logrus"
 )
 

--- a/v4/integrations/nrlogxi/README.md
+++ b/v4/integrations/nrlogxi/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrlogxi [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrlogxi?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrlogxi)
+# v4/integrations/nrlogxi [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrlogxi?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrlogxi)
 
 Package `nrlogxi` supports https://github.com/mgutz/logxi.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrlogxi"
+import "github.com/newrelic/go-agent/v4/integrations/nrlogxi"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrlogxi).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrlogxi).

--- a/v4/integrations/nrlogxi/example_test.go
+++ b/v4/integrations/nrlogxi/example_test.go
@@ -5,8 +5,8 @@ package nrlogxi_test
 
 import (
 	log "github.com/mgutz/logxi/v1"
-	nrlogxi "github.com/newrelic/go-agent/v3/integrations/nrlogxi"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	nrlogxi "github.com/newrelic/go-agent/v4/integrations/nrlogxi"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func Example() {

--- a/v4/integrations/nrlogxi/go.mod
+++ b/v4/integrations/nrlogxi/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/nrlogxi
+module github.com/newrelic/go-agent/v4/integrations/nrlogxi
 
 // As of Dec 2019, logxi requires 1.3+:
 // https://github.com/mgutz/logxi#requirements
@@ -10,5 +10,5 @@ require (
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	// 'v1', at commit aebf8a7d67ab, is the only logxi release.
 	github.com/mgutz/logxi v0.0.0-20161027140823-aebf8a7d67ab
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 )

--- a/v4/integrations/nrlogxi/nrlogxi.go
+++ b/v4/integrations/nrlogxi/nrlogxi.go
@@ -9,8 +9,8 @@ package nrlogxi
 
 import (
 	log "github.com/mgutz/logxi/v1"
-	"github.com/newrelic/go-agent/v3/internal"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func init() { internal.TrackUsage("integration", "logging", "logxi", "v1") }

--- a/v4/integrations/nrmicro/README.md
+++ b/v4/integrations/nrmicro/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrmicro [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrmicro?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrmicro)
+# v4/integrations/nrmicro [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrmicro?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrmicro)
 
 Package `nrmicro` instruments https://github.com/micro/go-micro.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrmicro"
+import "github.com/newrelic/go-agent/v4/integrations/nrmicro"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrmicro).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrmicro).

--- a/v4/integrations/nrmicro/go.mod
+++ b/v4/integrations/nrmicro/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/nrmicro
+module github.com/newrelic/go-agent/v4/integrations/nrmicro
 
 // As of Dec 2019, the go-micro go.mod file uses 1.13:
 // https://github.com/micro/go-micro/blob/master/go.mod
@@ -7,5 +7,5 @@ go 1.13
 require (
 	github.com/golang/protobuf v1.3.2
 	github.com/micro/go-micro v1.8.0
-	github.com/newrelic/go-agent/v3 v3.4.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 )

--- a/v4/integrations/nrmicro/nrmicro.go
+++ b/v4/integrations/nrmicro/nrmicro.go
@@ -15,9 +15,9 @@ import (
 	"github.com/micro/go-micro/registry"
 	"github.com/micro/go-micro/server"
 
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
-	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
+	"github.com/newrelic/go-agent/v4/newrelic"
 )
 
 type nrWrapper struct {

--- a/v4/integrations/nrmicro/nrmicro_doc.go
+++ b/v4/integrations/nrmicro/nrmicro_doc.go
@@ -49,7 +49,7 @@
 // recorded if no error is returned.
 //
 // Full server example:
-// https://github.com/newrelic/go-agent/blob/master/v3/integrations/nrmicro/example/server/server.go
+// https://github.com/newrelic/go-agent/blob/master/v4/integrations/nrmicro/example/server/server.go
 //
 // Micro Clients
 //
@@ -118,7 +118,7 @@
 //	cli = nrmicro.ClientWrapper()(cli)
 //
 // Full client example:
-// https://github.com/newrelic/go-agent/blob/master/v3/integrations/nrmicro/example/client/client.go
+// https://github.com/newrelic/go-agent/blob/master/v4/integrations/nrmicro/example/client/client.go
 //
 // Micro Producers
 //
@@ -139,7 +139,7 @@
 //	err := cli.Publish(ctx, msg)
 //
 // Full Publisher/Subscriber example:
-// https://github.com/newrelic/go-agent/blob/master/v3/integrations/nrmicro/example/pubsub/main.go
+// https://github.com/newrelic/go-agent/blob/master/v4/integrations/nrmicro/example/pubsub/main.go
 //
 // Micro Subscribers
 //
@@ -176,9 +176,9 @@
 // If a Subscriber returns an error, it will be recorded and reported.
 //
 // Full Publisher/Subscriber example:
-// https://github.com/newrelic/go-agent/blob/master/v3/integrations/nrmicro/example/pubsub/main.go
+// https://github.com/newrelic/go-agent/blob/master/v4/integrations/nrmicro/example/pubsub/main.go
 package nrmicro
 
-import "github.com/newrelic/go-agent/v3/internal"
+import "github.com/newrelic/go-agent/v4/internal"
 
 func init() { internal.TrackUsage("integration", "framework", "micro") }

--- a/v4/integrations/nrmicro/nrmicro_test.go
+++ b/v4/integrations/nrmicro/nrmicro_test.go
@@ -20,11 +20,11 @@ import (
 	rmemory "github.com/micro/go-micro/registry/memory"
 	"github.com/micro/go-micro/server"
 
-	proto "github.com/newrelic/go-agent/v3/integrations/nrmicro/example/proto"
+	proto "github.com/newrelic/go-agent/v4/integrations/nrmicro/example/proto"
 
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
-	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
+	"github.com/newrelic/go-agent/v4/newrelic"
 )
 
 const (

--- a/v4/integrations/nrmongo/README.md
+++ b/v4/integrations/nrmongo/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrmongo [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrmongo?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrmongo)
+# v4/integrations/nrmongo [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrmongo?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrmongo)
 
 Package `nrmongo` instruments https://github.com/mongodb/mongo-go-driver
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrmongo"
+import "github.com/newrelic/go-agent/v4/integrations/nrmongo"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrmongo).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrmongo).

--- a/v4/integrations/nrmysql/README.md
+++ b/v4/integrations/nrmysql/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrmysql [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrmysql?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrmysql)
+# v4/integrations/nrmysql [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrmysql?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrmysql)
 
 Package `nrmysql` instruments https://github.com/go-sql-driver/mysql.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrmysql"
+import "github.com/newrelic/go-agent/v4/integrations/nrmysql"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrmysql).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrmysql).

--- a/v4/integrations/nrmysql/example/main.go
+++ b/v4/integrations/nrmysql/example/main.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"time"
 
-	_ "github.com/newrelic/go-agent/v3/integrations/nrmysql"
-	"github.com/newrelic/go-agent/v3/newrelic"
+	_ "github.com/newrelic/go-agent/v4/integrations/nrmysql"
+	"github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func main() {

--- a/v4/integrations/nrmysql/go.mod
+++ b/v4/integrations/nrmysql/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/nrmysql
+module github.com/newrelic/go-agent/v4/integrations/nrmysql
 
 // 1.10 is the Go version in mysql's go.mod
 go 1.10
@@ -6,6 +6,5 @@ go 1.10
 require (
 	// v1.5.0 is the first mysql version to support gomod
 	github.com/go-sql-driver/mysql v1.5.0
-	// v3.3.0 includes the new location of ParseQuery
-	github.com/newrelic/go-agent/v3 v3.3.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 )

--- a/v4/integrations/nrmysql/nrmysql.go
+++ b/v4/integrations/nrmysql/nrmysql.go
@@ -23,7 +23,7 @@
 // Then change the side-effect import to this package, and open "nrmysql" instead:
 //
 //	import (
-//		_ "github.com/newrelic/go-agent/v3/integrations/nrmysql"
+//		_ "github.com/newrelic/go-agent/v4/integrations/nrmysql"
 //	)
 //
 //	func main() {
@@ -44,7 +44,7 @@
 //	row := db.QueryRowContext(ctx, "SELECT count(*) from tables")
 //
 // A working example is shown here:
-// https://github.com/newrelic/go-agent/tree/master/v3/integrations/nrmysql/example/main.go
+// https://github.com/newrelic/go-agent/tree/master/v4/integrations/nrmysql/example/main.go
 package nrmysql
 
 import (
@@ -52,9 +52,9 @@ import (
 	"net"
 
 	"github.com/go-sql-driver/mysql"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/newrelic"
-	"github.com/newrelic/go-agent/v3/newrelic/sqlparse"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/newrelic"
+	"github.com/newrelic/go-agent/v4/newrelic/sqlparse"
 )
 
 var (

--- a/v4/integrations/nrmysql/nrmysql_test.go
+++ b/v4/integrations/nrmysql/nrmysql_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-sql-driver/mysql"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func TestParseDSN(t *testing.T) {

--- a/v4/integrations/nrnats/README.md
+++ b/v4/integrations/nrnats/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrnats [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrnats?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrnats)
+# v4/integrations/nrnats [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrnats?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrnats)
 
 Package `nrnats` instruments https://github.com/nats-io/nats.go.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrnats"
+import "github.com/newrelic/go-agent/v4/integrations/nrnats"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrnats).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrnats).

--- a/v4/integrations/nrnats/example_test.go
+++ b/v4/integrations/nrnats/example_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go"
-	"github.com/newrelic/go-agent/v3/integrations/nrnats"
-	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrnats"
+	"github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func currentTransaction() *newrelic.Transaction { return nil }

--- a/v4/integrations/nrnats/examples/main.go
+++ b/v4/integrations/nrnats/examples/main.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	nats "github.com/nats-io/nats.go"
-	"github.com/newrelic/go-agent/v3/integrations/nrnats"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrnats"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 var app *newrelic.Application

--- a/v4/integrations/nrnats/go.mod
+++ b/v4/integrations/nrnats/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/nrnats
+module github.com/newrelic/go-agent/v4/integrations/nrnats
 
 // As of Dec 2019, 1.11 is the earliest version of Go tested by nats:
 // https://github.com/nats-io/nats.go/blob/master/.travis.yml
@@ -7,5 +7,5 @@ go 1.11
 require (
 	// v1.8.0 is the first nats version with a go.mod.
 	github.com/nats-io/nats.go v1.8.0
-	github.com/newrelic/go-agent/v3 v3.4.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 )

--- a/v4/integrations/nrnats/nrnats.go
+++ b/v4/integrations/nrnats/nrnats.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 
 	nats "github.com/nats-io/nats.go"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 // StartPublishSegment creates and starts a `newrelic.MessageProducerSegment`

--- a/v4/integrations/nrnats/nrnats_doc.go
+++ b/v4/integrations/nrnats/nrnats_doc.go
@@ -58,9 +58,9 @@
 //	nc.Subscribe(subject, nrnats.SubWrapper(app, myMessageHandler))
 //
 // Full Publisher/Subscriber example:
-// https://github.com/newrelic/go-agent/blob/master/v3/integrations/nrnats/examples/main.go
+// https://github.com/newrelic/go-agent/blob/master/v4/integrations/nrnats/examples/main.go
 package nrnats
 
-import "github.com/newrelic/go-agent/v3/internal"
+import "github.com/newrelic/go-agent/v4/internal"
 
 func init() { internal.TrackUsage("integration", "framework", "nats") }

--- a/v4/integrations/nrnats/test/go.mod
+++ b/v4/integrations/nrnats/test/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/test
+module github.com/newrelic/go-agent/v4/integrations/test
 
 // This module exists to avoid having extra nrnats module dependencies.
 
@@ -8,10 +8,10 @@ require (
 	github.com/nats-io/gnatsd v1.4.1 // indirect
 	github.com/nats-io/nats-server v1.4.1
 	github.com/nats-io/nats.go v1.8.0
-	github.com/newrelic/go-agent/v3 v3.4.0
-	github.com/newrelic/go-agent/v3/integrations/nrnats v0.0.0
+	github.com/newrelic/go-agent/v4 v4.0.0
+	github.com/newrelic/go-agent/v4/integrations/nrnats v0.0.0
 )
 
-replace github.com/newrelic/go-agent/v3 => ../../../
+replace github.com/newrelic/go-agent/v4 => ../../../
 
-replace github.com/newrelic/go-agent/v3/integrations/nrnats => ../
+replace github.com/newrelic/go-agent/v4/integrations/nrnats => ../

--- a/v4/integrations/nrnats/test/nrnats_test.go
+++ b/v4/integrations/nrnats/test/nrnats_test.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/nats-io/nats-server/test"
 	nats "github.com/nats-io/nats.go"
-	"github.com/newrelic/go-agent/v3/integrations/nrnats"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrnats"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func TestMain(m *testing.M) {

--- a/v4/integrations/nrpkgerrors/README.md
+++ b/v4/integrations/nrpkgerrors/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrpkgerrors [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrpkgerrors?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrpkgerrors)
+# v4/integrations/nrpkgerrors [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrpkgerrors?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrpkgerrors)
 
 Package `nrpkgerrors` introduces support for https://github.com/pkg/errors.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrpkgerrors"
+import "github.com/newrelic/go-agent/v4/integrations/nrpkgerrors"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrpkgerrors).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrpkgerrors).

--- a/v4/integrations/nrpkgerrors/example/main.go
+++ b/v4/integrations/nrpkgerrors/example/main.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/newrelic/go-agent/v3/integrations/nrpkgerrors"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrpkgerrors"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 	"github.com/pkg/errors"
 )
 

--- a/v4/integrations/nrpkgerrors/example_test.go
+++ b/v4/integrations/nrpkgerrors/example_test.go
@@ -4,8 +4,8 @@
 package nrpkgerrors_test
 
 import (
-	"github.com/newrelic/go-agent/v3/integrations/nrpkgerrors"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrpkgerrors"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 	"github.com/pkg/errors"
 )
 

--- a/v4/integrations/nrpkgerrors/go.mod
+++ b/v4/integrations/nrpkgerrors/go.mod
@@ -1,11 +1,11 @@
-module github.com/newrelic/go-agent/v3/integrations/nrpkgerrors
+module github.com/newrelic/go-agent/v4/integrations/nrpkgerrors
 
 // As of Dec 2019, 1.11 is the earliest version of Go tested by pkg/errors:
 // https://github.com/pkg/errors/blob/master/.travis.yml
 go 1.11
 
 require (
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 	// v0.8.0 was the last release in 2016, and when
 	// major development on pkg/errors stopped.
 	github.com/pkg/errors v0.8.0

--- a/v4/integrations/nrpkgerrors/nrkpgerrors_test.go
+++ b/v4/integrations/nrpkgerrors/nrkpgerrors_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 	"github.com/pkg/errors"
 )
 

--- a/v4/integrations/nrpkgerrors/nrpkgerrors.go
+++ b/v4/integrations/nrpkgerrors/nrpkgerrors.go
@@ -11,8 +11,8 @@ package nrpkgerrors
 import (
 	"fmt"
 
-	"github.com/newrelic/go-agent/v3/internal"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 	"github.com/pkg/errors"
 )
 

--- a/v4/integrations/nrpq/README.md
+++ b/v4/integrations/nrpq/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrpq [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrpq?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrpq)
+# v4/integrations/nrpq [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrpq?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrpq)
 
 Package `nrpq` instruments https://github.com/lib/pq.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrpq"
+import "github.com/newrelic/go-agent/v4/integrations/nrpq"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrpq).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrpq).

--- a/v4/integrations/nrredis-v7/README.md
+++ b/v4/integrations/nrredis-v7/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrredis-v7 [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrredis-v7?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrredis-v7)
+# v4/integrations/nrredis-v7 [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrredis-v7?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrredis-v7)
 
 Package `nrredis` instruments `"github.com/go-redis/redis/v7"`.
 
 ```go
-import nrredis "github.com/newrelic/go-agent/v3/integrations/nrredis-v7"
+import nrredis "github.com/newrelic/go-agent/v4/integrations/nrredis-v7"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrredis-v7).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrredis-v7).

--- a/v4/integrations/nrredis-v7/example/main.go
+++ b/v4/integrations/nrredis-v7/example/main.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	redis "github.com/go-redis/redis/v7"
-	nrredis "github.com/newrelic/go-agent/v3/integrations/nrredis-v7"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	nrredis "github.com/newrelic/go-agent/v4/integrations/nrredis-v7"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func main() {

--- a/v4/integrations/nrredis-v7/go.mod
+++ b/v4/integrations/nrredis-v7/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/nrredis-v7
+module github.com/newrelic/go-agent/v4/integrations/nrredis-v7
 
 // As of Jan 2020, go 1.11 is in the go-redis go.mod file:
 // https://github.com/go-redis/redis/blob/master/go.mod
@@ -6,5 +6,5 @@ go 1.11
 
 require (
 	github.com/go-redis/redis/v7 v7.0.0-beta.5
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 )

--- a/v4/integrations/nrredis-v7/nrredis.go
+++ b/v4/integrations/nrredis-v7/nrredis.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 
 	redis "github.com/go-redis/redis/v7"
-	"github.com/newrelic/go-agent/v3/internal"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func init() { internal.TrackUsage("integration", "datastore", "redis") }

--- a/v4/integrations/nrredis-v7/nrredis_example_test.go
+++ b/v4/integrations/nrredis-v7/nrredis_example_test.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 
 	redis "github.com/go-redis/redis/v7"
-	nrredis "github.com/newrelic/go-agent/v3/integrations/nrredis-v7"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	nrredis "github.com/newrelic/go-agent/v4/integrations/nrredis-v7"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func getTransaction() *newrelic.Transaction { return nil }

--- a/v4/integrations/nrredis-v7/nrredis_test.go
+++ b/v4/integrations/nrredis-v7/nrredis_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 
 	redis "github.com/go-redis/redis/v7"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func emptyDialer(context.Context, string, string) (net.Conn, error) {

--- a/v4/integrations/nrsnowflake/README.md
+++ b/v4/integrations/nrsnowflake/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrsnowflake [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrsnowflake?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrsnowflake)
+# v4/integrations/nrsnowflake [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrsnowflake?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrsnowflake)
 
 Package `nrsnowflake` instruments https://github.com/snowflakedb/gosnowflake.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrsnowflake"
+import "github.com/newrelic/go-agent/v4/integrations/nrsnowflake"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrsnowflake).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrsnowflake).

--- a/v4/integrations/nrsnowflake/example/main.go
+++ b/v4/integrations/nrsnowflake/example/main.go
@@ -13,8 +13,8 @@ import (
 
 	// 1. Instead of importing github.com/snowflakedb/gosnowflake, import the
 	// nrsnowflake integration
-	_ "github.com/newrelic/go-agent/v3/integrations/nrsnowflake"
-	"github.com/newrelic/go-agent/v3/newrelic"
+	_ "github.com/newrelic/go-agent/v4/integrations/nrsnowflake"
+	"github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func main() {

--- a/v4/integrations/nrsnowflake/go.mod
+++ b/v4/integrations/nrsnowflake/go.mod
@@ -1,10 +1,9 @@
-module github.com/newrelic/go-agent/v3/integrations/nrsnowflake
+module github.com/newrelic/go-agent/v4/integrations/nrsnowflake
 
 // snowflakedb/gosnowflake says it requires 1.12 but builds on 1.10
 go 1.10
 
 require (
-	// v3.3.0 includes the new location of ParseQuery
-	github.com/newrelic/go-agent/v3 v3.3.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 	github.com/snowflakedb/gosnowflake v1.3.4
 )

--- a/v4/integrations/nrsnowflake/nrsnowflake.go
+++ b/v4/integrations/nrsnowflake/nrsnowflake.go
@@ -23,7 +23,7 @@
 // Then change the side-effect import to this package, and open "nrsnowflake" instead:
 //
 //	import (
-//		_ "github.com/newrelic/go-agent/v3/integrations/nrsnowflake"
+//		_ "github.com/newrelic/go-agent/v4/integrations/nrsnowflake"
 //	)
 //
 //	func main() {
@@ -44,16 +44,16 @@
 //	row := db.QueryRowContext(ctx, "SELECT count(*) from tables")
 //
 // A working example is shown here:
-// https://github.com/newrelic/go-agent/tree/master/v3/integrations/nrsnowflake/example/main.go
+// https://github.com/newrelic/go-agent/tree/master/v4/integrations/nrsnowflake/example/main.go
 package nrsnowflake
 
 import (
 	"database/sql"
 	"strconv"
 
-	"github.com/newrelic/go-agent/v3/internal"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
-	"github.com/newrelic/go-agent/v3/newrelic/sqlparse"
+	"github.com/newrelic/go-agent/v4/internal"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
+	"github.com/newrelic/go-agent/v4/newrelic/sqlparse"
 	"github.com/snowflakedb/gosnowflake"
 )
 

--- a/v4/integrations/nrsnowflake/nrsnowflake_test.go
+++ b/v4/integrations/nrsnowflake/nrsnowflake_test.go
@@ -6,7 +6,7 @@ package nrsnowflake
 import (
 	"testing"
 
-	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/newrelic"
 	"github.com/snowflakedb/gosnowflake"
 )
 

--- a/v4/integrations/nrsqlite3/README.md
+++ b/v4/integrations/nrsqlite3/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrsqlite3 [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrsqlite3?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrsqlite3)
+# v4/integrations/nrsqlite3 [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrsqlite3?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrsqlite3)
 
 Package `nrsqlite3` instruments https://github.com/mattn/go-sqlite3.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrsqlite3"
+import "github.com/newrelic/go-agent/v4/integrations/nrsqlite3"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrsqlite3).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrsqlite3).

--- a/v4/integrations/nrsqlite3/example/main.go
+++ b/v4/integrations/nrsqlite3/example/main.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"time"
 
-	_ "github.com/newrelic/go-agent/v3/integrations/nrsqlite3"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	_ "github.com/newrelic/go-agent/v4/integrations/nrsqlite3"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 func main() {

--- a/v4/integrations/nrsqlite3/go.mod
+++ b/v4/integrations/nrsqlite3/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/nrsqlite3
+module github.com/newrelic/go-agent/v4/integrations/nrsqlite3
 
 // As of Dec 2019, 1.9 is the oldest version of Go tested by go-sqlite3:
 // https://github.com/mattn/go-sqlite3/blob/master/.travis.yml
@@ -6,6 +6,5 @@ go 1.9
 
 require (
 	github.com/mattn/go-sqlite3 v1.0.0
-	// v3.3.0 includes the new location of ParseQuery
-	github.com/newrelic/go-agent/v3 v3.3.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 )

--- a/v4/integrations/nrsqlite3/nrsqlite3.go
+++ b/v4/integrations/nrsqlite3/nrsqlite3.go
@@ -23,7 +23,7 @@
 // Then change the side-effect import to this package, and open "nrsqlite3" instead:
 //
 //	import (
-//		_ "github.com/newrelic/go-agent/v3/integrations/nrsqlite3"
+//		_ "github.com/newrelic/go-agent/v4/integrations/nrsqlite3"
 //	)
 //
 //	func main() {
@@ -68,7 +68,7 @@
 //	row := db.QueryRowContext(ctx, "SELECT count(*) from tables")
 //
 // A working example is shown here:
-// https://github.com/newrelic/go-agent/tree/master/v3/integrations/nrsqlite3/example/main.go
+// https://github.com/newrelic/go-agent/tree/master/v4/integrations/nrsqlite3/example/main.go
 package nrsqlite3
 
 import (
@@ -78,9 +78,9 @@ import (
 	"strings"
 
 	sqlite3 "github.com/mattn/go-sqlite3"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/newrelic"
-	"github.com/newrelic/go-agent/v3/newrelic/sqlparse"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/newrelic"
+	"github.com/newrelic/go-agent/v4/newrelic/sqlparse"
 )
 
 var (

--- a/v4/integrations/nrstan/README.md
+++ b/v4/integrations/nrstan/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrstan [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrstan?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrstan)
+# v4/integrations/nrstan [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrstan?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrstan)
 
 Package `nrstan` instruments https://github.com/nats-io/stan.go.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrstan"
+import "github.com/newrelic/go-agent/v4/integrations/nrstan"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrstan).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrstan).

--- a/v4/integrations/nrstan/examples/go.mod
+++ b/v4/integrations/nrstan/examples/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/nrstan/examples
+module github.com/newrelic/go-agent/v4/integrations/nrstan/examples
 
 // This module exists to avoid a dependency on nrnrats.
 
@@ -6,13 +6,13 @@ go 1.13
 
 require (
 	github.com/nats-io/stan.go v0.5.0
-	github.com/newrelic/go-agent/v3 v3.4.0
-	github.com/newrelic/go-agent/v3/integrations/nrnats v0.0.0
-	github.com/newrelic/go-agent/v3/integrations/nrstan v0.0.0
+	github.com/newrelic/go-agent/v4 v4.0.0
+	github.com/newrelic/go-agent/v4/integrations/nrnats v0.0.0
+	github.com/newrelic/go-agent/v4/integrations/nrstan v0.0.0
 )
 
-replace github.com/newrelic/go-agent/v3 => ../../../
+replace github.com/newrelic/go-agent/v4 => ../../../
 
-replace github.com/newrelic/go-agent/v3/integrations/nrstan => ../
+replace github.com/newrelic/go-agent/v4/integrations/nrstan => ../
 
-replace github.com/newrelic/go-agent/v3/integrations/nrnats => ../../nrnats/
+replace github.com/newrelic/go-agent/v4/integrations/nrnats => ../../nrnats/

--- a/v4/integrations/nrstan/examples/main.go
+++ b/v4/integrations/nrstan/examples/main.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	stan "github.com/nats-io/stan.go"
-	"github.com/newrelic/go-agent/v3/integrations/nrnats"
-	"github.com/newrelic/go-agent/v3/integrations/nrstan"
-	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrnats"
+	"github.com/newrelic/go-agent/v4/integrations/nrstan"
+	"github.com/newrelic/go-agent/v4/newrelic"
 )
 
 var app *newrelic.Application

--- a/v4/integrations/nrstan/go.mod
+++ b/v4/integrations/nrstan/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/nrstan
+module github.com/newrelic/go-agent/v4/integrations/nrstan
 
 // As of Dec 2019, 1.11 is the earliest Go version tested by Stan:
 // https://github.com/nats-io/stan.go/blob/master/.travis.yml
@@ -6,5 +6,5 @@ go 1.11
 
 require (
 	github.com/nats-io/stan.go v0.5.0
-	github.com/newrelic/go-agent/v3 v3.4.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 )

--- a/v4/integrations/nrstan/nrstan.go
+++ b/v4/integrations/nrstan/nrstan.go
@@ -5,9 +5,9 @@ package nrstan
 
 import (
 	stan "github.com/nats-io/stan.go"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 // StreamingSubWrapper can be used to wrap the function for STREAMING stan.Subscribe and stan.QueueSubscribe

--- a/v4/integrations/nrstan/nrstan_doc.go
+++ b/v4/integrations/nrstan/nrstan_doc.go
@@ -26,7 +26,7 @@
 // NATS Streaming publishers
 //
 // You can use `nrnats.StartPublishSegment` from the `nrnats` package
-// (https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrnats/#StartPublishSegment)
+// (https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrnats/#StartPublishSegment)
 // to start an external segment when doing a streaming publish, which must be ended after publishing is complete.
 // Example:
 //
@@ -40,9 +40,9 @@
 //	seg.End()
 //
 // Full Publisher/Subscriber example:
-// https://github.com/newrelic/go-agent/blob/master/v3/integrations/nrstan/examples/main.go
+// https://github.com/newrelic/go-agent/blob/master/v4/integrations/nrstan/examples/main.go
 package nrstan
 
-import "github.com/newrelic/go-agent/v3/internal"
+import "github.com/newrelic/go-agent/v4/internal"
 
 func init() { internal.TrackUsage("integration", "framework", "stan") }

--- a/v4/integrations/nrstan/test/go.mod
+++ b/v4/integrations/nrstan/test/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/go-agent/v3/integrations/nrstan/test
+module github.com/newrelic/go-agent/v4/integrations/nrstan/test
 
 // This module exists to avoid a dependency on
 // github.com/nats-io/nats-streaming-server in nrstan.
@@ -8,10 +8,10 @@ go 1.13
 require (
 	github.com/nats-io/nats-streaming-server v0.16.2
 	github.com/nats-io/stan.go v0.5.0
-	github.com/newrelic/go-agent/v3 v3.4.0
-	github.com/newrelic/go-agent/v3/integrations/nrstan v0.0.0
+	github.com/newrelic/go-agent/v4 v4.0.0
+	github.com/newrelic/go-agent/v4/integrations/nrstan v0.0.0
 )
 
-replace github.com/newrelic/go-agent/v3 => ../../../
+replace github.com/newrelic/go-agent/v4 => ../../../
 
-replace github.com/newrelic/go-agent/v3/integrations/nrstan => ../
+replace github.com/newrelic/go-agent/v4/integrations/nrstan => ../

--- a/v4/integrations/nrstan/test/nrstan_test.go
+++ b/v4/integrations/nrstan/test/nrstan_test.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/nats-io/nats-streaming-server/server"
 	stan "github.com/nats-io/stan.go"
-	"github.com/newrelic/go-agent/v3/integrations/nrstan"
-	"github.com/newrelic/go-agent/v3/internal"
-	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrstan"
+	"github.com/newrelic/go-agent/v4/internal"
+	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
 
 const (

--- a/v4/integrations/nrzap/README.md
+++ b/v4/integrations/nrzap/README.md
@@ -1,10 +1,10 @@
-# v3/integrations/nrzap [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrzap?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrzap)
+# v4/integrations/nrzap [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrzap?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrzap)
 
 Package `nrzap` supports https://github.com/uber-go/zap.
 
 ```go
-import "github.com/newrelic/go-agent/v3/integrations/nrzap"
+import "github.com/newrelic/go-agent/v4/integrations/nrzap"
 ```
 
 For more information, see
-[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrzap).
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrzap).

--- a/v4/integrations/nrzap/example_test.go
+++ b/v4/integrations/nrzap/example_test.go
@@ -4,8 +4,8 @@
 package nrzap_test
 
 import (
-	"github.com/newrelic/go-agent/v3/integrations/nrzap"
-	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/integrations/nrzap"
+	"github.com/newrelic/go-agent/v4/newrelic"
 	"go.uber.org/zap"
 )
 

--- a/v4/integrations/nrzap/go.mod
+++ b/v4/integrations/nrzap/go.mod
@@ -1,11 +1,11 @@
-module github.com/newrelic/go-agent/v3/integrations/nrzap
+module github.com/newrelic/go-agent/v4/integrations/nrzap
 
 // As of Dec 2019, zap has 1.13 in their go.mod file:
 // https://github.com/uber-go/zap/blob/master/go.mod
 go 1.13
 
 require (
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/newrelic/go-agent/v4 v4.0.0
 	// v1.12.0 is the earliest version of zap using modules.
 	go.uber.org/zap v1.12.0
 )

--- a/v4/integrations/nrzap/nrzap.go
+++ b/v4/integrations/nrzap/nrzap.go
@@ -7,8 +7,8 @@
 package nrzap
 
 import (
-	"github.com/newrelic/go-agent/v3/internal"
-	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v4/internal"
+	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 	"go.uber.org/zap"
 )
 

--- a/v4/newrelic/log.go
+++ b/v4/newrelic/log.go
@@ -14,9 +14,9 @@ import (
 // for use in multiple goroutines.  Two Logger implementations are included:
 // NewLogger, which logs at info level, and NewDebugLogger which logs at debug
 // level.  logrus, logxi, and zap are supported by the integration packages
-// https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrlogrus,
-// https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrlogxi,
-// and https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrzap
+// https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrlogrus,
+// https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrlogxi,
+// and https://godoc.org/github.com/newrelic/go-agent/v4/integrations/nrzap
 // respectively.
 type Logger interface {
 	Error(msg string, context map[string]interface{})

--- a/v4/newrelic/sqlparse/sqlparse.go
+++ b/v4/newrelic/sqlparse/sqlparse.go
@@ -49,7 +49,7 @@ var (
 // ParseQuery parses table and operation from the SQL query string.  It is
 // a helper meant to be used when writing database/sql driver instrumentation.
 // Check out full example usage here:
-// https://github.com/newrelic/go-agent/blob/master/v3/integrations/nrmysql/nrmysql.go
+// https://github.com/newrelic/go-agent/blob/master/v4/integrations/nrmysql/nrmysql.go
 //
 // ParseQuery is designed to work with MySQL, Postgres, and SQLite drivers.
 // Ability to correctly parse queries for other SQL databases is not


### PR DESCRIPTION
This pull request aims to switch all imports that were v3 to v4 in the shim.

There were two changes required to get all the tests to pass. I left comments in the code detailing these. Otherwise, all changes are simply `s/v3/v4`.