### PR TITLE
Implement Amazon's IMDSv2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+* To keep up with the latest security protocols implemented by Amazon Web
+  Services, the agent now uses AWS IMDSv2 to find utilization data.
+
 ## 3.9.0
 
 ### Changes

--- a/v3/internal/utilization/aws.go
+++ b/v3/internal/utilization/aws.go
@@ -17,7 +17,7 @@ const (
 	awsTokenEndpointPath = "/latest/api/token"
 	awsEndpoint          = "http://" + awsHostname + awsEndpointPath
 	awsTokenEndpoint     = "http://" + awsHostname + awsTokenEndpointPath
-	awsTokenTTL          = "60" // seconds this AWS utiliation session will last
+	awsTokenTTL          = "60" // seconds this AWS utilization session will last
 )
 
 type aws struct {
@@ -80,8 +80,9 @@ func getAWS(client *http.Client) (ret *aws, err error) {
 	// AWS' IMDSv2 requires us to get a token before requesting metadata.
 	awsToken, err := getAWSToken(client)
 	if err != nil {
-		ret = nil
-		err = unexpectedAWSErr{e: fmt.Errorf("error contacting AWS IMDSv2 token endpoint, %v", err)}
+		// No unexpectedAWSErr here: A timeout is usually going to
+		// happen.
+		return nil, err
 	}
 
 	//Add the header to the outbound request.

--- a/v3/internal/utilization/provider.go
+++ b/v3/internal/utilization/provider.go
@@ -14,8 +14,8 @@ import (
 
 // Constants from the spec.
 const (
-	maxFieldValueSize = 255             // The maximum value size, in bytes.
-	providerTimeout   = 1 * time.Second // The maximum time a HTTP provider may block.
+	maxFieldValueSize = 255                    // The maximum value size, in bytes.
+	providerTimeout   = 500 * time.Millisecond // The maximum time a HTTP provider may block.
 	lookupAddrTimeout = 500 * time.Millisecond
 )
 

--- a/v3/internal/utilization/provider_test.go
+++ b/v3/internal/utilization/provider_test.go
@@ -54,7 +54,13 @@ func (m *mockTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 		}
 	}
 
-	m.t.Errorf("Unknown request URI: %s", r.URL.String())
+	// Since this cross-agent test hacks the transport to check responses to
+	// the IMDS endpoint, this UN-hacks it for IMDSv2, where half the requests
+	// are going to the token-granting endpoint, not the information-gathering
+	// endpoint that's meant to be tested.
+	if r.URL.String() != "http://169.254.169.254/latest/api/token" {
+		m.t.Errorf("Unknown request URI: %s", r.URL.String())
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION
This implements a newer method of authentication to AWS instance metadata endpoints. 

Under IMDSv1, the agent simply called to an endpoint and received JSON with information about the instance size, availability zone, and other facts.

This newer IMDSv2 implements a session protocol. The agent calls two endpoints: one to get a session token that's valid for a specified time, and then the original endpoint with the session token to get the instance information.

As of this writing, AWS normally accepts both IMDSv1 and IMDSv2. A customer can tell AWS to only allow IMDSv2, so we're fine if we simply perform IMDSv2 calls exclusively.

Tests for these changes will need to be higher-level integration tests, since they rely on AWS services. Let me know if you think otherwise!

## Links
[Amazon's IMDSv2 Documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#configuring-instance-metadata-options)
[New Relic Java Agent Implementation](https://github.com/newrelic/newrelic-java-agent/blob/main/newrelic-agent/src/main/java/com/newrelic/agent/utilization/AWS.java)


## Details
One decision still in flight is what the timeout values should be for each call to the two endpoints. Since the original timeout was one second, I've split the difference and set the timeout for both calls to 500 milliseconds. These timeouts could be reduced, since the endpoints are reported to be very fast by the documentation above (< 10ms). Other New Relic language agents have other implementations, including a 100 millisecond timeout, and a back-off scheme using 15, 30, 60, 120, and 300 milliseconds.
