### PR TITLE
Move SQL query parsing into separate goroutine

### DIFF
--- a/v3/newrelic/sql_driver_test.go
+++ b/v3/newrelic/sql_driver_test.go
@@ -8,6 +8,7 @@ package newrelic
 import (
 	"context"
 	"database/sql/driver"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -86,9 +87,11 @@ var (
 			segment.DatabaseName = fields[2]
 		},
 		ParseQuery: func(segment *DatastoreSegment, query string) {
+			fmt.Println("%%%%% Parsing query")
 			fields := strings.Split(query, ",")
 			segment.Operation = fields[0]
 			segment.Collection = fields[1]
+			fmt.Println("%%%%% Query parsed")
 		},
 	}
 )

--- a/v3/newrelic/sqlparse/sqlparse.go
+++ b/v3/newrelic/sqlparse/sqlparse.go
@@ -4,6 +4,7 @@
 package sqlparse
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 

--- a/v3/newrelic/sqlparse/sqlparse_test.go
+++ b/v3/newrelic/sqlparse/sqlparse_test.go
@@ -192,3 +192,20 @@ func TestExtractTable(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkSqlParsing(b *testing.B) {
+	var segment newrelic.DatastoreSegment
+	query := `SELECT DISTINCT account_id, envdata->>'Ruby version' as "Ruby version", count(envdata->>'Ruby version')
+	FROM env_data_by_month
+	WHERE language='ruby'
+	AND envdata->>'Ruby version' IS NOT NULL
+	GROUP BY account_id, envdata->>'Ruby version'
+	ORDER BY account_id;`
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		ParseQuery(&segment, query)
+	}
+}


### PR DESCRIPTION
This PR is not ready for merge, but I wanted to make some notes on it. The goal here is to take the heavy lifting of Regex SQL parsing and move it into a separate goroutine. Things left to do:

- [ ] The main issue is that right now the datastore segment isn't actually getting updated with the **operation/collection**. Perhaps I passed something by value instead of by reference? Those fields are getting parsed, and set on **a** segment according to my print statements it's just not getting set properly on the final segment.
- [ ] Do rigorous testing around  deadlocks/ensure data is correct if the segment is waiting when a harvest happens
- [ ] Check: is this acutally helpful in the `Prepare` case? It should help when actually making a call to a db using `Exec` or `Query`, but if it is only using `Prepare` then it might actually slow that down because it doesn't have a database call to wait for as well.
- [ ] I left my `fmt.Printf` statements in. Maybe they'll be helpful, maybe I'm just lazy. Anyway, those should be removed
- [ ] Rebase and change the base branch to `develop`. 