### PR TITLE
nrzerologplugin: Plugin to support logs in context for Zerolog

### DIFF
--- a/v3/integrations/logcontext/nrzerologplugin/go.mod
+++ b/v3/integrations/logcontext/nrzerologplugin/go.mod
@@ -1,0 +1,10 @@
+module github.com/newrelic/go-agent/v3/integrations/logcontext/nrzerologplugin
+
+go 1.7
+
+require (
+	github.com/justinas/alice v1.2.0 // indirect
+	github.com/newrelic/go-agent/v3 v3.11.0
+	github.com/rs/zerolog v1.21.0
+)
+

--- a/v3/integrations/logcontext/nrzerologplugin/nrzerologplugin.go
+++ b/v3/integrations/logcontext/nrzerologplugin/nrzerologplugin.go
@@ -1,0 +1,84 @@
+package nrzerologplugin
+
+import (
+	"net/http"
+	"runtime"
+	"strconv"
+	"time"
+
+	"github.com/newrelic/go-agent/v3/integrations/logcontext"
+	"github.com/newrelic/go-agent/v3/internal"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/rs/zerolog"
+)
+
+func init() { internal.TrackUsage("integration", "logcontext", "zerolog") }
+
+// Middleware adds the necessary date to enable logs in context
+func Middleware(h http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+
+		updateContextFn := func(c zerolog.Context) zerolog.Context {
+			if txn := newrelic.FromContext(r.Context()); nil != txn {
+				data := map[string]interface{}{
+					logcontext.KeyMessage: zerolog.MessageFieldName,
+					logcontext.KeyLevel:   zerolog.LevelFieldName,
+				}
+
+				logcontext.AddLinkingMetadata(data, txn.GetLinkingMetadata())
+
+				c = c.Fields(data)
+			}
+
+			return c
+		}
+
+		zerolog.Ctx(r.Context()).UpdateContext(updateContextFn)
+		h.ServeHTTP(w, r)
+	}
+
+	return http.HandlerFunc(fn)
+}
+
+// Hook Zerolog hook to add information regarding the file to the logs
+func Hook(e *zerolog.Event, level zerolog.Level, msg string) {
+	if e.Enabled() {
+		// We cannot get the timestamp from zerolog, so we use the current one
+		e.Uint64(logcontext.KeyTimestamp, uint64(time.Now().UnixNano())/uint64(1000*1000))
+
+		// 6 is a magic number, that's the number of frames in the stacktrace we need to
+		// go up until we get to the function/method who actually called the logger.
+		// It depends on how many function calls we introduced and how many are
+		// introduced by zerolog.
+		file, line, method := traceinfo(6)
+		e.Str(logcontext.KeyFile, file)
+		e.Str(logcontext.KeyLine, strconv.Itoa(line))
+		e.Str(logcontext.KeyMethod, method)
+		e.Str(logcontext.KeyLevel, level.String())
+	}
+}
+
+// traceinfo returns the file, line number and function name.
+// calldepth is the number of frames to be ignored.
+func traceinfo(calldepth int) (string, int, string) {
+	pc := make([]uintptr, 1)
+	n := runtime.Callers(calldepth, pc)
+	frames := runtime.CallersFrames(pc[:n])
+	f, _ := frames.Next()
+	return f.File, f.Line, f.Function
+}
+
+// trimPath shortens given path leaving at most given number of right hand
+// segments.
+func trimPath(filepath string, segments int) string {
+	var chunks int
+	for i := len(filepath) - 1; i > 0; i-- {
+		if filepath[i] == '/' {
+			chunks++
+			if chunks >= segments {
+				return filepath[i+1:]
+			}
+		}
+	}
+	return filepath
+}

--- a/v3/integrations/logcontext/nrzerologplugin/nrzerologplugin_example_test.go
+++ b/v3/integrations/logcontext/nrzerologplugin/nrzerologplugin_example_test.go
@@ -1,0 +1,25 @@
+package nrzerologplugin_test
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/justinas/alice"
+	"github.com/newrelic/go-agent/v3/integrations/logcontext/nrzerologplugin"
+	"github.com/rs/zerolog"
+)
+
+func ExampleNrZerologPlugin() {
+	logger := zerolog.New(os.Stdout)
+	logger = logger.Hook(zerolog.HookFunc(nrzerologplugin.Hook))
+
+	myHandler := func(w http.ResponseWriter, r *http.Request) {
+		logger := zerolog.Ctx(r.Context())
+		logger.Info().Msg("hello world")
+		w.Write([]byte("hello world"))
+	}
+
+	chain := alice.New(nrzerologplugin.Middleware).Then(http.HandlerFunc(myHandler))
+
+	http.ListenAndServe(":8000", chain)
+}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links
solves https://github.com/newrelic/go-agent/issues/178

## Details

This adds a integration to enable logs-in-context for zerolog,
this integrarion is split into two parts:
* HTTP middleware: adds the "LinkingMetadata" into the logger's
context.
* Zerolog Hook: Adds the caller's information to the logs.

This PR still in a draft stage, but I wanted to share my approach and get some early feedback.
I'm aware the example still needs improvement, like adding all NewRelic initialisation, and documentation needs to be written.

It has already tested it with a demo application and it worked pretty well.

## Open questions:
1. How is the file name, line and function names used by NewRelic? Are they required?

## Caveats:
* We cannot get the timestamp from zerolog, so we use time.Now.
* Reading the filename and line depend on some internals of zerolog.



