### PR TITLE
Optimize ParseQuery function

### DIFF
--- a/v3/newrelic/sqlparse/sqlparse.go
+++ b/v3/newrelic/sqlparse/sqlparse.go
@@ -4,50 +4,80 @@
 package sqlparse
 
 import (
+	"bytes"
 	"fmt"
-	"regexp"
 	"strings"
 	"unicode"
 
 	newrelic "github.com/newrelic/go-agent/v3/newrelic"
 )
 
+var (
+	operations = map[string]string{
+		"select":   "from",
+		"delete":   "from",
+		"insert":   "into",
+		"update":   "",
+		"call":     "",
+		"create":   "",
+		"drop":     "",
+		"show":     "",
+		"set":      "",
+		"exec":     "",
+		"execute":  "",
+		"alter":    "",
+		"commit":   "",
+		"rollback": "",
+	}
+	updateModifiers = map[string]interface{}{
+		"low_priority": nil,
+		"ignore":       nil,
+		"or":           nil,
+		"rollback":     nil,
+		"abort":        nil,
+		"replace":      nil,
+		"fail":         nil,
+		"only":         nil,
+	}
+)
+
+// Extracts the table name from the given string.
 func extractTable(s string) string {
-	s = extractTableRegex.ReplaceAllString(s, "")
 	if idx := strings.Index(s, "."); idx > 0 {
 		s = s[idx+1:]
 	}
-	return s
+
+	var buffer bytes.Buffer
+
+	for _, c := range s {
+		if unicode.IsSpace(c) || strings.ContainsRune("`'(){}[]\"", c) {
+			continue
+		} else {
+			buffer.WriteRune(c)
+		}
+	}
+
+	return buffer.String()
 }
 
