### PR TITLE
Fixes issue with nil HttpResponse causing panics

### DIFF
--- a/v3/integrations/nrawssdk-v1/nrawssdk.go
+++ b/v3/integrations/nrawssdk-v1/nrawssdk.go
@@ -5,6 +5,8 @@
 package nrawssdk
 
 import (
+	"net/http"
+
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/newrelic/go-agent/v3/internal"
 	"github.com/newrelic/go-agent/v3/internal/awssupport"
@@ -25,7 +27,13 @@ func startSegment(req *request.Request) {
 
 func endSegment(req *request.Request) {
 	ctx := req.HTTPRequest.Context()
-	awssupport.EndSegment(ctx, req.HTTPResponse.Header)
+
+	hdr := http.Header{}
+	if req.HTTPRequest != nil {
+		hdr = req.HTTPRequest.Header
+	}
+
+	awssupport.EndSegment(ctx, hdr)
 }
 
 // InstrumentHandlers will add instrumentation to the given *request.Handlers.

--- a/v3/integrations/nrawssdk-v1/nrawssdk_test.go
+++ b/v3/integrations/nrawssdk-v1/nrawssdk_test.go
@@ -620,6 +620,8 @@ func TestGetRequestID(t *testing.T) {
 			primary:   []string{"hello"},
 			secondary: []string{"world"},
 		}, expected: "hello"},
+
+		{hdr: http.Header{}, expected: ""},
 	}
 
 	// Make sure our assumptions still hold against aws-sdk-go

--- a/v3/internal/awssupport/awssupport.go
+++ b/v3/internal/awssupport/awssupport.go
@@ -70,7 +70,7 @@ func StartSegment(input StartSegmentInputs) *http.Request {
 
 	var segment endable
 	// Service name capitalization is different for v1 and v2.
-	if input.ServiceName == "dynamodb" || input.ServiceName == "DynamoDB" {
+	if input.ServiceName == "dynamodb" || input.ServiceName == "DynamoDB" || input.ServiceName == "dax" {
 		segment = &newrelic.DatastoreSegment{
 			Product:            newrelic.DatastoreDynamoDB,
 			Collection:         getTableName(input.Params),

--- a/v3/internal/awssupport/awssupport_test.go
+++ b/v3/internal/awssupport/awssupport_test.go
@@ -73,6 +73,8 @@ func TestGetRequestID(t *testing.T) {
 			primary:   []string{"hello"},
 			secondary: []string{"world"},
 		}, expected: "hello"},
+
+		{hdr: http.Header{}, expected: ""},
 	}
 
 	for i, test := range testcases {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

<!--
Any relevant links that will help reviewers.
-->

https://github.com/newrelic/go-agent/issues/287
https://github.com/aws/aws-dax-go/issues/32

## Details

<!--
In-depth description of changes, other technical notes, etc.
-->

During the `endSegment` handler we need to check if `HTTPResponse` is populated. This prevents us from nil dereference panicking when requests to AWS services don't use HTTP such as DAX
