### PR TITLE
Add span attributes for message producer segments.

### DIFF
--- a/v4/newrelic/segments.go
+++ b/v4/newrelic/segments.go
@@ -147,9 +147,9 @@ type MessageDestinationType string
 // These message destination type constants are used in for the
 // MessageSegment.DestinationType field.
 const (
-	MessageQueue    MessageDestinationType = "Queue"
-	MessageTopic    MessageDestinationType = "Topic"
-	MessageExchange MessageDestinationType = "Exchange"
+	MessageQueue    MessageDestinationType = "queue"
+	MessageTopic    MessageDestinationType = "topic"
+	MessageExchange MessageDestinationType = "exchange"
 )
 
 func (s *span) end() {
@@ -450,8 +450,20 @@ func (s *MessageProducerSegment) End() {
 	if s.StartTime.isEnded() {
 		return
 	}
+	s.addAttributes(s.StartTime.Span.SetAttribute)
 	s.StartTime.Span.SetName(s.name())
 	s.StartTime.end()
+}
+
+func (s *MessageProducerSegment) addAttributes(setter func(string, interface{})) {
+	setter("messaging.system", valOrUnknown(s.Library))
+	setter("messaging.destination", valOrUnknown(s.DestinationName))
+	if s.DestinationType != "" {
+		setter("messaging.destination_kind", string(s.DestinationType))
+	}
+	if s.DestinationTemporary {
+		setter("messaging.temp_destination", true)
+	}
 }
 
 func (s *MessageProducerSegment) name() string {

--- a/v4/newrelic/segments.go
+++ b/v4/newrelic/segments.go
@@ -225,12 +225,12 @@ func (s *DatastoreSegment) End() {
 		return
 	}
 
-	s.addAttributes(s.StartTime.Span.SetAttribute)
+	s.addRequiredAttributes(s.StartTime.Span.SetAttribute)
 	s.StartTime.Span.SetName(s.name())
 	s.StartTime.end()
 }
 
-func (s *DatastoreSegment) addAttributes(setter func(string, interface{})) {
+func (s *DatastoreSegment) addRequiredAttributes(setter func(string, interface{})) {
 	setter("db.system", valOrUnknown(string(s.Product)))
 	setter("db.statement", valOrUnknown(s.statement()))
 	setter("db.operation", valOrUnknown(s.Operation))
@@ -303,7 +303,7 @@ func (s *ExternalSegment) End() {
 	if s.StartTime.isEnded() {
 		return
 	}
-	s.addAttributes(s.StartTime.Span.SetAttributes)
+	s.addRequiredAttributes(s.StartTime.Span.SetAttributes)
 	s.StartTime.Span.SetName(s.name())
 	s.setSpanStatus(s.StartTime.Span.SetStatus)
 	s.StartTime.end()
@@ -325,7 +325,7 @@ func (s *ExternalSegment) setSpanStatus(setter func(codes.Code, string)) {
 	}
 }
 
-func (s *ExternalSegment) addAttributes(setter func(...kv.KeyValue)) {
+func (s *ExternalSegment) addRequiredAttributes(setter func(...kv.KeyValue)) {
 	req := s.Request
 	if s.Response != nil && s.Response.Request != nil {
 		req = s.Response.Request
@@ -450,12 +450,12 @@ func (s *MessageProducerSegment) End() {
 	if s.StartTime.isEnded() {
 		return
 	}
-	s.addAttributes(s.StartTime.Span.SetAttribute)
+	s.addRequiredAttributes(s.StartTime.Span.SetAttribute)
 	s.StartTime.Span.SetName(s.name())
 	s.StartTime.end()
 }
 
-func (s *MessageProducerSegment) addAttributes(setter func(string, interface{})) {
+func (s *MessageProducerSegment) addRequiredAttributes(setter func(string, interface{})) {
 	setter("messaging.system", valOrUnknown(s.Library))
 	setter("messaging.destination", valOrUnknown(s.DestinationName))
 	if s.DestinationType != "" {

--- a/v4/newrelic/segments_test.go
+++ b/v4/newrelic/segments_test.go
@@ -788,6 +788,10 @@ func TestSegmentsAddAttribute(t *testing.T) {
 					StartTime: txn.StartSegmentNow(),
 				}
 			},
+			extraAttrs: map[string]interface{}{
+				"messaging.system":      "unknown",
+				"messaging.destination": "unknown",
+			},
 		},
 	}
 
@@ -1354,6 +1358,61 @@ func TestExternalSegmentSpanStatus(t *testing.T) {
 			if actStr != test.str {
 				t.Errorf("Incorrect string recorded:\n\texpect=%s actual=%s",
 					test.str, actStr)
+			}
+		})
+	}
+}
+
+func TestMessageProducerSegmentAttributes(t *testing.T) {
+	testcases := []struct {
+		name  string
+		seg   *MessageProducerSegment
+		attrs map[string]interface{}
+	}{
+		{
+			name: "empty segment",
+			seg:  &MessageProducerSegment{},
+			attrs: map[string]interface{}{
+				"messaging.system":      "unknown",
+				"messaging.destination": "unknown",
+			},
+		},
+		{
+			name: "complete segment",
+			seg: &MessageProducerSegment{
+				Library:              "kafka",
+				DestinationType:      MessageQueue,
+				DestinationName:      "mydestination",
+				DestinationTemporary: true,
+			},
+			attrs: map[string]interface{}{
+				"messaging.system":           "kafka",
+				"messaging.destination":      "mydestination",
+				"messaging.destination_kind": "queue",
+				"messaging.temp_destination": true,
+			},
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			attrs := make(map[string]interface{})
+			test.seg.addAttributes(func(k string, v interface{}) {
+				attrs[k] = v
+			})
+
+			if len(attrs) != len(test.attrs) {
+				t.Errorf("Incorrect number of attrs created:\n\texpect=%d actual=%d",
+					len(test.attrs), len(attrs))
+			}
+			for expK, expV := range test.attrs {
+				actV, ok := attrs[expK]
+				if !ok {
+					t.Errorf("Attribute '%s' not found", expK)
+				} else if actV != expV {
+					t.Errorf("Incorrect value for attribute '%s':\n\texpect=%s actual=%s",
+						expK, expV, actV)
+				}
 			}
 		})
 	}

--- a/v4/newrelic/segments_test.go
+++ b/v4/newrelic/segments_test.go
@@ -1003,7 +1003,7 @@ func TestDatastoreSegmentAttributes(t *testing.T) {
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
 			attrs := make(map[string]interface{})
-			test.seg.addAttributes(func(k string, v interface{}) {
+			test.seg.addRequiredAttributes(func(k string, v interface{}) {
 				attrs[k] = v
 			})
 
@@ -1251,7 +1251,7 @@ func TestExternalSegmentAttributes(t *testing.T) {
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
 			attrs := make(map[string]interface{})
-			test.seg.addAttributes(func(keyValues ...kv.KeyValue) {
+			test.seg.addRequiredAttributes(func(keyValues ...kv.KeyValue) {
 				for _, keyValue := range keyValues {
 					attrs[string(keyValue.Key)] = keyValue.Value.AsInterface()
 				}
@@ -1397,7 +1397,7 @@ func TestMessageProducerSegmentAttributes(t *testing.T) {
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
 			attrs := make(map[string]interface{})
-			test.seg.addAttributes(func(k string, v interface{}) {
+			test.seg.addRequiredAttributes(func(k string, v interface{}) {
 				attrs[k] = v
 			})
 


### PR DESCRIPTION
Based on the [open telemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/messaging.md) for messaging. This adds attributes to our `MessageProducerSegment`s.

The specification also says we should be including `net.peer.name`, `net.peer.ip`, and `net.peer.port`. However, our `MessageProducerSegment` does not have fields for these. Adding them would mean adding two new fields onto the segment type plus updating our instrumentation for micro and nats/stan to include these. That is outside the scope of this MMF.