### PR TITLE
Add Go version 1.15 to tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,70 +103,72 @@ jobs:
           - go-version: 1.13.x
             dirs: v3/newrelic,v3/internal,v3/examples
           - go-version: 1.14.x
+            dirs: v3/newrelic,v3/internal,v3/examples
+          - go-version: 1.15.x
             dirs: v3/newrelic,v3/internal,v3/examples,v3/integrations/logcontext
 
           # v3 integrations
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/logcontext/nrlogrusplugin
             extratesting: go get -u github.com/sirupsen/logrus@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrawssdk-v1
             extratesting: go get -u github.com/aws/aws-sdk-go@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrawssdk-v2
             extratesting: go get -u github.com/aws/aws-sdk-go-v2@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrecho-v3
             # Test against the latest v3 Echo:
             extratesting: go get -u github.com/labstack/echo@v3
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrecho-v4
             extratesting: go get -u github.com/labstack/echo/v4@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrelasticsearch-v7
             extratesting: go get -u github.com/elastic/go-elasticsearch/v7@7.x
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrgin
             extratesting: go get -u github.com/gin-gonic/gin@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrgorilla
             extratesting: go get -u github.com/gorilla/mux@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrgraphgophers
             extratesting: go get -u github.com/graph-gophers/graphql-go@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrlogrus
             extratesting: go get -u github.com/sirupsen/logrus@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrlogxi
             extratesting: go get -u github.com/mgutz/logxi@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrpkgerrors
             extratesting: go get -u github.com/pkg/errors@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrlambda
             extratesting: go get -u github.com/aws/aws-lambda-go@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrmysql
             extratesting: go get -u github.com/go-sql-driver/mysql@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrpq
             extratesting: go get -u github.com/lib/pq@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrpq/example/sqlx
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrredis-v7
             extratesting: go get -u github.com/go-redis/redis/v7@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrsqlite3
             extratesting: go get -u github.com/mattn/go-sqlite3@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrsnowflake
             extratesting: go get -u github.com/snowflakedb/gosnowflake@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrgrpc
             extratesting: go get -u google.golang.org/grpc@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrmicro
             # As of Dec 2019, there is a race condition in when using go-micro@master
             # in their logging system.  Instead, we'll test against the latest
@@ -174,36 +176,36 @@ jobs:
             # As of Jan 2019, it is impossible to go get the latest micro version.
             # As of June 2020, confirmed errors still result
             # extratesting: go get -u github.com/micro/go-micro@latest
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrnats
             extratesting: go get -u github.com/nats-io/nats.go/@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrnats/test
             extratesting: go get -u github.com/nats-io/nats.go/@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrstan
             extratesting: go get -u github.com/nats-io/stan.go/@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrstan/test
             extratesting: go get -u github.com/nats-io/stan.go/@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrstan/examples
             extratesting: go get -u github.com/nats-io/stan.go/@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/logcontext
             extratesting: go get -u github.com/sirupsen/logrus@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrzap
             extratesting: go get -u go.uber.org/zap@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrhttprouter
             extratesting: go get -u github.com/julienschmidt/httprouter@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrb3
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrmongo
             extratesting: go get -u go.mongodb.org/mongo-driver@master
-          - go-version: 1.14.x
+          - go-version: 1.15.x
             dirs: v3/integrations/nrgraphqlgo,v3/integrations/nrgraphqlgo/example
             extratesting: go get -u github.com/graphql-go/graphql@master
 

--- a/build-script.sh
+++ b/build-script.sh
@@ -4,7 +4,7 @@
 set -x
 set -e
 
-LATEST_VERSION="go1.14"
+LATEST_VERSION="go1.15"
 
 # NOTE: Once we get rid of travis for good, this whole section can be removed
 # along with the .travis.yml file.


### PR DESCRIPTION
Now that Go version 1.15 has been released, we should make sure to test against it.

Addresses issue #212.