### PR TITLE
updated version.go and release notes for 3.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+## 3.12.0
+
+### Changes
+* Updated `CHANGELOG.md` release notes language, to correct typographical errors and
+clean up grammar. [#289](https://github.com/newrelic/go-agent/issues/289)
+
+### Fixed
+* When using DAX to query a dynamodb table, the New Relic instrumentation
+panics with a `nil dereference` error. This was due to the way that the
+request is made internally such that there is no `HTTPRequest.Header` 
+defined, but one was expected. This correction checks for the existence
+of that header and takes an appropriate course of action if one is not
+found. [#287](https://github.com/newrelic/go-agent/issues/287) Thanks to
+@odannyc for reporting the issue and providing a pull request with a suggested
+fix.
+
+### Support Statement
+* New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach [end-of-life](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software).
+
 ## 3.11.0
 
 ### New Features

--- a/v3/newrelic/version.go
+++ b/v3/newrelic/version.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Version is the full string version of this Go Agent.
-	Version = "3.11.0"
+	Version = "3.12.0"
 )
 
 var (


### PR DESCRIPTION
## Details

Updates `version.go` and release notes for 3.12.0 release.

I made the assumption that changes to our internal workflow that are being adopted at the same time didn't need to be included in the release notes, but I can add that if they should also be in there.