### PR TITLE
Support custom attributes on segments and transactions.

### DIFF
--- a/v4/integrations/nrawssdk-v1/nrawssdk_test.go
+++ b/v4/integrations/nrawssdk-v1/nrawssdk_test.go
@@ -64,8 +64,9 @@ const (
 
 var (
 	genericSpan = internal.WantSpan{
-		Name:     txnName,
-		ParentID: internal.MatchNoParent,
+		Name:          txnName,
+		ParentID:      internal.MatchNoParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"transaction.name": "OtherTransaction/Go/" + txnName,
 			"sampled":          true,
@@ -78,8 +79,9 @@ var (
 		},
 	}
 	externalSpan = internal.WantSpan{
-		Name:     "http POST lambda.us-west-2.amazonaws.com",
-		ParentID: internal.MatchAnyParent,
+		Name:          "http POST lambda.us-west-2.amazonaws.com",
+		ParentID:      internal.MatchAnyParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"sampled":       true,
 			"category":      "http",
@@ -98,8 +100,9 @@ var (
 		},
 	}
 	externalSpanNoRequestID = internal.WantSpan{
-		Name:     "http POST lambda.us-west-2.amazonaws.com",
-		ParentID: internal.MatchAnyParent,
+		Name:          "http POST lambda.us-west-2.amazonaws.com",
+		ParentID:      internal.MatchAnyParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"sampled":       true,
 			"category":      "http",
@@ -117,8 +120,9 @@ var (
 		},
 	}
 	datastoreSpan = internal.WantSpan{
-		Name:     "'DescribeTable' on 'thebesttable' using 'DynamoDB'",
-		ParentID: internal.MatchAnyParent,
+		Name:          "'DescribeTable' on 'thebesttable' using 'DynamoDB'",
+		ParentID:      internal.MatchAnyParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"sampled":       true,
 			"category":      "datastore",

--- a/v4/integrations/nrawssdk-v2/nrawssdk_test.go
+++ b/v4/integrations/nrawssdk-v2/nrawssdk_test.go
@@ -81,8 +81,9 @@ const (
 
 var (
 	genericSpan = internal.WantSpan{
-		Name:     txnName,
-		ParentID: internal.MatchNoParent,
+		Name:          txnName,
+		ParentID:      internal.MatchNoParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"transaction.name": "OtherTransaction/Go/" + txnName,
 			"sampled":          true,
@@ -95,8 +96,9 @@ var (
 		},
 	}
 	externalSpan = internal.WantSpan{
-		Name:     "http POST lambda.us-west-2.amazonaws.com",
-		ParentID: internal.MatchAnyParent,
+		Name:          "http POST lambda.us-west-2.amazonaws.com",
+		ParentID:      internal.MatchAnyParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"sampled":       true,
 			"category":      "http",
@@ -115,8 +117,9 @@ var (
 		},
 	}
 	externalSpanNoRequestID = internal.WantSpan{
-		Name:     "http POST lambda.us-west-2.amazonaws.com",
-		ParentID: internal.MatchAnyParent,
+		Name:          "http POST lambda.us-west-2.amazonaws.com",
+		ParentID:      internal.MatchAnyParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"sampled":       true,
 			"category":      "http",
@@ -134,8 +137,9 @@ var (
 		},
 	}
 	datastoreSpan = internal.WantSpan{
-		Name:     "'DescribeTable' on 'thebesttable' using 'DynamoDB'",
-		ParentID: internal.MatchAnyParent,
+		Name:          "'DescribeTable' on 'thebesttable' using 'DynamoDB'",
+		ParentID:      internal.MatchAnyParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"sampled":       true,
 			"category":      "datastore",

--- a/v4/integrations/nrecho-v3/nrecho_test.go
+++ b/v4/integrations/nrecho-v3/nrecho_test.go
@@ -38,8 +38,9 @@ func TestBasicRoute(t *testing.T) {
 		IsWeb: true,
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{{
-		Name:     "GET /hello",
-		ParentID: internal.MatchNoParent,
+		Name:          "GET /hello",
+		ParentID:      internal.MatchNoParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"nr.apdexPerfZone":             "S",
 			"httpResponseCode":             "200",
@@ -162,8 +163,9 @@ func TestReturnsHTTPError(t *testing.T) {
 		NumErrors: 1,
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{{
-		Name:     "GET /hello",
-		ParentID: internal.MatchNoParent,
+		Name:          "GET /hello",
+		ParentID:      internal.MatchNoParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"nr.apdexPerfZone": "F",
 			"httpResponseCode": "418",
@@ -196,8 +198,9 @@ func TestReturnsError(t *testing.T) {
 		NumErrors: 1,
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{{
-		Name:     "GET /hello",
-		ParentID: internal.MatchNoParent,
+		Name:          "GET /hello",
+		ParentID:      internal.MatchNoParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"nr.apdexPerfZone": "F",
 			"httpResponseCode": "500",
@@ -230,8 +233,9 @@ func TestResponseCode(t *testing.T) {
 		NumErrors: 1,
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{{
-		Name:     "GET /hello",
-		ParentID: internal.MatchNoParent,
+		Name:          "GET /hello",
+		ParentID:      internal.MatchNoParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"nr.apdexPerfZone":             "F",
 			"httpResponseCode":             "418",

--- a/v4/integrations/nrecho-v4/nrecho_test.go
+++ b/v4/integrations/nrecho-v4/nrecho_test.go
@@ -38,8 +38,9 @@ func TestBasicRoute(t *testing.T) {
 		IsWeb: true,
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{{
-		Name:     "GET /hello",
-		ParentID: internal.MatchNoParent,
+		Name:          "GET /hello",
+		ParentID:      internal.MatchNoParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"nr.apdexPerfZone":             "S",
 			"httpResponseCode":             "200",
@@ -162,8 +163,9 @@ func TestReturnsHTTPError(t *testing.T) {
 		NumErrors: 1,
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{{
-		Name:     "GET /hello",
-		ParentID: internal.MatchNoParent,
+		Name:          "GET /hello",
+		ParentID:      internal.MatchNoParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"nr.apdexPerfZone": "F",
 			"httpResponseCode": "418",
@@ -196,8 +198,9 @@ func TestReturnsError(t *testing.T) {
 		NumErrors: 1,
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{{
-		Name:     "GET /hello",
-		ParentID: internal.MatchNoParent,
+		Name:          "GET /hello",
+		ParentID:      internal.MatchNoParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"nr.apdexPerfZone": "F",
 			"httpResponseCode": "500",
@@ -230,8 +233,9 @@ func TestResponseCode(t *testing.T) {
 		NumErrors: 1,
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{{
-		Name:     "GET /hello",
-		ParentID: internal.MatchNoParent,
+		Name:          "GET /hello",
+		ParentID:      internal.MatchNoParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"nr.apdexPerfZone":             "F",
 			"httpResponseCode":             "418",

--- a/v4/integrations/nrgin/nrgin_test.go
+++ b/v4/integrations/nrgin/nrgin_test.go
@@ -261,8 +261,9 @@ func TestStatusCodes(t *testing.T) {
 		t.Error("wrong response code", response.Code)
 	}
 	app.ExpectSpanEvents(t, []internal.WantSpan{{
-		Name:     txnName,
-		ParentID: internal.MatchNoParent,
+		Name:          txnName,
+		ParentID:      internal.MatchNoParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"nr.apdexPerfZone":             internal.MatchAnything,
 			"httpResponseCode":             expectCode,
@@ -308,8 +309,9 @@ func TestNoResponseBody(t *testing.T) {
 		t.Error("wrong response code", response.Code)
 	}
 	app.ExpectSpanEvents(t, []internal.WantSpan{{
-		Name:     txnName,
-		ParentID: internal.MatchNoParent,
+		Name:          txnName,
+		ParentID:      internal.MatchNoParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"nr.apdexPerfZone": internal.MatchAnything,
 			"httpResponseCode": expectCode,

--- a/v4/integrations/nrgrpc/nrgrpc_client_test.go
+++ b/v4/integrations/nrgrpc/nrgrpc_client_test.go
@@ -117,8 +117,9 @@ func TestUnaryClientInterceptor(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "gRPC TestApplication/DoUnaryUnary bufnet",
-			ParentID: internal.MatchAnyParent,
+			Name:          "gRPC TestApplication/DoUnaryUnary bufnet",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":  "http",
 				"component": "gRPC",
@@ -127,8 +128,9 @@ func TestUnaryClientInterceptor(t *testing.T) {
 			},
 		},
 		{
-			Name:     "UnaryUnary",
-			ParentID: internal.MatchNoParent,
+			Name:          "UnaryUnary",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":         "generic",
 				"transaction.name": "OtherTransaction/Go/UnaryUnary",
@@ -209,8 +211,9 @@ func TestUnaryStreamClientInterceptor(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "gRPC TestApplication/DoUnaryStream bufnet",
-			ParentID: internal.MatchAnyParent,
+			Name:          "gRPC TestApplication/DoUnaryStream bufnet",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":  "http",
 				"component": "gRPC",
@@ -219,8 +222,9 @@ func TestUnaryStreamClientInterceptor(t *testing.T) {
 			},
 		},
 		{
-			Name:     "UnaryStream",
-			ParentID: internal.MatchNoParent,
+			Name:          "UnaryStream",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":         "generic",
 				"transaction.name": "OtherTransaction/Go/UnaryStream",
@@ -299,8 +303,9 @@ func TestStreamUnaryClientInterceptor(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "gRPC TestApplication/DoStreamUnary bufnet",
-			ParentID: internal.MatchAnyParent,
+			Name:          "gRPC TestApplication/DoStreamUnary bufnet",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":  "http",
 				"component": "gRPC",
@@ -309,8 +314,9 @@ func TestStreamUnaryClientInterceptor(t *testing.T) {
 			},
 		},
 		{
-			Name:     "StreamUnary",
-			ParentID: internal.MatchNoParent,
+			Name:          "StreamUnary",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":         "generic",
 				"transaction.name": "OtherTransaction/Go/StreamUnary",
@@ -402,8 +408,9 @@ func TestStreamStreamClientInterceptor(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "gRPC TestApplication/DoStreamStream bufnet",
-			ParentID: internal.MatchAnyParent,
+			Name:          "gRPC TestApplication/DoStreamStream bufnet",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":  "http",
 				"component": "gRPC",
@@ -412,8 +419,9 @@ func TestStreamStreamClientInterceptor(t *testing.T) {
 			},
 		},
 		{
-			Name:     "StreamStream",
-			ParentID: internal.MatchNoParent,
+			Name:          "StreamStream",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":         "generic",
 				"transaction.name": "OtherTransaction/Go/StreamStream",
@@ -559,8 +567,9 @@ func TestClientStreamingError(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "UnaryStream",
-			ParentID: internal.MatchNoParent,
+			Name:          "UnaryStream",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":         "generic",
 				"transaction.name": "OtherTransaction/Go/UnaryStream",

--- a/v4/integrations/nrgrpc/nrgrpc_server_test.go
+++ b/v4/integrations/nrgrpc/nrgrpc_server_test.go
@@ -84,8 +84,9 @@ func TestUnaryServerInterceptor(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "DoUnaryUnary",
-			ParentID: internal.MatchAnyParent,
+			Name:          "DoUnaryUnary",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"guid":                        internal.MatchAnything,
 				"nr.apdexPerfZone":            internal.MatchAnything,
@@ -107,16 +108,18 @@ func TestUnaryServerInterceptor(t *testing.T) {
 			},
 		},
 		{
-			Name:     "TestApplication/DoUnaryUnary",
-			ParentID: internal.MatchAnyParent,
+			Name:          "TestApplication/DoUnaryUnary",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category": "generic",
 				"parentId": internal.MatchAnything,
 			},
 		},
 		{
-			Name:     "gRPC TestApplication/DoUnaryUnary bufnet",
-			ParentID: internal.MatchAnyParent,
+			Name:          "gRPC TestApplication/DoUnaryUnary bufnet",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":                    "generic",
 				"transaction.name":            "WebTransaction/Go/TestApplication/DoUnaryUnary",
@@ -168,8 +171,9 @@ func TestUnaryServerInterceptorError(t *testing.T) {
 		{Name: "WebTransactionTotalTime/Go/TestApplication/DoUnaryUnaryError", Scope: "", Forced: false, Data: nil},
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{{
-		Name:     "TestApplication/DoUnaryUnaryError",
-		ParentID: internal.MatchNoParent,
+		Name:          "TestApplication/DoUnaryUnaryError",
+		ParentID:      internal.MatchNoParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"guid":                        internal.MatchAnything,
 			"nr.apdexPerfZone":            internal.MatchAnything,
@@ -254,8 +258,9 @@ func TestUnaryStreamServerInterceptor(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "DoUnaryStream",
-			ParentID: internal.MatchAnyParent,
+			Name:          "DoUnaryStream",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"guid":                        internal.MatchAnything,
 				"nr.apdexPerfZone":            internal.MatchAnything,
@@ -277,16 +282,18 @@ func TestUnaryStreamServerInterceptor(t *testing.T) {
 			},
 		},
 		{
-			Name:     "TestApplication/DoUnaryStream",
-			ParentID: internal.MatchAnyParent,
+			Name:          "TestApplication/DoUnaryStream",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category": "generic",
 				"parentId": internal.MatchAnything,
 			},
 		},
 		{
-			Name:     "gRPC TestApplication/DoUnaryStream bufnet",
-			ParentID: internal.MatchAnyParent,
+			Name:          "gRPC TestApplication/DoUnaryStream bufnet",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":                    "generic",
 				"transaction.name":            "WebTransaction/Go/TestApplication/DoUnaryStream",
@@ -353,8 +360,9 @@ func TestStreamUnaryServerInterceptor(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "DoStreamUnary",
-			ParentID: internal.MatchAnyParent,
+			Name:          "DoStreamUnary",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"guid":                        internal.MatchAnything,
 				"nr.apdexPerfZone":            internal.MatchAnything,
@@ -376,16 +384,18 @@ func TestStreamUnaryServerInterceptor(t *testing.T) {
 			},
 		},
 		{
-			Name:     "TestApplication/DoStreamUnary",
-			ParentID: internal.MatchAnyParent,
+			Name:          "TestApplication/DoStreamUnary",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category": "generic",
 				"parentId": internal.MatchAnything,
 			},
 		},
 		{
-			Name:     "gRPC TestApplication/DoStreamUnary bufnet",
-			ParentID: internal.MatchAnyParent,
+			Name:          "gRPC TestApplication/DoStreamUnary bufnet",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":                    "generic",
 				"transaction.name":            "WebTransaction/Go/TestApplication/DoStreamUnary",
@@ -465,8 +475,9 @@ func TestStreamStreamServerInterceptor(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "DoStreamStream",
-			ParentID: internal.MatchAnyParent,
+			Name:          "DoStreamStream",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"guid":                        internal.MatchAnything,
 				"nr.apdexPerfZone":            internal.MatchAnything,
@@ -488,16 +499,18 @@ func TestStreamStreamServerInterceptor(t *testing.T) {
 			},
 		},
 		{
-			Name:     "TestApplication/DoStreamStream",
-			ParentID: internal.MatchAnyParent,
+			Name:          "TestApplication/DoStreamStream",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category": "generic",
 				"parentId": internal.MatchAnything,
 			},
 		},
 		{
-			Name:     "gRPC TestApplication/DoStreamStream bufnet",
-			ParentID: internal.MatchAnyParent,
+			Name:          "gRPC TestApplication/DoStreamStream bufnet",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":                    "generic",
 				"transaction.name":            "WebTransaction/Go/TestApplication/DoStreamStream",
@@ -553,8 +566,9 @@ func TestStreamServerInterceptorError(t *testing.T) {
 		{Name: "WebTransactionTotalTime/Go/TestApplication/DoUnaryStreamError", Scope: "", Forced: false, Data: nil},
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{{
-		Name:     "TestApplication/DoUnaryStreamError",
-		ParentID: internal.MatchNoParent,
+		Name:          "TestApplication/DoUnaryStreamError",
+		ParentID:      internal.MatchNoParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"guid":                        internal.MatchAnything,
 			"nr.apdexPerfZone":            internal.MatchAnything,

--- a/v4/integrations/nrhttprouter/nrhttprouter_test.go
+++ b/v4/integrations/nrhttprouter/nrhttprouter_test.go
@@ -99,8 +99,9 @@ func TestHandle(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "GET /hello/:name",
-			ParentID: internal.MatchNoParent,
+			Name:          "GET /hello/:name",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"nr.apdexPerfZone": internal.MatchAnything,
 				"color":            "purple",
@@ -140,8 +141,9 @@ func TestHandler(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "GET /hello/",
-			ParentID: internal.MatchNoParent,
+			Name:          "GET /hello/",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"nr.apdexPerfZone": internal.MatchAnything,
 				"color":            "purple",
@@ -224,8 +226,9 @@ func TestNotFound(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "NotFound",
-			ParentID: internal.MatchNoParent,
+			Name:          "NotFound",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"nr.apdexPerfZone": internal.MatchAnything,
 				"color":            "purple",

--- a/v4/integrations/nrmicro/nrmicro_test.go
+++ b/v4/integrations/nrmicro/nrmicro_test.go
@@ -190,8 +190,9 @@ func testClientCallWithTransaction(c client.Client, t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "Micro TestHandler.Method testing",
-			ParentID: internal.MatchAnyParent,
+			Name:          "Micro TestHandler.Method testing",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":  "http",
 				"component": "Micro",
@@ -200,8 +201,9 @@ func testClientCallWithTransaction(c client.Client, t *testing.T) {
 			},
 		},
 		{
-			Name:     "name",
-			ParentID: internal.MatchNoParent,
+			Name:          "name",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":         "generic",
 				"transaction.name": "OtherTransaction/Go/name",
@@ -344,16 +346,18 @@ func TestClientPublishWithTransaction(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "topic send",
-			ParentID: internal.MatchAnyParent,
+			Name:          "topic send",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category": "generic",
 				"parentId": internal.MatchAnything,
 			},
 		},
 		{
-			Name:     "name",
-			ParentID: internal.MatchNoParent,
+			Name:          "name",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":         "generic",
 				"transaction.name": "OtherTransaction/Go/name",
@@ -508,8 +512,9 @@ func TestClientStreamWrapperWithTransaction(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "Micro TestHandler.StreamingMethod testing",
-			ParentID: internal.MatchAnyParent,
+			Name:          "Micro TestHandler.StreamingMethod testing",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":  "http",
 				"component": "Micro",
@@ -518,8 +523,9 @@ func TestClientStreamWrapperWithTransaction(t *testing.T) {
 			},
 		},
 		{
-			Name:     "name",
-			ParentID: internal.MatchNoParent,
+			Name:          "name",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":         "generic",
 				"transaction.name": "OtherTransaction/Go/name",
@@ -591,16 +597,18 @@ func TestServerWrapperWithApp(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "Method",
-			ParentID: internal.MatchAnyParent,
+			Name:          "Method",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category": "generic",
 				"parentId": internal.MatchAnything,
 			},
 		},
 		{
-			Name:     "TestHandler.Method",
-			ParentID: internal.MatchAnyParent,
+			Name:          "TestHandler.Method",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":                      "generic",
 				"transaction.name":              "WebTransaction/Go/TestHandler.Method",
@@ -622,8 +630,9 @@ func TestServerWrapperWithApp(t *testing.T) {
 			},
 		},
 		{
-			Name:     "Micro TestHandler.Method testing",
-			ParentID: internal.MatchAnyParent,
+			Name:          "Micro TestHandler.Method testing",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"guid":                          internal.MatchAnything,
 				"priority":                      internal.MatchAnything,
@@ -694,8 +703,9 @@ func TestServerWrapperWithAppReturnsError(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "TestHandlerWithError.Method",
-			ParentID: internal.MatchNoParent,
+			Name:          "TestHandlerWithError.Method",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":                         "generic",
 				"transaction.name":                 "WebTransaction/Go/TestHandlerWithError.Method",
@@ -725,8 +735,9 @@ func TestServerWrapperWithAppReturnsError(t *testing.T) {
 		},
 	}})
 	app.ExpectSpanEvents(t, []internal.WantSpan{{
-		Name:     "TestHandlerWithError.Method",
-		ParentID: internal.MatchNoParent,
+		Name:          "TestHandlerWithError.Method",
+		ParentID:      internal.MatchNoParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"guid":                          internal.MatchAnything,
 			"priority":                      internal.MatchAnything,
@@ -788,8 +799,9 @@ func TestServerWrapperWithAppReturnsNonMicroError(t *testing.T) {
 		{Name: "Apdex", Scope: "", Forced: true, Data: nil},
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{{
-		Name:     "TestHandlerWithNonMicroError.Method",
-		ParentID: internal.MatchNoParent,
+		Name:          "TestHandlerWithNonMicroError.Method",
+		ParentID:      internal.MatchNoParent,
+		SkipAttrsTest: true,
 		Attributes: map[string]interface{}{
 			"guid":                          internal.MatchAnything,
 			"priority":                      internal.MatchAnything,
@@ -898,8 +910,9 @@ func TestServerSubscribe(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "segment",
-			ParentID: internal.MatchAnyParent,
+			Name:          "segment",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category": "generic",
 				"name":     "Custom/segment",
@@ -907,8 +920,9 @@ func TestServerSubscribe(t *testing.T) {
 			},
 		},
 		{
-			Name:     "topic receive",
-			ParentID: internal.MatchAnyParent,
+			Name:          "topic receive",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":                 "generic",
 				"transaction.name":         "OtherTransaction/Go/Message/Micro/Topic/Named/topic",
@@ -924,8 +938,9 @@ func TestServerSubscribe(t *testing.T) {
 			},
 		},
 		{
-			Name:     "topic send",
-			ParentID: internal.MatchAnyParent,
+			Name:          "topic send",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"guid":                     internal.MatchAnything,
 				"parent.account":           123,
@@ -1000,8 +1015,9 @@ func TestServerSubscribeWithError(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "topic receive",
-			ParentID: internal.MatchNoParent,
+			Name:          "topic receive",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":                         "generic",
 				"name":                             "OtherTransaction/Go/Message/Micro/Topic/Named/topic",

--- a/v4/integrations/nrmongo/nrmongo_test.go
+++ b/v4/integrations/nrmongo/nrmongo_test.go
@@ -150,8 +150,9 @@ func TestMonitor(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "'commName' on 'collName' using 'MongoDB'",
-			ParentID: internal.MatchAnyParent,
+			Name:          "'commName' on 'collName' using 'MongoDB'",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"sampled":       true,
 				"category":      "datastore",
@@ -166,8 +167,9 @@ func TestMonitor(t *testing.T) {
 			},
 		},
 		{
-			Name:     "txnName",
-			ParentID: internal.MatchNoParent,
+			Name:          "txnName",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"transaction.name": "OtherTransaction/Go/txnName",
 				"sampled":          true,

--- a/v4/integrations/nrnats/test/nrnats_test.go
+++ b/v4/integrations/nrnats/test/nrnats_test.go
@@ -90,16 +90,18 @@ func TestStartPublishSegmentBasic(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "mysubject send",
-			ParentID: internal.MatchAnyParent,
+			Name:          "mysubject send",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category": "generic",
 				"parentId": internal.MatchAnything,
 			},
 		},
 		{
-			Name:     "testing",
-			ParentID: internal.MatchNoParent,
+			Name:          "testing",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"category":         "generic",
 				"transaction.name": "OtherTransaction/Go/testing",
@@ -163,8 +165,9 @@ func TestSubWrapper(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "subject2 receive",
-			ParentID: internal.MatchNoParent,
+			Name:          "subject2 receive",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"guid":               internal.MatchAnything,
 				"priority":           internal.MatchAnything,

--- a/v4/integrations/nrstan/test/nrstan_test.go
+++ b/v4/integrations/nrstan/test/nrstan_test.go
@@ -87,8 +87,9 @@ func TestSubWrapper(t *testing.T) {
 	})
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "sample.subject2 receive",
-			ParentID: internal.MatchNoParent,
+			Name:          "sample.subject2 receive",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"guid":               internal.MatchAnything,
 				"priority":           internal.MatchAnything,

--- a/v4/internal/expect.go
+++ b/v4/internal/expect.go
@@ -99,12 +99,17 @@ type WantTxn struct {
 
 // WantSpan is a span or transaction expectation.
 type WantSpan struct {
-	Name       string
-	SpanID     string
-	TraceID    string
-	ParentID   string
-	Kind       string
-	Attributes map[string]interface{}
+	Name     string
+	SpanID   string
+	TraceID  string
+	ParentID string
+	Kind     string
+	// SkipAttrsTest indicates whether checks for attributes should be skipped.
+	// TODO: This allows us to skip testing attributes in integrations for now.
+	// The field should be removed once all segment and transaction level attributes
+	// have been added.
+	SkipAttrsTest bool
+	Attributes    map[string]interface{}
 }
 
 // Expect exposes methods that allow for testing whether the correct data was

--- a/v4/internal/integrationsupport/integrationsupport_test.go
+++ b/v4/internal/integrationsupport/integrationsupport_test.go
@@ -36,8 +36,9 @@ func TestSuccess(t *testing.T) {
 
 	app.ExpectSpanEvents(t, []internal.WantSpan{
 		{
-			Name:     "mySegment",
-			ParentID: internal.MatchAnyParent,
+			Name:          "mySegment",
+			ParentID:      internal.MatchAnyParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"parentId":                         internal.MatchAnything,
 				"category":                         "generic",
@@ -45,8 +46,9 @@ func TestSuccess(t *testing.T) {
 			},
 		},
 		{
-			Name:     "hello",
-			ParentID: internal.MatchNoParent,
+			Name:          "hello",
+			ParentID:      internal.MatchNoParent,
+			SkipAttrsTest: true,
 			Attributes: map[string]interface{}{
 				"transaction.name": "OtherTransaction/Go/hello",
 				"category":         "generic",

--- a/v4/internal/otel_expect.go
+++ b/v4/internal/otel_expect.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"go.opentelemetry.io/otel/api/kv"
 	"go.opentelemetry.io/otel/api/trace/testtrace"
 )
 
@@ -49,6 +50,23 @@ func spansMatch(want WantSpan, span *testtrace.Span) error {
 		if kind := span.SpanKind().String(); kind != want.Kind {
 			return fmt.Errorf("Incorrect kind for span '%s':\n\texpect=%s actual=%s",
 				name, want.Kind, kind)
+		}
+	}
+	if want.Attributes != nil {
+		foundAttrs := span.Attributes()
+		if len(foundAttrs) != len(want.Attributes) {
+			return fmt.Errorf("Incorrect number of attributes for span '%s':\n\texpect=%d actual=%d",
+				name, len(want.Attributes), len(foundAttrs))
+		}
+		for k, v := range want.Attributes {
+			if foundVal, ok := foundAttrs[kv.Key(k)]; ok {
+				if f := foundVal.AsInterface(); f != v {
+					return fmt.Errorf("Incorrect value for attr '%s' on span '%s':\n\texpect=%s actual=%s",
+						k, name, v, f)
+				}
+			} else {
+				return fmt.Errorf("Attr '%s' not found on span '%s'", k, name)
+			}
 		}
 	}
 	return nil

--- a/v4/internal/otel_expect.go
+++ b/v4/internal/otel_expect.go
@@ -52,7 +52,7 @@ func spansMatch(want WantSpan, span *testtrace.Span) error {
 				name, want.Kind, kind)
 		}
 	}
-	if want.Attributes != nil {
+	if !want.SkipAttrsTest && want.Attributes != nil {
 		foundAttrs := span.Attributes()
 		if len(foundAttrs) != len(want.Attributes) {
 			return fmt.Errorf("Incorrect number of attributes for span '%s':\n\texpect=%d actual=%d",

--- a/v4/newrelic/segments.go
+++ b/v4/newrelic/segments.go
@@ -170,7 +170,15 @@ func (s *span) isEnded() bool {
 //
 // The key must contain fewer than than 255 bytes.  The value must be a
 // number, string, or boolean.
-func (s *Segment) AddAttribute(key string, val interface{}) {}
+func (s *Segment) AddAttribute(key string, val interface{}) {
+	if s == nil {
+		return
+	}
+	if s.StartTime.span == nil {
+		return
+	}
+	s.StartTime.Span.SetAttribute(key, val)
+}
 
 // End finishes the segment.
 func (s *Segment) End() {
@@ -188,7 +196,15 @@ func (s *Segment) End() {
 //
 // The key must contain fewer than than 255 bytes.  The value must be a
 // number, string, or boolean.
-func (s *DatastoreSegment) AddAttribute(key string, val interface{}) {}
+func (s *DatastoreSegment) AddAttribute(key string, val interface{}) {
+	if s == nil {
+		return
+	}
+	if s.StartTime.span == nil {
+		return
+	}
+	s.StartTime.Span.SetAttribute(key, val)
+}
 
 // End finishes the datastore segment.
 func (s *DatastoreSegment) End() {
@@ -218,7 +234,15 @@ func (s *DatastoreSegment) name() string {
 //
 // The key must contain fewer than than 255 bytes.  The value must be a
 // number, string, or boolean.
-func (s *ExternalSegment) AddAttribute(key string, val interface{}) {}
+func (s *ExternalSegment) AddAttribute(key string, val interface{}) {
+	if s == nil {
+		return
+	}
+	if s.StartTime.span == nil {
+		return
+	}
+	s.StartTime.Span.SetAttribute(key, val)
+}
 
 // End finishes the external segment.
 func (s *ExternalSegment) End() {
@@ -295,7 +319,15 @@ func (s *ExternalSegment) method() string {
 //
 // The key must contain fewer than than 255 bytes.  The value must be a
 // number, string, or boolean.
-func (s *MessageProducerSegment) AddAttribute(key string, val interface{}) {}
+func (s *MessageProducerSegment) AddAttribute(key string, val interface{}) {
+	if s == nil {
+		return
+	}
+	if s.StartTime.span == nil {
+		return
+	}
+	s.StartTime.Span.SetAttribute(key, val)
+}
 
 // End finishes the message segment.
 func (s *MessageProducerSegment) End() {

--- a/v4/newrelic/transaction.go
+++ b/v4/newrelic/transaction.go
@@ -103,7 +103,15 @@ func (txn *Transaction) NoticeError(err error) {}
 //
 // For more information, see:
 // https://docs.newrelic.com/docs/agents/manage-apm-agents/agent-metrics/collect-custom-attributes
-func (txn *Transaction) AddAttribute(key string, value interface{}) {}
+func (txn *Transaction) AddAttribute(key string, value interface{}) {
+	if txn == nil {
+		return
+	}
+	if txn.rootSpan == nil {
+		return
+	}
+	txn.rootSpan.Span.SetAttribute(key, value)
+}
 
 // SetWebRequestHTTP marks the transaction as a web transaction.  If
 // the request is non-nil, SetWebRequestHTTP will additionally collect

--- a/v4/newrelic/transaction_test.go
+++ b/v4/newrelic/transaction_test.go
@@ -324,3 +324,55 @@ func TestSetWebRequestHTTPAcceptDTHeaders(t *testing.T) {
 			txnParentID, remoteSpanID)
 	}
 }
+
+func TestTransactionAddAttribute(t *testing.T) {
+	app := newTestApp(t)
+	txn := app.StartTransaction("transaction")
+	txn.AddAttribute("attr-string", "this is a string")
+	txn.AddAttribute("attr-float-32", float32(1.5))
+	txn.AddAttribute("attr-float-64", float64(2.5))
+	txn.AddAttribute("attr-int", int(2))
+	txn.AddAttribute("attr-int-8", int8(3))
+	txn.AddAttribute("attr-int-16", int16(4))
+	txn.AddAttribute("attr-int-32", int32(5))
+	txn.AddAttribute("attr-int-64", int64(6))
+	txn.AddAttribute("attr-uint", uint(7))
+	txn.AddAttribute("attr-uint-8", uint8(8))
+	txn.AddAttribute("attr-uint-16", uint16(9))
+	txn.AddAttribute("attr-uint-32", uint32(10))
+	txn.AddAttribute("attr-uint-64", uint64(11))
+	txn.AddAttribute("attr-uint-ptr", uintptr(12))
+	txn.AddAttribute("attr-bool", true)
+	txn.End()
+
+	app.ExpectSpanEvents(t, []internal.WantSpan{
+		{
+			Name: "transaction",
+			Attributes: map[string]interface{}{
+				"attr-string":   "this is a string",
+				"attr-float-32": float32(1.5),
+				"attr-float-64": float64(2.5),
+				"attr-int":      int64(2),
+				"attr-int-8":    int64(3),
+				"attr-int-16":   int64(4),
+				"attr-int-32":   int32(5),
+				"attr-int-64":   int64(6),
+				"attr-uint":     uint64(7),
+				"attr-uint-8":   uint64(8),
+				"attr-uint-16":  uint64(9),
+				"attr-uint-32":  uint32(10),
+				"attr-uint-64":  uint64(11),
+				"attr-uint-ptr": uint64(12),
+				"attr-bool":     true,
+			},
+		},
+	})
+}
+
+func TestNilTransactionAddAttribute(t *testing.T) {
+	// AddAttribute APIs don't panic when used on nil txn
+	var txn *Transaction
+	txn.AddAttribute("color", "purple")
+	txn = new(Transaction)
+	txn.AddAttribute("color", "purple")
+}


### PR DESCRIPTION
Implements all `*.AddAttribute` APIs and tests to make sure those APIs work as expected.

What is not included here is testing for attributes in integration packages. Because I wished to use the `app.ExpectSpanEvents` method for testing, I had to find a way to state specifically when I wanted attributes to be tested and when not. This is why I added the `SkipAttrsTest` field to `WantSpan`. Once all transaction and segment level attributes (ie we've completed work to add "intrinsic" and "agent" attributes) we should remove this field.