### PR TITLE
Improve testing from datastore metrics.

### DIFF
--- a/v4/integrations/nrredis-v7/nrredis_test.go
+++ b/v4/integrations/nrredis-v7/nrredis_test.go
@@ -40,10 +40,10 @@ func TestPing(t *testing.T) {
 		{Name: "OtherTransactionTotalTime", Forced: nil},
 		{Name: "Datastore/all", Forced: nil},
 		{Name: "Datastore/allOther", Forced: nil},
-		{Name: "Datastore/Redis/all", Forced: nil},
-		{Name: "Datastore/Redis/allOther", Forced: nil},
-		{Name: "Datastore/operation/Redis/ping", Forced: nil},
-		{Name: "Datastore/operation/Redis/ping", Scope: "OtherTransaction/Go/txnName", Forced: nil},
+		{Name: "Datastore/redis/all", Forced: nil},
+		{Name: "Datastore/redis/allOther", Forced: nil},
+		{Name: "Datastore/operation/redis/ping", Forced: nil},
+		{Name: "Datastore/operation/redis/ping", Scope: "OtherTransaction/Go/txnName", Forced: nil},
 	})
 }
 
@@ -69,11 +69,11 @@ func TestPingWithOptionsAndAddress(t *testing.T) {
 		{Name: "OtherTransactionTotalTime", Forced: nil},
 		{Name: "Datastore/all", Forced: nil},
 		{Name: "Datastore/allOther", Forced: nil},
-		{Name: "Datastore/Redis/all", Forced: nil},
-		{Name: "Datastore/Redis/allOther", Forced: nil},
-		{Name: "Datastore/instance/Redis/myhost/myport", Forced: nil},
-		{Name: "Datastore/operation/Redis/ping", Forced: nil},
-		{Name: "Datastore/operation/Redis/ping", Scope: "OtherTransaction/Go/txnName", Forced: nil},
+		{Name: "Datastore/redis/all", Forced: nil},
+		{Name: "Datastore/redis/allOther", Forced: nil},
+		{Name: "Datastore/instance/redis/myhost/myport", Forced: nil},
+		{Name: "Datastore/operation/redis/ping", Forced: nil},
+		{Name: "Datastore/operation/redis/ping", Scope: "OtherTransaction/Go/txnName", Forced: nil},
 	})
 }
 

--- a/v4/internal/otel_expect.go
+++ b/v4/internal/otel_expect.go
@@ -2,6 +2,8 @@ package internal
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 
 	"go.opentelemetry.io/otel/api/kv"
@@ -13,7 +15,7 @@ type OpenTelemetryExpect struct {
 	Spans *testtrace.StandardSpanRecorder
 }
 