-var (
-	basicTable        = `[^)(\]\[\}\{\s,;]+`
-	enclosedTable     = `[\[\(\{]` + `\s*` + basicTable + `\s*` + `[\]\)\}]`
-	tablePattern      = `(` + `\s+` + basicTable + `|` + `\s*` + enclosedTable + `)`
-	extractTableRegex = regexp.MustCompile(`[\s` + "`" + `"'\(\)\{\}\[\]]*`)
-	updateRegex       = regexp.MustCompile(`(?is)^update(?:\s+(?:low_priority|ignore|or|rollback|abort|replace|fail|only))*` + tablePattern)
-	sqlOperations     = map[string]*regexp.Regexp{
-		"select":   regexp.MustCompile(tablePattern),
-		"delete":   regexp.MustCompile(tablePattern),
-		"insert":   regexp.MustCompile(tablePattern),
-		"update":   updateRegex,
-		"call":     nil,
-		"create":   nil,
-		"drop":     nil,
-		"show":     nil,
-		"set":      nil,
-		"exec":     nil,
-		"execute":  nil,
-		"alter":    nil,
-		"commit":   nil,
-		"rollback": nil,
+// Returns a new string with trailing comments removed.
+func cutComment(query string) string {
+	query = skipSpace(query)
+	for i, c := range query {
+		if strings.HasPrefix(query[i:], "/*") || strings.HasPrefix(query[i:], "--") || c == ';' || c == '#' {
+			query = fmt.Sprintf("%s%s", query[:i], skipComment(query[i:]))
+			return cutComment(query)
+		}
 	}
-	firstWordRegex   = regexp.MustCompile(`^\w+`)
-	cCommentRegex    = regexp.MustCompile(`(?is)/\*.*?\*/`)
-	lineCommentRegex = regexp.MustCompile(`(?im)(?:--|#).*?$`)
-	sqlPrefixRegex   = regexp.MustCompile(`^[\s;]*`)
-)
+	return query
+}
 
+type sqlQuery struct {
+	q string
+	p uint64
+}
+
+// Returns a string slice of query without trailing spaces.
 func skipSpace(query string) string {
 	for i, c := range query {
 		if !unicode.IsSpace(c) {
@@ -57,6 +87,7 @@ func skipSpace(query string) string {
 	return ""
 }
 
+// Returns a string slice of query with trailing comments removed.
 func skipComment(query string) string {
 	query = skipSpace(query)
 
@@ -86,45 +117,44 @@ func skipComment(query string) string {
 	return query
 }
 
-func cutComment(query string) string {
-	query = skipSpace(query)
-	for i, _ := range query {
-		if strings.HasPrefix(query[i:], "/*") || strings.HasPrefix(query[i:], "--") || strings.HasPrefix(query[i:], ";") {
-			query = fmt.Sprintf("%s%s", query[:i], skipComment(query[i:]))
-			return cutComment(query)
-		}
-	}
-	return query
-}
-
+// Returns the first word and the remainder of the given string (with trailing
+// comments removed).
+//
+// A word is either sequence of letters and digits, or a single special
+// character.
 func firstWord(query string) (string, string) {
 	query = skipSpace(query)
 	for i, c := range query {
 		if !unicode.IsLetter(c) && !unicode.IsDigit(c) {
-			if unicode.IsSpace(c) || c == '(' || c == '[' || c == '{' {
-				return query[0:i], skipSpace(query[i+1:])
+			if unicode.IsSpace(c) || i != 0 {
+				return query[0:i], skipComment(query[i+1:])
 			} else {
-				return query[0 : i+1], skipSpace(query[i+1:])
+				return query[0 : i+1], skipComment(query[i+1:])
 			}
 		}
 	}
 	return query, ""
 }
 
-func firstWordOnlySpace(query string) (string, string) {
+// Returns the first token and the remainder of the given string (with trailing
+// comments removed).
+//
+// A token is either an expression surrounded by [], or the charater sequence
+// before the first space, '(', or '{'.
+func firstToken(query string) (string, string) {
 	query = skipSpace(query)
 
 	if strings.HasPrefix(query, "[") {
 		for i, c := range query {
 			if c == ']' {
-				return query[0 : i+1], skipSpace(query[i+1:])
+				return query[0 : i+1], skipComment(query[i+1:])
 			}
 		}
 	}
 
 	for i, c := range query {
-		if unicode.IsSpace(c) || (i != 0 && (c == '(' || c == ',' || c == '{')) {
-			return query[0:i], skipSpace(query[i+1:])
+		if unicode.IsSpace(c) || (i != 0 && strings.ContainsRune("({,", c)) {
+			return query[0:i], skipComment(query[i+1:])
 		}
 	}
 	return query, ""
@@ -139,78 +169,36 @@ func firstWordOnlySpace(query string) (string, string) {
 // Ability to correctly parse queries for other SQL databases is not
 // guaranteed.
 func ParseQuery(segment *newrelic.DatastoreSegment, query string) {
-	//fmt.Printf("### Original       : %v\n", query)
 	s := skipComment(query)
-	//fmt.Printf("### Skipped comment: %v\n", s)
 	op, s := firstWord(s)
-	op = strings.ToLower(op)
-	//fmt.Printf("### First word     : %v.\n", op)
-	fmt.Printf("")
-	op = cutComment(op)
-	if _, ok := sqlOperations[op]; ok {
+	op = strings.ToLower(cutComment(op))
+	if tablePrefix, ok := operations[op]; ok {
 		segment.Operation = op
-		if op == "select" || op == "delete" || op == "insert" {
-			var token string
-			if op == "insert" {
-				token = "into"
-			} else {
-				token = "from"
-			}
+		if tablePrefix != "" {
 			for {
-				s = skipComment(s)
-				from, next := firstWord(s)
-				next = skipComment(next)
-				s = next
-				//fmt.Printf("### query: %v, first word %v\n", query, from)
-				if strings.ToLower(from) == token {
-					table, next := firstWordOnlySpace(s)
-					//fmt.Printf("### s: %v\n", s)
-					//fmt.Printf("### table: %v, next: %v\n", table, next)
-					s = next
+				var token string
+				token, s = firstWord(s)
+				if token == "" {
+					break
+				}
+				if strings.ToLower(token) == tablePrefix {
+					var table string
+					table, s = firstToken(s)
 					segment.Collection = extractTable(cutComment(table))
-				} else if from == "" {
-					break
-				}
-			}
-		} else if op == "update" {
-			for {
-				modifiers := map[string]interface{}{
-					"low_priority": nil,
-					"ignore":       nil,
-					"or":           nil,
-					"rollback":     nil,
-					"abort":        nil,
-					"replace":      nil,
-					"fail":         nil,
-					"only":         nil,
-				}
-
-				s = skipComment(s)
-				from, next := firstWordOnlySpace(s)
-				next = skipComment(next)
-				s = next
-				//fmt.Printf("### query: %v, first word %v\n", query, from)
-				if _, ok := modifiers[strings.ToLower(from)]; ok {
-					continue
-				} else {
-					segment.Collection = extractTable(cutComment(from))
-					break
 				}
 			}
 		}
-	}
-}
-
-func ParseQuery2(segment *newrelic.DatastoreSegment, query string) {
-	s := cCommentRegex.ReplaceAllString(query, "")
-	s = lineCommentRegex.ReplaceAllString(s, "")
-	s = sqlPrefixRegex.ReplaceAllString(s, "")
-	op := strings.ToLower(firstWordRegex.FindString(query))
-	if rg, ok := sqlOperations[op]; ok {
-		segment.Operation = op
-		if nil != rg {
-			if m := rg.FindStringSubmatch(query); len(m) > 1 {
-				segment.Collection = extractTable(m[1])
+		if op == "update" {
+			for {
+				var token string
+				token, s = firstToken(s)
+				if token == "" {
+					break
+				}
+				if _, ok := updateModifiers[strings.ToLower(token)]; !ok {
+					segment.Collection = extractTable(cutComment(token))
+					break
+				}
 			}
 		}
 	}

--- a/v3/newrelic/sqlparse/sqlparse.go
+++ b/v3/newrelic/sqlparse/sqlparse.go
@@ -191,8 +191,7 @@ func ParseQuery(segment *newrelic.DatastoreSegment, query string) {
 					segment.Collection = extractTable(removeAllComments(table))
 				}
 			}
-		}
-		if op == "update" {
+		} else if op == "update" {
 			for {
 				token := sql.nextToken()
 				if token == "" {

--- a/v3/newrelic/sqlparse/sqlparse.go
+++ b/v3/newrelic/sqlparse/sqlparse.go
@@ -50,7 +50,7 @@ func extractTable(s string) string {
 	var buffer bytes.Buffer
 
 	for _, c := range s {
-		if unicode.IsSpace(c) || strings.ContainsRune("`'(){}[]\"", c) {
+		if unicode.IsSpace(c) || strings.ContainsRune("`'(){}[]\";", c) {
 			continue
 		} else {
 			buffer.WriteRune(c)

--- a/v3/newrelic/sqlparse/sqlparse.go
+++ b/v3/newrelic/sqlparse/sqlparse.go
@@ -4,8 +4,10 @@
 package sqlparse
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
+	"unicode"
 
 	newrelic "github.com/newrelic/go-agent/v3/newrelic"
 )
@@ -25,9 +27,9 @@ var (
 	extractTableRegex = regexp.MustCompile(`[\s` + "`" + `"'\(\)\{\}\[\]]*`)
 	updateRegex       = regexp.MustCompile(`(?is)^update(?:\s+(?:low_priority|ignore|or|rollback|abort|replace|fail|only))*` + tablePattern)
 	sqlOperations     = map[string]*regexp.Regexp{
-		"select":   regexp.MustCompile(`(?is)^.*?\sfrom` + tablePattern),
-		"delete":   regexp.MustCompile(`(?is)^.*?\sfrom` + tablePattern),
-		"insert":   regexp.MustCompile(`(?is)^.*?\sinto?` + tablePattern),
+		"select":   regexp.MustCompile(tablePattern),
+		"delete":   regexp.MustCompile(tablePattern),
+		"insert":   regexp.MustCompile(tablePattern),
 		"update":   updateRegex,
 		"call":     nil,
 		"create":   nil,
@@ -46,6 +48,88 @@ var (
 	sqlPrefixRegex   = regexp.MustCompile(`^[\s;]*`)
 )
 
+func skipSpace(query string) string {
+	for i, c := range query {
+		if !unicode.IsSpace(c) {
+			return query[i:]
+		}
+	}
+	return ""
+}
+
+func skipComment(query string) string {
+	query = skipSpace(query)
+
+	for {
+		if strings.HasPrefix(query, "/*") {
+			if commentEnd := strings.Index(query[2:], "*/"); commentEnd != -1 {
+				query = query[commentEnd+4:]
+				query = skipSpace(query)
+			} else {
+				return ""
+			}
+		} else if strings.HasPrefix(query, "--") {
+			if commentEnd := strings.Index(query[2:], "\n"); commentEnd != -1 {
+				query = query[commentEnd+3:]
+				query = skipSpace(query)
+			} else {
+				return ""
+			}
+		} else if strings.HasPrefix(query, ";") || strings.HasPrefix(query, "#") {
+			query = query[1:]
+			query = skipSpace(query)
+		} else {
+			break
+		}
+	}
+
+	return query
+}
+
+func cutComment(query string) string {
+	query = skipSpace(query)
+	for i, _ := range query {
+		if strings.HasPrefix(query[i:], "/*") || strings.HasPrefix(query[i:], "--") || strings.HasPrefix(query[i:], ";") {
+			query = fmt.Sprintf("%s%s", query[:i], skipComment(query[i:]))
+			return cutComment(query)
+		}
+	}
+	return query
+}
+
+func firstWord(query string) (string, string) {
+	query = skipSpace(query)
+	for i, c := range query {
+		if !unicode.IsLetter(c) && !unicode.IsDigit(c) {
+			if unicode.IsSpace(c) || c == '(' || c == '[' || c == '{' {
+				return query[0:i], skipSpace(query[i+1:])
+			} else {
+				return query[0 : i+1], skipSpace(query[i+1:])
+			}
+		}
+	}
+	return query, ""
+}
+
+func firstWordOnlySpace(query string) (string, string) {
+	query = skipSpace(query)
+
+	if strings.HasPrefix(query, "[") {
+		for i, c := range query {
+			if c == ']' {
+				return query[0 : i+1], skipSpace(query[i+1:])
+			}
+		}
+	}
+
+	for i, c := range query {
+		if unicode.IsSpace(c) || (i != 0 && (c == '(' || c == ',' || c == '{')) {
+			return query[0:i], skipSpace(query[i+1:])
+		}
+	}
+	return query, ""
+}
+
 // ParseQuery parses table and operation from the SQL query string.  It is
 // a helper meant to be used when writing database/sql driver instrumentation.
 // Check out full example usage here:
@@ -55,14 +139,77 @@ var (
 // Ability to correctly parse queries for other SQL databases is not
 // guaranteed.
 func ParseQuery(segment *newrelic.DatastoreSegment, query string) {
+	//fmt.Printf("### Original       : %v\n", query)
+	s := skipComment(query)
+	//fmt.Printf("### Skipped comment: %v\n", s)
+	op, s := firstWord(s)
+	op = strings.ToLower(op)
+	//fmt.Printf("### First word     : %v.\n", op)
+	fmt.Printf("")
+	op = cutComment(op)
+	if _, ok := sqlOperations[op]; ok {
+		segment.Operation = op
+		if op == "select" || op == "delete" || op == "insert" {
+			var token string
+			if op == "insert" {
+				token = "into"
+			} else {
+				token = "from"
+			}
+			for {
+				s = skipComment(s)
+				from, next := firstWord(s)
+				next = skipComment(next)
+				s = next
+				//fmt.Printf("### query: %v, first word %v\n", query, from)
+				if strings.ToLower(from) == token {
+					table, next := firstWordOnlySpace(s)
+					//fmt.Printf("### s: %v\n", s)
+					//fmt.Printf("### table: %v, next: %v\n", table, next)
+					s = next
+					segment.Collection = extractTable(cutComment(table))
+				} else if from == "" {
+					break
+				}
+			}
+		} else if op == "update" {
+			for {
+				modifiers := map[string]interface{}{
+					"low_priority": nil,
+					"ignore":       nil,
+					"or":           nil,
+					"rollback":     nil,
+					"abort":        nil,
+					"replace":      nil,
+					"fail":         nil,
+					"only":         nil,
+				}
+
+				s = skipComment(s)
+				from, next := firstWordOnlySpace(s)
+				next = skipComment(next)
+				s = next
+				//fmt.Printf("### query: %v, first word %v\n", query, from)
+				if _, ok := modifiers[strings.ToLower(from)]; ok {
+					continue
+				} else {
+					segment.Collection = extractTable(cutComment(from))
+					break
+				}
+			}
+		}
+	}
+}
+
+func ParseQuery2(segment *newrelic.DatastoreSegment, query string) {
 	s := cCommentRegex.ReplaceAllString(query, "")
 	s = lineCommentRegex.ReplaceAllString(s, "")
 	s = sqlPrefixRegex.ReplaceAllString(s, "")
-	op := strings.ToLower(firstWordRegex.FindString(s))
+	op := strings.ToLower(firstWordRegex.FindString(query))
 	if rg, ok := sqlOperations[op]; ok {
 		segment.Operation = op
 		if nil != rg {
-			if m := rg.FindStringSubmatch(s); len(m) > 1 {
+			if m := rg.FindStringSubmatch(query); len(m) > 1 {
 				segment.Collection = extractTable(m[1])
 			}
 		}

--- a/v3/newrelic/sqlparse/sqlparse.go
+++ b/v3/newrelic/sqlparse/sqlparse.go
@@ -60,7 +60,7 @@ func extractTable(s string) string {
 	return buffer.String()
 }
 
-// Returns a string slice of query without trailing spaces.
+// Returns a string slice of query without leading spaces.
 func skipSpace(query string) string {
 	for i, c := range query {
 		if !unicode.IsSpace(c) {
@@ -70,7 +70,7 @@ func skipSpace(query string) string {
 	return query
 }
 
-// Returns a string slice of query with trailing comments removed.
+// Returns a string slice of query with leading comments removed.
 func skipComment(query string) string {
 	query = skipSpace(query)
 
@@ -177,7 +177,7 @@ func (q *sqlTokenizer) nextToken() string {
 // guaranteed.
 func ParseQuery(segment *newrelic.DatastoreSegment, query string) {
 	sql := sqlTokenizer{query: query}
-	op := strings.ToLower(removeAllComments(sql.nextWord()))
+	op := strings.ToLower(sql.nextWord())
 	if tablePrefix, ok := operations[op]; ok {
 		segment.Operation = op
 		if tablePrefix != "" {

--- a/v3/newrelic/sqlparse/sqlparse.go
+++ b/v3/newrelic/sqlparse/sqlparse.go
@@ -77,15 +77,13 @@ func skipComment(query string) string {
 	if strings.HasPrefix(query, "/*") {
 		if commentEnd := strings.Index(query[2:], "*/"); commentEnd != -1 {
 			return skipComment(query[commentEnd+4:])
-		} else {
-			return ""
 		}
+		return ""
 	} else if strings.HasPrefix(query, "--") {
 		if commentEnd := strings.Index(query[2:], "\n"); commentEnd != -1 {
 			return skipComment(query[commentEnd+3:])
-		} else {
-			return ""
 		}
+		return ""
 	} else if strings.HasPrefix(query, ";") || strings.HasPrefix(query, "#") {
 		return skipComment(query[1:])
 	}

--- a/v3/newrelic/sqlparse/sqlparse.go
+++ b/v3/newrelic/sqlparse/sqlparse.go
@@ -79,12 +79,12 @@ func skipComment(query string) string {
 			return skipComment(query[commentEnd+4:])
 		}
 		return ""
-	} else if strings.HasPrefix(query, "--") {
-		if commentEnd := strings.Index(query[2:], "\n"); commentEnd != -1 {
-			return skipComment(query[commentEnd+3:])
+	} else if strings.HasPrefix(query, "--") || strings.HasPrefix(query, "#") {
+		if commentEnd := strings.Index(query[1:], "\n"); commentEnd != -1 {
+			return skipComment(query[commentEnd+2:])
 		}
 		return ""
-	} else if strings.HasPrefix(query, ";") || strings.HasPrefix(query, "#") {
+	} else if strings.HasPrefix(query, ";") {
 		return skipComment(query[1:])
 	}
 
@@ -95,8 +95,8 @@ func skipComment(query string) string {
 func removeAllComments(query string) string {
 	query = skipComment(query)
 	for i, c := range query {
-		if strings.HasPrefix(query[i:], "/*") || strings.HasPrefix(query[i:], "--") || c == ';' || c == '#' {
-			query = fmt.Sprintf("%s%s", query[:i], skipComment(query[i:]))
+		if strings.HasPrefix(query[i:], "/*") || strings.HasPrefix(query[i:], "--") || c == '#' {
+			query = fmt.Sprintf("%s %s", query[:i], skipComment(query[i:]))
 			return removeAllComments(query)
 		}
 	}
@@ -121,7 +121,7 @@ func (q *sqlTokenizer) nextWord() string {
 			var word string
 			if unicode.IsSpace(c) || i != 0 {
 				word = q.query[0:i]
-				q.query = q.query[i+1:]
+				q.query = q.query[i:]
 			} else {
 				word = q.query[0 : i+1]
 				q.query = q.query[i+1:]

--- a/v3/newrelic/sqlparse/sqlparse_test.go
+++ b/v3/newrelic/sqlparse/sqlparse_test.go
@@ -203,14 +203,14 @@ func TestSqlTokenizerNextWord(t *testing.T) {
 	} {
 		tokenizer := sqlTokenizer{input}
 
-		for i, word := range words {
+		for _, word := range words {
 			if next := tokenizer.nextWord(); word != next {
-				t.Errorf("%d query '%s': expected %s, got %s", i, input, word, next)
+				t.Errorf("query '%s': expected %s, got %s", input, word, next)
 			}
 		}
 
 		if next := tokenizer.nextWord(); next != "" {
-			t.Errorf("Expected empty word, got %s", next)
+			t.Errorf("query '%s': expected empty word, got %s", input, next)
 		}
 	}
 }
@@ -226,12 +226,12 @@ func TestSqlTokenizerNextToken(t *testing.T) {
 
 		for _, token := range tokens {
 			if next := tokenizer.nextToken(); token != next {
-				t.Errorf("Expected %s, got %s", token, next)
+				t.Errorf("query '%s': expected %s, got %s", input, token, next)
 			}
 		}
 
 		if next := tokenizer.nextToken(); next != "" {
-			t.Errorf("Expected empty token , got %s", next)
+			t.Errorf("query '%s': expected empty token , got %s", input, next)
 		}
 	}
 }
@@ -247,7 +247,7 @@ func TestRemoveAllComments(t *testing.T) {
 		"query# comment\nother":                             "query other",
 	} {
 		if result := removeAllComments(input); result != expected {
-			t.Errorf("Expected %s, got %s (for input %s)", expected, result, input)
+			t.Errorf("query '%s': expected %s, got %s (for input %s)", input, expected, result)
 		}
 	}
 }
@@ -263,7 +263,7 @@ func TestSkipComment(t *testing.T) {
 		" query":               "query",
 	} {
 		if result := skipComment(input); result != expected {
-			t.Errorf("Expected %s, got %s (for input %s)", expected, result, input)
+			t.Errorf("query '%s': expected %s, got %s (for input %s)", input, expected, result)
 		}
 	}
 }
@@ -276,7 +276,7 @@ func TestSkipSpace(t *testing.T) {
 		"\n query": "query",
 	} {
 		if result := skipSpace(input); result != expected {
-			t.Errorf("Expected %s, got %s (for input %s)", expected, result, input)
+			t.Errorf("query: '%s': expected %s, got %s", input, expected, result)
 		}
 	}
 }

--- a/v3/newrelic/sqlparse/sqlparse_test.go
+++ b/v3/newrelic/sqlparse/sqlparse_test.go
@@ -123,7 +123,7 @@ func TestLineComment(t *testing.T) {
 	}
 }
 
-func TestSemicolonPrefix(t *testing.T) {
+func TestSemicolon(t *testing.T) {
 	for _, tc := range []sqlTestcase{
 		{
 			Input:     `;select * from foo`,
@@ -138,6 +138,11 @@ func TestSemicolonPrefix(t *testing.T) {
 		{
 			Input: ` ;
 			SELECT * FROM foo`,
+			Operation: "select",
+			Table:     "foo",
+		},
+		{
+			Input:     `SELECT * FROM foo;`,
 			Operation: "select",
 			Table:     "foo",
 		},

--- a/v3/newrelic/sqlparse/sqlparse_test.go
+++ b/v3/newrelic/sqlparse/sqlparse_test.go
@@ -281,3 +281,20 @@ func TestSkipSpace(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkSqlParsing(b *testing.B) {
+	var segment newrelic.DatastoreSegment
+	query := `SELECT DISTINCT id, envdata->>'Go version' as "Go version", count(envdata->>'Go version')
+		FROM env_data_by_month
+		    WHERE language='go'
+			AND envdata->>'Go version' IS NOT NULL
+			    GROUP BY id, envdata->>'Go version'
+				ORDER BY id;`
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		ParseQuery(&segment, query)
+	}
+}

--- a/v3/newrelic/sqlparse/sqlparse_test.go
+++ b/v3/newrelic/sqlparse/sqlparse_test.go
@@ -195,11 +195,11 @@ func TestExtractTable(t *testing.T) {
 
 func TestSqlTokenizerNextWord(t *testing.T) {
 	for input, words := range map[string][]string{
-		"SELECT * FROM table":            []string{"SELECT", "*", "FROM", "table"},
-		"SELECT * FROM [ table ]":        []string{"SELECT", "*", "FROM", "[", "table", "]"},
-		"SELECT a,b FROM table":          []string{"SELECT", "a", ",", "b", "FROM", "table"},
-		"SELECT * FROM (SELECT COUNT())": []string{"SELECT", "*", "FROM", "(", "SELECT", "COUNT", "(", ")", ")"},
-		"UPDATE rollback{foo}":           []string{"UPDATE", "rollback", "{", "foo", "}"},
+		"SELECT * FROM table":            {"SELECT", "*", "FROM", "table"},
+		"SELECT * FROM [ table ]":        {"SELECT", "*", "FROM", "[", "table", "]"},
+		"SELECT a,b FROM table":          {"SELECT", "a", ",", "b", "FROM", "table"},
+		"SELECT * FROM (SELECT COUNT())": {"SELECT", "*", "FROM", "(", "SELECT", "COUNT", "(", ")", ")"},
+		"UPDATE rollback{foo}":           {"UPDATE", "rollback", "{", "foo", "}"},
 	} {
 		tokenizer := sqlTokenizer{input}
 
@@ -217,10 +217,10 @@ func TestSqlTokenizerNextWord(t *testing.T) {
 
 func TestSqlTokenizerNextToken(t *testing.T) {
 	for input, tokens := range map[string][]string{
-		"SELECT * FROM [ table ]":        []string{"SELECT", "*", "FROM", "[ table ]"},
-		"SELECT a,b FROM table":          []string{"SELECT", "a", "b", "FROM", "table"},
-		"SELECT * FROM (SELECT COUNT())": []string{"SELECT", "*", "FROM", "(SELECT", "COUNT", "))"},
-		"UPDATE rollback{foo}":           []string{"UPDATE", "rollback", "foo}"},
+		"SELECT * FROM [ table ]":        {"SELECT", "*", "FROM", "[ table ]"},
+		"SELECT a,b FROM table":          {"SELECT", "a", "b", "FROM", "table"},
+		"SELECT * FROM (SELECT COUNT())": {"SELECT", "*", "FROM", "(SELECT", "COUNT", "))"},
+		"UPDATE rollback{foo}":           {"UPDATE", "rollback", "foo}"},
 	} {
 		tokenizer := sqlTokenizer{input}
 

--- a/v3/newrelic/sqlparse/sqlparse_test.go
+++ b/v3/newrelic/sqlparse/sqlparse_test.go
@@ -247,7 +247,7 @@ func TestRemoveAllComments(t *testing.T) {
 		"query# comment\nother":                             "query other",
 	} {
 		if result := removeAllComments(input); result != expected {
-			t.Errorf("query '%s': expected %s, got %s (for input %s)", input, expected, result)
+			t.Errorf("query '%s': expected %s, got %s", input, expected, result)
 		}
 	}
 }
@@ -263,7 +263,7 @@ func TestSkipComment(t *testing.T) {
 		" query":               "query",
 	} {
 		if result := skipComment(input); result != expected {
-			t.Errorf("query '%s': expected %s, got %s (for input %s)", input, expected, result)
+			t.Errorf("query '%s': expected %s, got %s", input, expected, result)
 		}
 	}
 }

--- a/v3/newrelic/sqlparse/sqlparse_test.go
+++ b/v3/newrelic/sqlparse/sqlparse_test.go
@@ -243,8 +243,9 @@ func TestRemoveAllComments(t *testing.T) {
 		"query /* comment */":                               "query  ",
 		"query /* comment */ other":                         "query  other",
 		"query /* comment */ other /* other comment */ end": "query  other  end",
-		"query # comment":                                   "query  ",
-		"query# comment\nother":                             "query other",
+		"/* leading */ query /* comment */ other /* other comment */ end /* trailing */": "query  other  end  ",
+		"query # comment":       "query  ",
+		"query# comment\nother": "query other",
 	} {
 		if result := removeAllComments(input); result != expected {
 			t.Errorf("query '%s': expected %s, got %s", input, expected, result)


### PR DESCRIPTION
In some instances, usages of `regex` can be very slow. This can cause considerable overhead in the `ParseQuery` function, which can use up to 6 evaluations of regular expressions.

This PR replaces the regular expressions with plain string operations. The main part consists in introducing a naive SQL tokenizer, which can extract SQL tokens from a string.

All unit tests pass, and the new algorithm is about 3 times faster, some benchmarks show it to be almost 10 times faster:

```
pkg: github.com/newrelic/go-agent/v3/newrelic/sqlparse
BenchmarkSqlParsing-4                         30             35010 ns/op             296 B/op         36 allocs/op
BenchmarkSqlParsingWithRegex-4                 3            338403 ns/op            1946 B/op         14 allocs/op
```
