### PR TITLE
Fix go-fmt issue

### DIFF
--- a/v3/newrelic/internal_set_web_request_test.go
+++ b/v3/newrelic/internal_set_web_request_test.go
@@ -253,7 +253,7 @@ func TestSetWebRequestWithDistributedTracing(t *testing.T) {
 			"request.method":           "GET",
 			"request.uri":              "http://www.newrelic.com",
 			"request.headers.host":     "myhost",
-    },
+		},
 	}})
 }
 


### PR DESCRIPTION
A white space issue was introduced directly into master accidentally. This fixes that issue.