### PR TITLE
Fix command for StartExternalSegment

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -369,8 +369,8 @@ ways to use this functionality:
    For example:
 
     ```go
-    func external(txn newrelic.Transaction, req *http.Request) (*http.Response, error) {
-      s := txn.StartExternalSegment(req)
+    func external(txn *newrelic.Transaction, req *http.Request) (*http.Response, error) {
+      s := newrelic.StartExternalSegment(txn, req)
       response, err := http.DefaultClient.Do(req)
       s.Response = response
       s.End()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Details
There is no command for `txn.StartExternalSegment` for both v3 version and non-v3
https://github.com/newrelic/go-agent/blob/5a0eaeb7452a247fa8bdfc5de98f7532b13738ea/segments.go#L185
https://github.com/newrelic/go-agent/blob/5a0eaeb7452a247fa8bdfc5de98f7532b13738ea/v3/newrelic/segments.go#L282

This PR updates the documentation to match the actual command provided by the package.