### PR TITLE
Reenable tests that required DT implementation.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -275,38 +275,32 @@ jobs:
           - go-version: 1.14.x
             dirs: v4/integrations/nrsnowflake
             extratesting: go get -u github.com/snowflakedb/gosnowflake@master
-          # gRPC tests should be skipped until Distributed Tracing has been
-          # implemented.
-          # - go-version: 1.14.x
-          #   dirs: v4/integrations/nrgrpc
-          #   extratesting: go get -u google.golang.org/grpc@master
-          # Micro tests should be skipped until Distributed Tracing has been
-          # implemented.
-          #- go-version: 1.14.x
-          #  dirs: v4/integrations/nrmicro
+          - go-version: 1.14.x
+            dirs: v4/integrations/nrgrpc
+            extratesting: go get -u google.golang.org/grpc@master
+          - go-version: 1.14.x
+            dirs: v4/integrations/nrmicro
             # As of Dec 2019, there is a race condition in when using go-micro@master
             # in their logging system.  Instead, we'll test against the latest
             # released version.
             # As of Jan 2019, it is impossible to go get the latest micro version.
             # As of June 2020, confirmed errors still result
             # extratesting: go get -u github.com/micro/go-micro@latest
-          # Nats/Stan tests should be skipped until Distributed Tracing has
-          # been implemented.
-          # - go-version: 1.14.x
-          #   dirs: v4/integrations/nrnats
-          #   extratesting: go get -u github.com/nats-io/nats.go/@master
-          # - go-version: 1.14.x
-          #   dirs: v4/integrations/nrnats/test
-          #   extratesting: go get -u github.com/nats-io/nats.go/@master
-          # - go-version: 1.14.x
-          #   dirs: v4/integrations/nrstan
-          #   extratesting: go get -u github.com/nats-io/stan.go/@master
-          # - go-version: 1.14.x
-          #   dirs: v4/integrations/nrstan/test
-          #   extratesting: go get -u github.com/nats-io/stan.go/@master
-          # - go-version: 1.14.x
-          #   dirs: v4/integrations/nrstan/examples
-          #   extratesting: go get -u github.com/nats-io/stan.go/@master
+          - go-version: 1.14.x
+            dirs: v4/integrations/nrnats
+            extratesting: go get -u github.com/nats-io/nats.go/@master
+          - go-version: 1.14.x
+            dirs: v4/integrations/nrnats/test
+            extratesting: go get -u github.com/nats-io/nats.go/@master
+          - go-version: 1.14.x
+            dirs: v4/integrations/nrstan
+            extratesting: go get -u github.com/nats-io/stan.go/@master
+          - go-version: 1.14.x
+            dirs: v4/integrations/nrstan/test
+            extratesting: go get -u github.com/nats-io/stan.go/@master
+          - go-version: 1.14.x
+            dirs: v4/integrations/nrstan/examples
+            extratesting: go get -u github.com/nats-io/stan.go/@master
           - go-version: 1.14.x
             dirs: v4/integrations/logcontext
             extratesting: go get -u github.com/sirupsen/logrus@master

