### PR TITLE
Support nil and empty Applications.

### DIFF
--- a/v4/newrelic/application.go
+++ b/v4/newrelic/application.go
@@ -21,6 +21,12 @@ type Application struct {
 
 // StartTransaction begins a Transaction with the given name.
 func (app *Application) StartTransaction(name string) *Transaction {
+	if app == nil {
+		return nil
+	}
+	if app.tracer == nil {
+		return nil
+	}
 	ctx, sp := app.tracer.Start(context.Background(), name,
 		trace.WithSpanKind(trace.SpanKindInternal))
 	s := &span{

--- a/v4/newrelic/application_test.go
+++ b/v4/newrelic/application_test.go
@@ -1,0 +1,29 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package newrelic
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNilApplication(t *testing.T) {
+	// Ensure using a nil application does not panic
+	var app *Application
+	app.StartTransaction("txn")
+	app.RecordCustomEvent("Event", nil)
+	app.RecordCustomMetric("Metric", 42)
+	app.WaitForConnection(time.Nanosecond)
+	app.Shutdown(time.Nanosecond)
+}
+
+func TestEmptyApplication(t *testing.T) {
+	// Ensure using an empty application does not panic
+	app := new(Application)
+	app.StartTransaction("txn")
+	app.RecordCustomEvent("Event", nil)
+	app.RecordCustomMetric("Metric", 42)
+	app.WaitForConnection(time.Nanosecond)
+	app.Shutdown(time.Nanosecond)
+}


### PR DESCRIPTION
Make sure that when using `(*Application)(nil)` or `&Application{}` that all methods do not panic.