### PR TITLE
Integration package for CloudSQLProxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ package primitives can be found [here](GUIDE.md#datastore-segments).
 | [mattn/go-sqlite3](https://github.com/mattn/go-sqlite3) | [v3/integrations/nrsqlite3](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrsqlite3) | Instrument SQLite driver |
 | [snowflakedb/gosnowflake](https://github.com/snowflakedb/gosnowflake) | [v3/integrations/nrsnowflake](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrsnowflake) | Instrument Snowflake driver |
 | [mongodb/mongo-go-driver](https://github.com/mongodb/mongo-go-driver) | [v3/integrations/nrmongo](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrmongo) | Instrument MongoDB calls |
+| [cloudsqlproxy/proxy/dialers/postgres](https://github.com/GoogleCloudPlatform/cloudsql-proxy/tree/main/proxy/dialers/postgres) | [v3/integrations/nrcloudsqlpostgres](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrcloudsqlpostgres) | Instrument Cloud SQL Postgres calls |
 
 #### Logging
 

--- a/v3/integrations/nrcloudsqlpostgres/example/main.go
+++ b/v3/integrations/nrcloudsqlpostgres/example/main.go
@@ -1,0 +1,44 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"time"
+
+	_ "github.com/newrelic/go-agent/v3/integrations/nrcloudsqlpostgres"
+	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+)
+
+func main() {
+	// docker run --rm -e POSTGRES_PASSWORD=docker -p 5432:5432 postgres
+	db, err := sql.Open("nrcloudsqlpostgres", "host=project01:region01:instance01 port=5432 user=postgres dbname=postgres password=docker sslmode=disable")
+	if err != nil {
+		panic(err)
+	}
+
+	app, err := newrelic.NewApplication(
+		newrelic.ConfigAppName("Cloud SQL Postgres App"),
+		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+		newrelic.ConfigDebugLogger(os.Stdout),
+	)
+	if nil != err {
+		panic(err)
+	}
+	app.WaitForConnection(5 * time.Second)
+	txn := app.StartTransaction("postgresQuery")
+
+	ctx := newrelic.NewContext(context.Background(), txn)
+	row := db.QueryRowContext(ctx, "SELECT count(*) FROM pg_catalog.pg_tables")
+	var count int
+	row.Scan(&count)
+
+	txn.End()
+	app.Shutdown(5 * time.Second)
+
+	fmt.Println("number of entries in pg_catalog.pg_tables", count)
+}

--- a/v3/integrations/nrcloudsqlpostgres/example/sqlx/go.mod
+++ b/v3/integrations/nrcloudsqlpostgres/example/sqlx/go.mod
@@ -1,0 +1,17 @@
+// This sqlx example is a separate module to avoid adding sqlx dependency to the
+// nrpq go.mod file.
+
+module github.com/newrelic/go-agent/v3/integrations/nrcloudsqlpostgres/example/sqlx
+
+go 1.13
+
+require (
+	github.com/jmoiron/sqlx v1.2.0
+	github.com/GoogleCloudPlatform/cloudsql-proxy v1.19.2
+	github.com/newrelic/go-agent/v3 v3.3.0
+	github.com/newrelic/go-agent/v3/integrations/nrcloudsqlpostgres v0.0.0
+)
+
+replace github.com/newrelic/go-agent/v3 => ../../../../
+
+replace github.com/newrelic/go-agent/v3/integrations/nrcloudsqlpostgres => ../../

--- a/v3/integrations/nrcloudsqlpostgres/example/sqlx/main.go
+++ b/v3/integrations/nrcloudsqlpostgres/example/sqlx/main.go
@@ -1,0 +1,140 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// An application that illustrates how to instrument jmoiron/sqlx with DatastoreSegments
+//
+// To run this example, be sure the environment varible NEW_RELIC_LICENSE_KEY
+// is set to your license key.  Postgres must be running on the default port
+// 5432 and have a user "foo" and a database "bar".
+//
+// Adding instrumentation for the SQLx package is easy.  It means you can
+// make database calls without having to manually create DatastoreSegments.
+// Setup can be done in two steps:
+//
+// Set up your driver
+//
+// If you are using one of our currently supported database drivers (see
+// https://docs.newrelic.com/docs/agents/go-agent/get-started/go-agent-compatibility-requirements#frameworks),
+// follow the instructions on installing the driver.
+//
+// As an example, for the `lib/pq` driver, you will use the newrelic
+// integration's driver in place of the postgres driver.  If your code is using
+// sqlx.Open with `lib/pq` like this:
+//
+//	import (
+//		"github.com/jmoiron/sqlx"
+//		_ "github.com/lib/pq"
+//	)
+//
+//	func main() {
+//		db, err := sqlx.Open("cloudsqlpostgres", "host:project01:region01:instance01 user=pqgotest dbname=pqgotest sslmode=verify-full")
+//	}
+//
+// Then change the side-effect import to the integration package, and open
+// "nrpostgres" instead:
+//
+//	import (
+//		"github.com/jmoiron/sqlx"
+//		_ "github.com/newrelic/go-agent/v3/integrations/nrcloudsqlpostgres"
+//	)
+//
+//	func main() {
+//		db, err := sqlx.Open("nrcloudsqlpostgres", "host:project01:region01:instance01 user=pqgotest dbname=pqgotest sslmode=verify-full")
+//	}
+//
+// If you are not using one of the supported database drivers, use the
+// `InstrumentSQLDriver`
+// (https://godoc.org/github.com/newrelic/go-agent#InstrumentSQLDriver) API.
+// See
+// https://github.com/newrelic/go-agent/blob/master/v3/integrations/nrcloudsqlpostgres/nrmysql.go
+// for a full example.
+//
+// Add context to your database calls
+//
+// Next, you must provide a context containing a newrelic.Transaction to all
+// methods on sqlx.DB, sqlx.NamedStmt, sqlx.Stmt, and sqlx.Tx that make a
+// database call.  For example, instead of the following:
+//
+//	err := db.Get(&jason, "SELECT * FROM person WHERE first_name=$1", "Jason")
+//
+// Do this:
+//
+//	ctx := newrelic.NewContext(context.Background(), txn)
+//	err := db.GetContext(ctx, &jason, "SELECT * FROM person WHERE first_name=$1", "Jason")
+//
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/newrelic/go-agent/v3/integrations/nrcloudsqlpostgres"
+	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+)
+
+var schema = `
+CREATE TABLE person (
+    first_name text,
+    last_name text,
+    email text
+)`
+
+// Person is a person in the database
+type Person struct {
+	FirstName string `db:"first_name"`
+	LastName  string `db:"last_name"`
+	Email     string
+}
+
+func createApp() *newrelic.Application {
+	app, err := newrelic.NewApplication(
+		newrelic.ConfigAppName("SQLx"),
+		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+		newrelic.ConfigDebugLogger(os.Stdout),
+	)
+	if nil != err {
+		log.Fatalln(err)
+	}
+	if err := app.WaitForConnection(5 * time.Second); nil != err {
+		log.Fatalln(err)
+	}
+	return app
+}
+
+func main() {
+	// Create application
+	app := createApp()
+	defer app.Shutdown(10 * time.Second)
+	// Start a transaction
+	txn := app.StartTransaction("main")
+	defer txn.End()
+	// Add transaction to context
+	ctx := newrelic.NewContext(context.Background(), txn)
+
+	// Connect to database using the "nrpostgres" driver
+	db, err := sqlx.Connect("nrcloudsqlpostgres", "host=project01:region01:instance01 user=foo dbname=bar sslmode=disable")
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// Create database table if it does not exist already
+	// When the context is passed, DatastoreSegments will be created
+	db.ExecContext(ctx, schema)
+
+	// Add people to the database
+	// When the context is passed, DatastoreSegments will be created
+	tx := db.MustBegin()
+	tx.MustExecContext(ctx, "INSERT INTO person (first_name, last_name, email) VALUES ($1, $2, $3)", "Jason", "Moiron", "jmoiron@jmoiron.net")
+	tx.MustExecContext(ctx, "INSERT INTO person (first_name, last_name, email) VALUES ($1, $2, $3)", "John", "Doe", "johndoeDNE@gmail.net")
+	tx.Commit()
+
+	// Read from the database
+	// When the context is passed, DatastoreSegments will be created
+	people := []Person{}
+	db.SelectContext(ctx, &people, "SELECT * FROM person ORDER BY first_name ASC")
+	jason := Person{}
+	db.GetContext(ctx, &jason, "SELECT * FROM person WHERE first_name=$1", "Jason")
+}

--- a/v3/integrations/nrcloudsqlpostgres/go.mod
+++ b/v3/integrations/nrcloudsqlpostgres/go.mod
@@ -1,0 +1,9 @@
+module github.com/newrelic/go-agent/v3/integrations/nrcloudsqlpostgress
+
+go 1.13
+
+require (
+	github.com/GoogleCloudPlatform/cloudsql-proxy v1.19.1
+	// v3.3.0 includes the new location of ParseQuery
+	github.com/newrelic/go-agent/v3 v3.3.0
+)

--- a/v3/integrations/nrcloudsqlpostgres/nrcloudsqlpostgres.go
+++ b/v3/integrations/nrcloudsqlpostgres/nrcloudsqlpostgres.go
@@ -1,9 +1,9 @@
 // Copyright 2020 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// +build go1.10
+// +build go1.13
 
-// Package nrpq instruments https://github.com/lib/pq.
+// Package nrcloudsqlpostgres instruments https://github.com/GoogleCloudPlatform/cloudsql-proxy.
 //
 // Use this package to instrument your PostgreSQL calls without having to manually
 // create DatastoreSegments.  This is done in a two step process:
@@ -13,25 +13,22 @@
 // If your code is using sql.Open like this:
 //
 //	import (
-//		_ "github.com/lib/pq"
+//		_ "github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/dialers/postgres"
 //	)
 //
 //	func main() {
-//		db, err := sql.Open("postgres", "user=pqgotest dbname=pqgotest sslmode=verify-full")
+//		db, err := sql.Open("cloudsqlpostgres", "host=project:region:instance user=postgres dbname=postgres password=password sslmode=disable")
 //	}
 //
-// Then change the side-effect import to this package, and open "nrpostgres" instead:
+// Then change the side-effect import to this package, and open "nrcloudsqlpostgres" instead:
 //
 //	import (
 //		_ "salesloft.com/costello/core/newrelic/driver/nrcloudsqlproxy"
 //	)
 //
 //	func main() {
-//		db, err := sql.Open("nrcloudsqlproxy", "user=pqgotest dbname=pqgotest sslmode=verify-full")
+//		db, err := sql.Open("nrcloudsqlpostgres", "host=project:region:instance user=postgres dbname=postgres password=password sslmode=disable")
 //	}
-//
-// If your code is using pq.NewConnector, simply use nrpq.NewConnector
-// instead.
 //
 // 2. Provide a context containing a newrelic.Transaction to all exec and query
 // methods on sql.DB, sql.Conn, and sql.Tx.  This requires using the
@@ -55,7 +52,6 @@ package nrcloudsqlpostgres
 import (
 	"database/sql"
 	"os"
-	"path"
 	"regexp"
 	"strings"
 
@@ -122,11 +118,6 @@ func parseDSN(getenv func(string) string) func(*newrelic.DatastoreSegment, strin
 		}
 		if "" == ppoid {
 			ppoid = "5432"
-		}
-		if strings.HasPrefix(host, "/") {
-			// this is a unix socket
-			ppoid = path.Join(host, ".s.PGSQL."+ppoid)
-			host = "localhost"
 		}
 
 		s.Host = host

--- a/v3/integrations/nrcloudsqlpostgres/nrcloudsqlpostgres.go
+++ b/v3/integrations/nrcloudsqlpostgres/nrcloudsqlpostgres.go
@@ -1,0 +1,136 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// +build go1.10
+
+// Package nrpq instruments https://github.com/lib/pq.
+//
+// Use this package to instrument your PostgreSQL calls without having to manually
+// create DatastoreSegments.  This is done in a two step process:
+//
+// 1. Use this package's driver in place of the postgres driver.
+//
+// If your code is using sql.Open like this:
+//
+//	import (
+//		_ "github.com/lib/pq"
+//	)
+//
+//	func main() {
+//		db, err := sql.Open("postgres", "user=pqgotest dbname=pqgotest sslmode=verify-full")
+//	}
+//
+// Then change the side-effect import to this package, and open "nrpostgres" instead:
+//
+//	import (
+//		_ "salesloft.com/costello/core/newrelic/driver/nrcloudsqlproxy"
+//	)
+//
+//	func main() {
+//		db, err := sql.Open("nrcloudsqlproxy", "user=pqgotest dbname=pqgotest sslmode=verify-full")
+//	}
+//
+// If your code is using pq.NewConnector, simply use nrpq.NewConnector
+// instead.
+//
+// 2. Provide a context containing a newrelic.Transaction to all exec and query
+// methods on sql.DB, sql.Conn, and sql.Tx.  This requires using the
+// context methods ExecContext, QueryContext, and QueryRowContext in place of
+// Exec, Query, and QueryRow respectively.  For example, instead of the
+// following:
+//
+//	row := db.QueryRow("SELECT count(*) FROM pg_catalog.pg_tables")
+//
+// Do this:
+//
+//	ctx := newrelic.NewContext(context.Background(), txn)
+//	row := db.QueryRowContext(ctx, "SELECT count(*) FROM pg_catalog.pg_tables")
+//
+// Unfortunately, sql.Stmt exec and query calls are not supported since pq.stmt
+// does not have ExecContext and QueryContext methods (as of June 2019, see
+// https://github.com/lib/pq/pull/768).
+
+package nrcloudsqlpostgres
+
+import (
+	"database/sql"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/newrelic/go-agent/v3/internal"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v3/newrelic/sqlparse"
+
+	"github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/dialers/postgres"
+)
+
+var (
+	baseBuilder = newrelic.SQLDriverSegmentBuilder{
+		BaseSegment: newrelic.DatastoreSegment{
+			Product: newrelic.DatastorePostgres,
+		},
+		ParseQuery: sqlparse.ParseQuery,
+		ParseDSN:   parseDSN(os.Getenv),
+	}
+)
+
+func init() {
+	sql.Register("nrcloudsqlpostgres", newrelic.InstrumentSQLDriver(&postgres.Driver{}, baseBuilder))
+	internal.TrackUsage("integration", "driver", "cloudsqlpostgres")
+}
+
+var dsnSplit = regexp.MustCompile(`(\w+)\s*=\s*('[^=]*'|[^'\s]+)`)
+
+func getFirstHost(value string) string {
+	host := strings.SplitN(value, ",", 2)[0]
+	host = strings.Trim(host, "[]")
+	return host
+}
+
+func parseDSN(getenv func(string) string) func(*newrelic.DatastoreSegment, string) {
+	return func(s *newrelic.DatastoreSegment, dsn string) {
+		host := getenv("PGHOST")
+		hostaddr := ""
+		ppoid := getenv("PGPORT")
+		dbname := getenv("PGDATABASE")
+
+		for _, split := range dsnSplit.FindAllStringSubmatch(dsn, -1) {
+			if len(split) != 3 {
+				continue
+			}
+			key := split[1]
+			value := strings.Trim(split[2], `'`)
+
+			switch key {
+			case "dbname":
+				dbname = value
+			case "host":
+				host = getFirstHost(value)
+			case "hostaddr":
+				hostaddr = getFirstHost(value)
+			case "port":
+				ppoid = strings.SplitN(value, ",", 2)[0]
+			}
+		}
+
+		if "" != hostaddr {
+			host = hostaddr
+		} else if "" == host {
+			host = "localhost"
+		}
+		if "" == ppoid {
+			ppoid = "5432"
+		}
+		if strings.HasPrefix(host, "/") {
+			// this is a unix socket
+			ppoid = path.Join(host, ".s.PGSQL."+ppoid)
+			host = "localhost"
+		}
+
+		s.Host = host
+		s.PortPathOrID = ppoid
+		s.DatabaseName = dbname
+	}
+}

--- a/v3/integrations/nrcloudsqlpostgres/nrcloudsqlpostgres_test.go
+++ b/v3/integrations/nrcloudsqlpostgres/nrcloudsqlpostgres_test.go
@@ -1,0 +1,169 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nrcloudsqlpostgres
+
+import (
+	"testing"
+
+	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+)
+
+func TestParseDSN(t *testing.T) {
+	testcases := []struct {
+		dsn             string
+		expHost         string
+		expPortPathOrID string
+		expDatabaseName string
+		env             map[string]string
+	}{
+		// key,value pairs
+		{
+			dsn:             "host=1.2.3.4 port=1234 dbname=mydb",
+			expHost:         "1.2.3.4",
+			expPortPathOrID: "1234",
+			expDatabaseName: "mydb",
+		},
+		{
+			dsn:             "host =1.2.3.4 port= 1234 dbname = mydb",
+			expHost:         "1.2.3.4",
+			expPortPathOrID: "1234",
+			expDatabaseName: "mydb",
+		},
+		{
+			dsn:             "host =        1.2.3.4 port=\t\t1234 dbname =\n\t\t\tmydb",
+			expHost:         "1.2.3.4",
+			expPortPathOrID: "1234",
+			expDatabaseName: "mydb",
+		},
+		{
+			dsn:             "host ='1.2.3.4' port= '1234' dbname = 'mydb'",
+			expHost:         "1.2.3.4",
+			expPortPathOrID: "1234",
+			expDatabaseName: "mydb",
+		},
+		{
+			dsn:             `host='ain\'t_single_quote' port='port\\slash' dbname='my db spaced'`,
+			expHost:         `ain\'t_single_quote`,
+			expPortPathOrID: `port\\slash`,
+			expDatabaseName: "my db spaced",
+		},
+		{
+			dsn:             `host=localhost port=so=does=this`,
+			expHost:         "localhost",
+			expPortPathOrID: "so=does=this",
+		},
+		{
+			dsn:             "host=1.2.3.4 hostaddr=5.6.7.8",
+			expHost:         "5.6.7.8",
+			expPortPathOrID: "5432",
+		},
+		{
+			dsn:             "hostaddr=5.6.7.8 host=1.2.3.4",
+			expHost:         "5.6.7.8",
+			expPortPathOrID: "5432",
+		},
+		{
+			dsn:             "hostaddr=1.2.3.4",
+			expHost:         "1.2.3.4",
+			expPortPathOrID: "5432",
+		},
+		{
+			dsn:             "host=example.com,example.org port=80,443",
+			expHost:         "example.com",
+			expPortPathOrID: "80",
+		},
+		{
+			dsn:             "hostaddr=example.com,example.org port=80,443",
+			expHost:         "example.com",
+			expPortPathOrID: "80",
+		},
+		{
+			dsn:             "hostaddr='' host='' port=80,",
+			expHost:         "localhost",
+			expPortPathOrID: "80",
+		},
+		{
+			dsn:             "host=/path/to/socket",
+			expHost:         "localhost",
+			expPortPathOrID: "/path/to/socket/.s.PGSQL.5432",
+		},
+		{
+			dsn:             "port=1234 host=/path/to/socket",
+			expHost:         "localhost",
+			expPortPathOrID: "/path/to/socket/.s.PGSQL.1234",
+		},
+		{
+			dsn:             "host=/path/to/socket port=1234",
+			expHost:         "localhost",
+			expPortPathOrID: "/path/to/socket/.s.PGSQL.1234",
+		},
+
+		// env vars
+		{
+			dsn:             "host=host_string port=port_string dbname=dbname_string",
+			expHost:         "host_string",
+			expPortPathOrID: "port_string",
+			expDatabaseName: "dbname_string",
+			env: map[string]string{
+				"PGHOST":     "host_env",
+				"PGPORT":     "port_env",
+				"PGDATABASE": "dbname_env",
+			},
+		},
+		{
+			dsn:             "",
+			expHost:         "host_env",
+			expPortPathOrID: "port_env",
+			expDatabaseName: "dbname_env",
+			env: map[string]string{
+				"PGHOST":     "host_env",
+				"PGPORT":     "port_env",
+				"PGDATABASE": "dbname_env",
+			},
+		},
+		{
+			dsn:             "host=host_string",
+			expHost:         "host_string",
+			expPortPathOrID: "5432",
+			env: map[string]string{
+				"PGHOSTADDR": "hostaddr_env",
+			},
+		},
+		{
+			dsn:             "hostaddr=hostaddr_string",
+			expHost:         "hostaddr_string",
+			expPortPathOrID: "5432",
+			env: map[string]string{
+				"PGHOST": "host_env",
+			},
+		},
+		{
+			dsn:             "host=host_string hostaddr=hostaddr_string",
+			expHost:         "hostaddr_string",
+			expPortPathOrID: "5432",
+			env: map[string]string{
+				"PGHOST": "host_env",
+			},
+		},
+	}
+
+	for _, test := range testcases {
+		getenv := func(env string) string {
+			return test.env[env]
+		}
+
+		s := &newrelic.DatastoreSegment{}
+		parseDSN(getenv)(s, test.dsn)
+
+		if test.expHost != s.Host {
+			t.Errorf(`incorrect host, expected="%s", actual="%s"`, test.expHost, s.Host)
+		}
+		if test.expPortPathOrID != s.PortPathOrID {
+			t.Errorf(`incorrect port path or id, expected="%s", actual="%s"`, test.expPortPathOrID, s.PortPathOrID)
+		}
+		if test.expDatabaseName != s.DatabaseName {
+			t.Errorf(`incorrect database name, expected="%s", actual="%s"`, test.expDatabaseName, s.DatabaseName)
+		}
+	}
+}

--- a/v3/integrations/nrcloudsqlpostgres/nrcloudsqlpostgres_test.go
+++ b/v3/integrations/nrcloudsqlpostgres/nrcloudsqlpostgres_test.go
@@ -83,21 +83,6 @@ func TestParseDSN(t *testing.T) {
 			expHost:         "localhost",
 			expPortPathOrID: "80",
 		},
-		{
-			dsn:             "host=/path/to/socket",
-			expHost:         "localhost",
-			expPortPathOrID: "/path/to/socket/.s.PGSQL.5432",
-		},
-		{
-			dsn:             "port=1234 host=/path/to/socket",
-			expHost:         "localhost",
-			expPortPathOrID: "/path/to/socket/.s.PGSQL.1234",
-		},
-		{
-			dsn:             "host=/path/to/socket port=1234",
-			expHost:         "localhost",
-			expPortPathOrID: "/path/to/socket/.s.PGSQL.1234",
-		},
 
 		// env vars
 		{


### PR DESCRIPTION

## Links
https://github.com/GoogleCloudPlatform/cloudsql-proxy
https://github.com/GoogleCloudPlatform/cloudsql-proxy/tree/main/proxy/dialers/postgres


## Details
This Pull Request add an integration package to instrument calls for Cloud SQL Postgres.

The main change between this driver and the PostgreSQL driver is in the `host` param of the DSN, becaus it only accepts instances of Cloud SQL Postgres.
