### PR TITLE
fix issue 221: grpc error reporting

### DIFF
--- a/v3/integrations/nrgrpc/go.mod
+++ b/v3/integrations/nrgrpc/go.mod
@@ -10,7 +10,7 @@ require (
 	// because all dependencies were removed in this version.
 	github.com/golang/protobuf v1.3.3
 	github.com/kisielk/gotool v1.0.0 // indirect
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/newrelic/go-agent/v3 v3.12.0
 	// v1.15.0 is the earliest version of grpc using modules.
 	google.golang.org/grpc v1.27.0
 )

--- a/v3/integrations/nrgrpc/go.mod
+++ b/v3/integrations/nrgrpc/go.mod
@@ -5,10 +5,12 @@ module github.com/newrelic/go-agent/v3/integrations/nrgrpc
 go 1.11
 
 require (
+	github.com/golang/lint v0.0.0-20180702182130-06c8688daad7 // indirect
 	// protobuf v1.3.0 is the earliest version using modules, we use v1.3.1
 	// because all dependencies were removed in this version.
-	github.com/golang/protobuf v1.3.1
+	github.com/golang/protobuf v1.3.3
+	github.com/kisielk/gotool v1.0.0 // indirect
 	github.com/newrelic/go-agent/v3 v3.0.0
 	// v1.15.0 is the earliest version of grpc using modules.
-	google.golang.org/grpc v1.15.0
+	google.golang.org/grpc v1.27.0
 )

--- a/v3/integrations/nrgrpc/nrgrpc_server_test.go
+++ b/v3/integrations/nrgrpc/nrgrpc_server_test.go
@@ -211,6 +211,27 @@ func TestUnaryServerInterceptorError(t *testing.T) {
 			"request.uri":                 "grpc://bufnet/TestApplication/DoUnaryUnaryError",
 		},
 		UserAttributes: map[string]interface{}{},
+	}, {
+		Intrinsics: map[string]interface{}{
+			"error.class":     "*status.statusError",
+			"error.message":   "rpc error: code = DataLoss desc = oooooops!",
+			"guid":            internal.MatchAnything,
+			"priority":        internal.MatchAnything,
+			"sampled":         internal.MatchAnything,
+			"spanId":          internal.MatchAnything,
+			"traceId":         internal.MatchAnything,
+			"transactionName": "WebTransaction/Go/TestApplication/DoUnaryUnaryError",
+		},
+		AgentAttributes: map[string]interface{}{
+			"httpResponseCode":            15,
+			"http.statusCode":             15,
+			"request.headers.User-Agent":  internal.MatchAnything,
+			"request.headers.userAgent":   internal.MatchAnything,
+			"request.headers.contentType": "application/grpc",
+			"request.method":              "TestApplication/DoUnaryUnaryError",
+			"request.uri":                 "grpc://bufnet/TestApplication/DoUnaryUnaryError",
+		},
+		UserAttributes: map[string]interface{}{},
 	}})
 }
 
@@ -596,6 +617,27 @@ func TestStreamServerInterceptorError(t *testing.T) {
 		Intrinsics: map[string]interface{}{
 			"error.class":     "15",
 			"error.message":   "response code 15",
+			"guid":            internal.MatchAnything,
+			"priority":        internal.MatchAnything,
+			"sampled":         internal.MatchAnything,
+			"spanId":          internal.MatchAnything,
+			"traceId":         internal.MatchAnything,
+			"transactionName": "WebTransaction/Go/TestApplication/DoUnaryStreamError",
+		},
+		AgentAttributes: map[string]interface{}{
+			"httpResponseCode":            15,
+			"http.statusCode":             15,
+			"request.headers.User-Agent":  internal.MatchAnything,
+			"request.headers.userAgent":   internal.MatchAnything,
+			"request.headers.contentType": "application/grpc",
+			"request.method":              "TestApplication/DoUnaryStreamError",
+			"request.uri":                 "grpc://bufnet/TestApplication/DoUnaryStreamError",
+		},
+		UserAttributes: map[string]interface{}{},
+	}, {
+		Intrinsics: map[string]interface{}{
+			"error.class":     "*status.statusError",
+			"error.message":   "rpc error: code = DataLoss desc = oooooops!",
 			"guid":            internal.MatchAnything,
 			"priority":        internal.MatchAnything,
 			"sampled":         internal.MatchAnything,

--- a/v3/integrations/nrgrpc/nrgrpc_server_test.go
+++ b/v3/integrations/nrgrpc/nrgrpc_server_test.go
@@ -213,7 +213,7 @@ func TestUnaryServerInterceptorError(t *testing.T) {
 		UserAttributes: map[string]interface{}{},
 	}, {
 		Intrinsics: map[string]interface{}{
-			"error.class":     "*status.statusError",
+			"error.class":     internal.MatchAnything,
 			"error.message":   "rpc error: code = DataLoss desc = oooooops!",
 			"guid":            internal.MatchAnything,
 			"priority":        internal.MatchAnything,
@@ -636,7 +636,7 @@ func TestStreamServerInterceptorError(t *testing.T) {
 		UserAttributes: map[string]interface{}{},
 	}, {
 		Intrinsics: map[string]interface{}{
-			"error.class":     "*status.statusError",
+			"error.class":     internal.MatchAnything,
 			"error.message":   "rpc error: code = DataLoss desc = oooooops!",
 			"guid":            internal.MatchAnything,
 			"priority":        internal.MatchAnything,


### PR DESCRIPTION
Adds error reporting to the nrgrpc integration. An error value returned from an instrumented unary or stream server call now creates an error span in the current transaction which contains the error message. Previously it only set an error status code.