### PR TITLE
Access tracer from the application.

### DIFF
--- a/v4/newrelic/transaction.go
+++ b/v4/newrelic/transaction.go
@@ -192,7 +192,7 @@ func (txn *Transaction) StartSegmentNow() SegmentStartTime {
 		return SegmentStartTime{}
 	}
 	parent := txn.thread.getCurrentSpan()
-	ctx, sp := txn.rootSpan.Span.Tracer().Start(parent.ctx, "",
+	ctx, sp := txn.app.tracer.Start(parent.ctx, "",
 		trace.WithSpanKind(trace.SpanKindInternal))
 	span := &span{
 		Span:   sp,


### PR DESCRIPTION
When starting a segment, we should be using the tracer from the application.