-func spansMatch(want WantSpan, span *testtrace.Span) error {
+func spansMatch(want WantSpan, span *testtrace.Span, exactAttrs bool) error {
 	name := span.Name()
 	if want.Name != "" {
 		if name != want.Name {
@@ -54,13 +56,13 @@ func spansMatch(want WantSpan, span *testtrace.Span) error {
 	}
 	if !want.SkipAttrsTest && want.Attributes != nil {
 		foundAttrs := span.Attributes()
-		if len(foundAttrs) != len(want.Attributes) {
+		if exactAttrs && len(foundAttrs) != len(want.Attributes) {
 			return fmt.Errorf("Incorrect number of attributes for span '%s':\n\texpect=%d actual=%d",
 				name, len(want.Attributes), len(foundAttrs))
 		}
 		for k, v := range want.Attributes {
 			if foundVal, ok := foundAttrs[kv.Key(k)]; ok {
-				if f := foundVal.AsInterface(); f != v {
+				if f := foundVal.AsInterface(); v != MatchAnything && f != v {
 					return fmt.Errorf("Incorrect value for attr '%s' on span '%s':\n\texpect=%s actual=%s",
 						k, name, v, f)
 				}
@@ -90,16 +92,16 @@ func (e *OpenTelemetryExpect) ExpectSpanEvents(t Validator, want []WantSpan) {
 		return
 	}
 	for i := 0; i < len(want); i++ {
-		if err := spansMatch(want[i], spans[i]); err != nil {
+		if err := spansMatch(want[i], spans[i], true); err != nil {
 			t.Error(err)
 		}
 	}
 }
 
-func (e *OpenTelemetryExpect) expectSpanPresent(t Validator, want WantSpan) {
+func (e *OpenTelemetryExpect) expectSpanPresent(t Validator, want WantSpan, exactAttrs bool) {
 	t.Helper()
 	for _, span := range e.spans() {
-		if err := spansMatch(want, span); err == nil {
+		if err := spansMatch(want, span, exactAttrs); err == nil {
 			return
 		}
 	}
@@ -127,6 +129,17 @@ func (e *OpenTelemetryExpect) ExpectErrorEvents(t Validator, want []WantEvent) {
 // ExpectMetrics TODO
 func (e *OpenTelemetryExpect) ExpectMetrics(t Validator, want []WantMetric) {
 	t.Helper()
+	var hasDsSpan bool
+	dsSpan := WantSpan{
+		ParentID: MatchAnyParent,
+		Attributes: map[string]interface{}{
+			"db.collection": MatchAnything,
+			"db.operation":  MatchAnything,
+			"db.statement":  MatchAnything,
+			"db.system":     MatchAnything,
+		},
+	}
+
 	for _, metric := range want {
 		if strings.HasPrefix(metric.Name, "WebTransaction/Go/") {
 			name := strings.TrimPrefix(metric.Name, "WebTransaction/Go/")
@@ -138,9 +151,8 @@ func (e *OpenTelemetryExpect) ExpectMetrics(t Validator, want []WantMetric) {
 			span := WantSpan{
 				Name: name,
 			}
-			e.expectSpanPresent(t, span)
-		}
-		if strings.HasPrefix(metric.Name, "OtherTransaction/Go/") {
+			e.expectSpanPresent(t, span, true)
+		} else if strings.HasPrefix(metric.Name, "OtherTransaction/Go/") {
 			name := strings.TrimPrefix(metric.Name, "OtherTransaction/Go/")
 			if strings.HasPrefix(name, "Message/") {
 				if split := strings.SplitN(name, "/", 5); len(split) == 5 {
@@ -150,62 +162,90 @@ func (e *OpenTelemetryExpect) ExpectMetrics(t Validator, want []WantMetric) {
 			span := WantSpan{
 				Name: name,
 			}
-			e.expectSpanPresent(t, span)
-		}
-		if strings.HasPrefix(metric.Name, "External/") {
+			e.expectSpanPresent(t, span, true)
+		} else if strings.HasPrefix(metric.Name, "External/") {
 			if split := strings.SplitN(metric.Name, "/", 4); len(split) == 4 {
 				name := split[2] + " " + split[3] + " " + split[1]
 				span := WantSpan{
 					Name:     name,
 					ParentID: MatchAnyParent,
 				}
-				e.expectSpanPresent(t, span)
+				e.expectSpanPresent(t, span, true)
 			}
-		}
-		if strings.HasPrefix(metric.Name, "Datastore/statement/") && metric.Scope == "" {
+		} else if strings.HasPrefix(metric.Name, "Datastore/statement/") && metric.Scope == "" {
 			if split := strings.SplitN(metric.Name, "/", 5); len(split) == 5 {
-				name := fmt.Sprintf("'%s' on '%s' using '%s'", split[4], split[3], split[2])
-				span := WantSpan{
-					Name:     name,
-					ParentID: MatchAnyParent,
+				hasDsSpan = true
+				prod, coll, op := split[2], split[3], split[4]
+				name := fmt.Sprintf("'%s' on '%s' using '%s'", op, coll, prod)
+				dsSpan.Name = name
+				dsSpan.Attributes["db.collection"] = coll
+				dsSpan.Attributes[dbnameKey(prod)] = MatchAnything
+				dsSpan.Attributes["db.operation"] = op
+				dsSpan.Attributes["db.statement"] = name
+				dsSpan.Attributes["db.system"] = prod
+			}
+		} else if strings.HasPrefix(metric.Name, "Datastore/operation/") {
+			if split := strings.SplitN(metric.Name, "/", 4); len(split) == 4 {
+				hasDsSpan = true
+				prod, op := split[2], split[3]
+				dsSpan.Attributes[dbnameKey(prod)] = MatchAnything
+				dsSpan.Attributes["db.operation"] = op
+				dsSpan.Attributes["db.system"] = prod
+			}
+		} else if strings.HasPrefix(metric.Name, "Datastore/instance/") {
+			if split := strings.SplitN(metric.Name, "/", 5); len(split) == 5 {
+				hasDsSpan = true
+				prod, host, ipStr := split[2], split[3], split[4]
+				dsSpan.Attributes["db.system"] = prod
+				if ip, err := strconv.Atoi(ipStr); err == nil {
+					dsSpan.Attributes["net.peer.port"] = int64(ip)
 				}
-				e.expectSpanPresent(t, span)
+				if net.ParseIP(host) != nil {
+					dsSpan.Attributes["net.peer.ip"] = host
+				} else {
+					dsSpan.Attributes["net.peer.name"] = host
+				}
 			}
-		}
-		if strings.HasPrefix(metric.Name, "Datastore/operation/") {
-			span := WantSpan{
-				// Since we do not know the table name we can not infer the
-				// span name.
-				Name:     "",
-				ParentID: MatchAnyParent,
-			}
-			e.expectSpanPresent(t, span)
-		}
-		if strings.HasPrefix(metric.Name, "Custom/") && metric.Scope == "" {
+		} else if strings.HasPrefix(metric.Name, "Custom/") && metric.Scope == "" {
 			if split := strings.SplitN(metric.Name, "/", 2); len(split) == 2 {
 				span := WantSpan{
 					Name:     split[1],
 					ParentID: MatchAnyParent,
 				}
-				e.expectSpanPresent(t, span)
+				e.expectSpanPresent(t, span, true)
 			}
-		}
-		if strings.HasPrefix(metric.Name, "TransportDuration") &&
+		} else if strings.HasPrefix(metric.Name, "TransportDuration") &&
 			strings.HasSuffix(metric.Name, "/all") {
 			// The presence of this metric is used to test that a
 			// distributed trace payload is successfully received.
 			e.expectSpanPayloadReceived(t)
-		}
-		if strings.HasPrefix(metric.Name, "MessageBroker") && metric.Scope == "" {
+		} else if strings.HasPrefix(metric.Name, "MessageBroker") && metric.Scope == "" {
 			if split := strings.SplitN(metric.Name, "/", 6); len(split) == 6 {
 				name := split[5] + " send"
 				span := WantSpan{
 					Name:     name,
 					ParentID: MatchAnyParent,
 				}
-				e.expectSpanPresent(t, span)
+				e.expectSpanPresent(t, span, true)
 			}
 		}
+	}
+
+	if hasDsSpan {
+		e.expectSpanPresent(t, dsSpan, false)
+	}
+}
+
+func dbnameKey(product string) string {
+	switch product {
+	case "cassandra":
+		return "db.cassandra.keyspace"
+	case "redis":
+		return "db.redis.database_index"
+	case "mongodb":
+		return "db.mongodb.collection"
+	default:
+		return "db.name"
 	}
 }
 
@@ -226,7 +266,7 @@ func (e *OpenTelemetryExpect) ExpectTxnMetrics(t Validator, want WantTxn) {
 		Name:     want.Name,
 		ParentID: MatchNoParent,
 	}
-	if err := spansMatch(exp, spans[0]); err != nil {
+	if err := spansMatch(exp, spans[0], true); err != nil {
 		t.Error(err)
 	}
 }

--- a/v4/newrelic/segments_test.go
+++ b/v4/newrelic/segments_test.go
@@ -985,6 +985,34 @@ func TestDatastoreSegmentAttributes(t *testing.T) {
 			},
 		},
 		{
+			name: "host is localhost",
+			seg: &DatastoreSegment{
+				Host: "localhost",
+			},
+			attrs: map[string]interface{}{
+				"db.collection": "unknown",
+				"db.name":       "unknown",
+				"db.operation":  "unknown",
+				"db.statement":  "'unknown' on 'unknown' using 'unknown'",
+				"db.system":     "unknown",
+				"net.peer.name": thisHost,
+			},
+		},
+		{
+			name: "host is 127.0.0.1",
+			seg: &DatastoreSegment{
+				Host: "127.0.0.1",
+			},
+			attrs: map[string]interface{}{
+				"db.collection": "unknown",
+				"db.name":       "unknown",
+				"db.operation":  "unknown",
+				"db.statement":  "'unknown' on 'unknown' using 'unknown'",
+				"db.system":     "unknown",
+				"net.peer.name": thisHost,
+			},
+		},
+		{
 			name: "port is a path",
 			seg: &DatastoreSegment{
 				PortPathOrID: "/this/is/a/path/to/a/socket.sock",


### PR DESCRIPTION
There are three metrics that we used to create for datastore segments. With all three of those combined we can create a pretty clear picture of what the corresponding datastore span would look like. This pull request goes about making that happen.

Along the way I uncovered one issue with our datastore attributes. In the v3 agent anytime we'd see "localhost" or similar for a hostname on datastores, we'd replace it with the hostname of the local machine. I made that update here as well. And with that all the tests passed!