### PR TITLE
examples/server gets config from environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 * Replaced the NR AWS SDK V2 integration for the v3 agent with a new version that works. See the v3/integrations/nrawssdk-v2/example/main.go file for an example of how to use it.
 
+### Changes
+* The v3/examples/server/main.go example now uses `newrelic.ConfigFromEnvironment()`, rather than explicitly pulling in the license key with `newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY"))`. The team is starting to use this as a general systems integration testing script, and this facilitates testing with different settings enabled.
+
 ## 3.12.0
 
 ### Changes

--- a/v3/examples/server/main.go
+++ b/v3/examples/server/main.go
@@ -249,7 +249,7 @@ func browser(w http.ResponseWriter, r *http.Request) {
 func main() {
 	app, err := newrelic.NewApplication(
 		newrelic.ConfigAppName("Example App"),
-		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+		newrelic.ConfigFromEnvironment(),
 		newrelic.ConfigDebugLogger(os.Stdout),
 	)
 	if nil != err {


### PR DESCRIPTION
Use newrelic.ConfigFromEnvironment(), rather than explicitly pulling in the license key with newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")), to facilitate testing

Closes issue #305.