### PR TITLE
Change logging level for 8T rebalancing messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changes
+* Changed logging level for messages resulting from Infinite Tracing load balancing operations which were previously logged as errors; now they are debugging messages. [#213](https://github.com/newrelic/go-agent/issues/213)
+
 ## 3.10.0
 
 ### New Features

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ New Relic is moving toward OpenTelemetry. OpenTelemetry is a unified standard fo
 
 
 ## Roadmap
-**The roadmap project is found [here](https://github.com/newrelic/go-agent/projects/1)**.  
+**The Go instrumentation roadmap project is found [here](https://github.com/orgs/newrelic/projects/24)**.  
 
 This roadmap project is broken down into the following sections:
 


### PR DESCRIPTION
Downgraded logging level for rebalancing messages that aren't actually errors.

Resolves #213 