--- a/v4/integrations/nrgrpc/nrgrpc_client_test.go
+++ b/v4/integrations/nrgrpc/nrgrpc_client_test.go
@@ -74,14 +74,7 @@ func TestGetURL(t *testing.T) {
 }
 
 func testApp() integrationsupport.ExpectApp {
-	return integrationsupport.NewTestApp(replyFn, integrationsupport.ConfigFullTraces)
-}
-
-var replyFn = func(reply *internal.ConnectReply) {
-	reply.SetSampleEverything()
-	reply.AccountID = "123"
-	reply.TrustedAccountKey = "123"
-	reply.PrimaryAppID = "456"
+	return integrationsupport.NewTestApp(integrationsupport.ConfigFullTraces)
 }
 
 func TestUnaryClientInterceptor(t *testing.T) {
@@ -103,7 +96,7 @@ func TestUnaryClientInterceptor(t *testing.T) {
 	if nil != err {
 		t.Fatal("cannot unmarshall client response", err)
 	}
-	if hdr, ok := hdrs["newrelic"]; !ok || len(hdr) != 1 || "" == hdr[0] {
+	if hdr, ok := hdrs["traceparent"]; !ok || len(hdr) != 1 || "" == hdr[0] {
 		t.Error("distributed trace header not sent", hdrs)
 	}
 	txn.End()
@@ -192,7 +185,7 @@ func TestUnaryStreamClientInterceptor(t *testing.T) {
 		if nil != err {
 			t.Fatal("cannot unmarshall client response", err)
 		}
-		if hdr, ok := hdrs["newrelic"]; !ok || len(hdr) != 1 || "" == hdr[0] {
+		if hdr, ok := hdrs["traceparent"]; !ok || len(hdr) != 1 || "" == hdr[0] {
 			t.Error("distributed trace header not sent", hdrs)
 		}
 		recved++
@@ -289,7 +282,7 @@ func TestStreamUnaryClientInterceptor(t *testing.T) {
 	if nil != err {
 		t.Fatal("cannot unmarshall client response", err)
 	}
-	if hdr, ok := hdrs["newrelic"]; !ok || len(hdr) != 1 || "" == hdr[0] {
+	if hdr, ok := hdrs["traceparent"]; !ok || len(hdr) != 1 || "" == hdr[0] {
 		t.Error("distributed trace header not sent", hdrs)
 	}
 	txn.End()
@@ -381,7 +374,7 @@ func TestStreamStreamClientInterceptor(t *testing.T) {
 			if nil != err {
 				t.Fatal("cannot unmarshall client response", err)
 			}
-			if hdr, ok := hdrs["newrelic"]; !ok || len(hdr) != 1 || "" == hdr[0] {
+			if hdr, ok := hdrs["traceparent"]; !ok || len(hdr) != 1 || "" == hdr[0] {
 				t.Error("distributed trace header not sent", hdrs)
 			}
 			recved++
@@ -462,8 +455,8 @@ func TestClientUnaryMetadata(t *testing.T) {
 	ctx := newrelic.NewContext(context.Background(), txn)
 
 	md := metadata.New(map[string]string{
-		"testing":  "hello world",
-		"newrelic": "payload",
+		"testing":     "hello world",
+		"traceparent": "payload",
 	})
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
@@ -481,7 +474,7 @@ func TestClientUnaryMetadata(t *testing.T) {
 	if nil != err {
 		t.Fatal("cannot unmarshall client response", err)
 	}
-	if hdr, ok := hdrs["newrelic"]; !ok || len(hdr) != 1 || "" == hdr[0] || "payload" == hdr[0] {
+	if hdr, ok := hdrs["traceparent"]; !ok || len(hdr) != 1 || "" == hdr[0] || "payload" == hdr[0] {
 		t.Error("distributed trace header not sent", hdrs)
 	}
 	if hdr, ok := hdrs["testing"]; !ok || len(hdr) != 1 || "hello world" != hdr[0] {
@@ -504,7 +497,7 @@ func TestNilTxnClientUnary(t *testing.T) {
 	if nil != err {
 		t.Fatal("cannot unmarshall client response", err)
 	}
-	if _, ok := hdrs["newrelic"]; ok {
+	if _, ok := hdrs["traceparent"]; ok {
 		t.Error("distributed trace header sent", hdrs)
 	}
 }
@@ -536,7 +529,7 @@ func TestNilTxnClientStreaming(t *testing.T) {
 	if nil != err {
 		t.Fatal("cannot unmarshall client response", err)
 	}
-	if _, ok := hdrs["newrelic"]; ok {
+	if _, ok := hdrs["traceparent"]; ok {
 		t.Error("distributed trace header sent", hdrs)
 	}
 }

--- a/v4/integrations/nrmicro/nrmicro.go
+++ b/v4/integrations/nrmicro/nrmicro.go
@@ -15,7 +15,6 @@ import (
 	"github.com/micro/go-micro/registry"
 	"github.com/micro/go-micro/server"
 
-	"github.com/newrelic/go-agent/v4/internal"
 	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
 	"github.com/newrelic/go-agent/v4/newrelic"
 )
@@ -199,13 +198,8 @@ func SubscriberWrapper(app *newrelic.Application) server.SubscriberWrapper {
 			return fn
 		}
 		return func(ctx context.Context, m server.Message) (err error) {
-			namer := internal.MessageMetricKey{
-				Library:         "Micro",
-				DestinationType: string(newrelic.MessageTopic),
-				DestinationName: m.Topic(),
-				Consumer:        true,
-			}
-			txn := app.StartTransaction(namer.Name())
+			name := m.Topic() + " receive"
+			txn := app.StartTransaction(name)
 			defer txn.End()
 			integrationsupport.AddAgentAttribute(txn, newrelic.AttributeMessageRoutingKey, m.Topic(), nil)
 			if md, ok := metadata.FromContext(ctx); ok {

--- a/v4/integrations/nrmicro/nrmicro_test.go
+++ b/v4/integrations/nrmicro/nrmicro_test.go
@@ -78,7 +78,7 @@ func (t *TestHandlerWithNonMicroError) Method(ctx context.Context, req *TestRequ
 
 func getDTRequestHeaderVal(ctx context.Context) string {
 	if md, ok := metadata.FromContext(ctx); ok {
-		if dtHeader, ok := md[newrelic.DistributedTraceNewRelicHeader]; ok {
+		if dtHeader, ok := md[newrelic.DistributedTraceW3CTraceParentHeader]; ok {
 			return dtHeader
 		}
 		return missingHeaders
@@ -87,14 +87,7 @@ func getDTRequestHeaderVal(ctx context.Context) string {
 }
 
 func createTestApp() integrationsupport.ExpectApp {
-	return integrationsupport.NewTestApp(replyFn, cfgFn, integrationsupport.ConfigFullTraces)
-}
-
-var replyFn = func(reply *internal.ConnectReply) {
-	reply.SetSampleEverything()
-	reply.AccountID = "123"
-	reply.TrustedAccountKey = "123"
-	reply.PrimaryAppID = "456"
+	return integrationsupport.NewTestApp(cfgFn, integrationsupport.ConfigFullTraces)
 }
 
 var cfgFn = func(cfg *newrelic.Config) {
@@ -292,7 +285,7 @@ func TestClientPublishWithNoTransaction(t *testing.T) {
 	if _, err := b.Subscribe(topic, func(e broker.Event) error {
 		defer wg.Done()
 		h := e.Message().Header
-		if _, ok := h[newrelic.DistributedTraceNewRelicHeader]; ok {
+		if _, ok := h[newrelic.DistributedTraceW3CTraceParentHeader]; ok {
 			t.Error("Distributed tracing headers found", h)
 		}
 		return nil
@@ -320,7 +313,7 @@ func TestClientPublishWithTransaction(t *testing.T) {
 	if _, err := b.Subscribe(topic, func(e broker.Event) error {
 		defer wg.Done()
 		h := e.Message().Header
-		if _, ok := h[newrelic.DistributedTraceNewRelicHeader]; !ok {
+		if _, ok := h[newrelic.DistributedTraceW3CTraceParentHeader]; !ok {
 			t.Error("Distributed tracing headers not found", h)
 		}
 		return nil

--- a/v4/integrations/nrnats/nrnats.go
+++ b/v4/integrations/nrnats/nrnats.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	nats "github.com/nats-io/nats.go"
-	"github.com/newrelic/go-agent/v4/internal"
 	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
 	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
@@ -48,13 +47,8 @@ func SubWrapper(app *newrelic.Application, f func(msg *nats.Msg)) func(msg *nats
 		return f
 	}
 	return func(msg *nats.Msg) {
-		namer := internal.MessageMetricKey{
-			Library:         "NATS",
-			DestinationType: string(newrelic.MessageTopic),
-			DestinationName: msg.Subject,
-			Consumer:        true,
-		}
-		txn := app.StartTransaction(namer.Name())
+		name := msg.Subject + " receive"
+		txn := app.StartTransaction(name)
 		defer txn.End()
 
 		integrationsupport.AddAgentAttribute(txn, newrelic.AttributeMessageRoutingKey, msg.Sub.Subject, nil)

--- a/v4/integrations/nrnats/test/nrnats_test.go
+++ b/v4/integrations/nrnats/test/nrnats_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 }
 
 func testApp() integrationsupport.ExpectApp {
-	return integrationsupport.NewTestApp(integrationsupport.SampleEverythingReplyFn, integrationsupport.ConfigFullTraces, cfgFn)
+	return integrationsupport.NewTestApp(integrationsupport.ConfigFullTraces, cfgFn)
 }
 
 var cfgFn = func(cfg *newrelic.Config) {

--- a/v4/integrations/nrstan/nrstan.go
+++ b/v4/integrations/nrstan/nrstan.go
@@ -5,7 +5,6 @@ package nrstan
 
 import (
 	stan "github.com/nats-io/stan.go"
-	"github.com/newrelic/go-agent/v4/internal"
 	"github.com/newrelic/go-agent/v4/internal/integrationsupport"
 	newrelic "github.com/newrelic/go-agent/v4/newrelic"
 )
@@ -19,13 +18,8 @@ func StreamingSubWrapper(app *newrelic.Application, f func(msg *stan.Msg)) func(
 		return f
 	}
 	return func(msg *stan.Msg) {
-		namer := internal.MessageMetricKey{
-			Library:         "STAN",
-			DestinationType: string(newrelic.MessageTopic),
-			DestinationName: msg.MsgProto.Subject,
-			Consumer:        true,
-		}
-		txn := app.StartTransaction(namer.Name())
+		name := msg.MsgProto.Subject + " receive"
+		txn := app.StartTransaction(name)
 		defer txn.End()
 
 		integrationsupport.AddAgentAttribute(txn, newrelic.AttributeMessageRoutingKey, msg.MsgProto.Subject, nil)

--- a/v4/integrations/nrstan/test/nrstan_test.go
+++ b/v4/integrations/nrstan/test/nrstan_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 }
 
 func createTestApp() integrationsupport.ExpectApp {
-	return integrationsupport.NewTestApp(integrationsupport.SampleEverythingReplyFn, integrationsupport.ConfigFullTraces, cfgFn)
+	return integrationsupport.NewTestApp(integrationsupport.ConfigFullTraces, cfgFn)
 }
 
 var cfgFn = func(cfg *newrelic.Config) {


### PR DESCRIPTION
This pull request re-enables grpc, micro, and nats/stan testing. A few small changes were required in each in order to get it working. I left comments in those places.