### PR TITLE
implemented JSON distributed trace converter

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -3,6 +3,6 @@ module github.com/newrelic/go-agent/v3
 go 1.7
 
 require (
-	github.com/golang/protobuf v1.4.3
-	google.golang.org/grpc v1.39.0
+	github.com/golang/protobuf v1.3.3
+	google.golang.org/grpc v1.27.0
 )

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -3,6 +3,6 @@ module github.com/newrelic/go-agent/v3
 go 1.7
 
 require (
-	github.com/golang/protobuf v1.3.3
-	google.golang.org/grpc v1.27.0
+	github.com/golang/protobuf v1.4.3
+	google.golang.org/grpc v1.39.0
 )

--- a/v3/newrelic/trace_context_test.go
+++ b/v3/newrelic/trace_context_test.go
@@ -47,7 +47,7 @@ type TraceContextTestCase struct {
 	} `json:"intrinsics"`
 }
 
-func TestJsonDTHeaders(t *testing.T) {
+func TestJSONDTHeaders(t *testing.T) {
 	type testcase struct {
 		in  string
 		out http.Header
@@ -59,7 +59,7 @@ func TestJsonDTHeaders(t *testing.T) {
 		{"{}", http.Header{}, false},
 		{" invalid ", http.Header{}, true},
 		{`"foo"`, http.Header{}, true},
-		{`{"foo": "bar"}`, map[string][]string{
+		{`{"foo": "bar"}`, http.Header{
 			"Foo": {"bar"},
 		}, false},
 		{`{
@@ -70,13 +70,13 @@ func TestJsonDTHeaders(t *testing.T) {
 				"beta",
 				"gamma"
 			]
-		}`, map[string][]string{
+		}`, http.Header{
 			"Foo":      {"bar"},
 			"Baz":      {"quux"},
 			"Multiple": {"alpha", "beta", "gamma"},
 		}, false},
 	} {
-		h, err := DistributedTraceHeadersFromJson(test.in)
+		h, err := DistributedTraceHeadersFromJSON(test.in)
 
 		if err != nil {
 			if !test.err {

--- a/v3/newrelic/transaction.go
+++ b/v3/newrelic/transaction.go
@@ -292,7 +292,9 @@ func (txn *Transaction) AcceptDistributedTraceHeadersFromJSON(t TransportType, j
 // and emits a http.Header value suitable for passing on to the
 // txn.AcceptDistributedTraceHeaders() function.
 //
-// This helps facilitate headers passed to your Go application from components written in other
+// This is a convenience function provided for cases where you receive the trace header data
+// already as a JSON string and want to avoid manually converting that to an http.Header.
+// It helps facilitate handling of headers passed to your Go application from components written in other
 // languages which may natively handle these header values as JSON strings.
 //
 // For example, given the input string
@@ -304,9 +306,6 @@ func (txn *Transaction) AcceptDistributedTraceHeadersFromJSON(t TransportType, j
 //     "Tracestate": {"blorfl"},
 //     "Newrelic": {"xyzzy"},
 //   }
-//
-// This is a convenience function provided for cases where you receive the trace header data
-// already as a JSON string and want to avoid manually converting that to an http.Header.
 //
 // The JSON string must be a single object whose values may be strings or arrays of strings.
 // These are translated directly to http headers with singleton or multiple values.

--- a/v3/newrelic/transaction.go
+++ b/v3/newrelic/transaction.go
@@ -272,14 +272,14 @@ func (txn *Transaction) AcceptDistributedTraceHeaders(t TransportType, hdrs http
 }
 
 //
-// AcceptDistributedTraceHeadersFromJson() works just like AcceptDistributedTraceHeaders(), except
-// that it takes the header data as a JSON string à la DistributedTraceHeadersFromJson(). Additionally
+// AcceptDistributedTraceHeadersFromJSON works just like AcceptDistributedTraceHeaders(), except
+// that it takes the header data as a JSON string à la DistributedTraceHeadersFromJSON(). Additionally
 // (unlike AcceptDistributedTraceHeaders()) it returns an error if it was unable to successfully
 // convert the JSON string to http headers. There is no guarantee that the header data found in JSON
 // is correct beyond conforming to the expected types and syntax.
 //
-func (txn *Transaction) AcceptDistributedTraceHeadersFromJson(t TransportType, jsondata string) error {
-	hdrs, err := DistributedTraceHeadersFromJson(jsondata)
+func (txn *Transaction) AcceptDistributedTraceHeadersFromJSON(t TransportType, jsondata string) error {
+	hdrs, err := DistributedTraceHeadersFromJSON(jsondata)
 	if err != nil {
 		return err
 	}
@@ -288,7 +288,7 @@ func (txn *Transaction) AcceptDistributedTraceHeadersFromJson(t TransportType, j
 }
 
 //
-// DistributedTraceHeadersFromJson() takes a set of distributed trace headers as a JSON-encoded string
+// DistributedTraceHeadersFromJSON takes a set of distributed trace headers as a JSON-encoded string
 // and emits a http.Header value suitable for passing on to the
 // txn.AcceptDistributedTraceHeaders() function.
 //
@@ -302,7 +302,7 @@ func (txn *Transaction) AcceptDistributedTraceHeadersFromJson(t TransportType, j
 // The JSON string must be a single object whose values may be strings or arrays of strings.
 // These are translated directly to http headers with singleton or multiple values.
 //
-func DistributedTraceHeadersFromJson(jsondata string) (hdrs http.Header, err error) {
+func DistributedTraceHeadersFromJSON(jsondata string) (hdrs http.Header, err error) {
 	var raw interface{}
 	hdrs = http.Header{}
 	if jsondata == "" {
@@ -325,17 +325,17 @@ func DistributedTraceHeadersFromJson(jsondata string) (hdrs http.Header, err err
 					case string:
 						hdrs.Add(k, sval)
 					default:
-						err = fmt.Errorf("JSON object must have only strings or arrays of strings.")
+						err = fmt.Errorf("the JSON object must have only strings or arrays of strings")
 						return
 					}
 				}
 			default:
-				err = fmt.Errorf("JSON object must have only strings or arrays of strings.")
+				err = fmt.Errorf("the JSON object must have only strings or arrays of strings")
 				return
 			}
 		}
 	default:
-		err = fmt.Errorf("JSON string must be a single object.")
+		err = fmt.Errorf("the JSON string must consist of only a single object")
 		return
 	}
 	return

--- a/v3/newrelic/transaction.go
+++ b/v3/newrelic/transaction.go
@@ -292,15 +292,33 @@ func (txn *Transaction) AcceptDistributedTraceHeadersFromJSON(t TransportType, j
 // and emits a http.Header value suitable for passing on to the
 // txn.AcceptDistributedTraceHeaders() function.
 //
+// This helps facilitate headers passed to your Go application from components written in other
+// languages which may natively handle these header values as JSON strings.
+//
 // For example, given the input string
 //   `{"traceparent": "frob", "tracestate": "blorfl", "newrelic": "xyzzy"}`
 // This will emit an http.Header value with headers "traceparent", "tracestate", and "newrelic".
+// Specifically:
+//   http.Header{
+//     "Traceparent": {"frob"},
+//     "Tracestate": {"blorfl"},
+//     "Newrelic": {"xyzzy"},
+//   }
 //
 // This is a convenience function provided for cases where you receive the trace header data
 // already as a JSON string and want to avoid manually converting that to an http.Header.
 //
 // The JSON string must be a single object whose values may be strings or arrays of strings.
 // These are translated directly to http headers with singleton or multiple values.
+// In the case of multiple string values, these are translated to a multi-value HTTP
+// header. For example:
+//   `{"traceparent": "12345", "colors": ["red", "green", "blue"]}`
+// which produces
+//   http.Header{
+//     "Traceparent": {"12345"},
+//     "Colors": {"red", "green", "blue"},
+//   }
+// (Note that the HTTP headers are capitalized.)
 //
 func DistributedTraceHeadersFromJSON(jsondata string) (hdrs http.Header, err error) {
 	var raw interface{}

--- a/v3/newrelic/transaction.go
+++ b/v3/newrelic/transaction.go
@@ -4,6 +4,8 @@
 package newrelic
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -267,6 +269,76 @@ func (txn *Transaction) AcceptDistributedTraceHeaders(t TransportType, hdrs http
 		return
 	}
 	txn.thread.logAPIError(txn.thread.AcceptDistributedTraceHeaders(t, hdrs), "accept trace payload", nil)
+}
+
+//
+// AcceptDistributedTraceHeadersFromJson() works just like AcceptDistributedTraceHeaders(), except
+// that it takes the header data as a JSON string à la DistributedTraceHeadersFromJson(). Additionally
+// (unlike AcceptDistributedTraceHeaders()) it returns an error if it was unable to successfully
+// convert the JSON string to http headers. There is no guarantee that the header data found in JSON
+// is correct beyond conforming to the expected types and syntax.
+//
+func (txn *Transaction) AcceptDistributedTraceHeadersFromJson(t TransportType, jsondata string) error {
+	hdrs, err := DistributedTraceHeadersFromJson(jsondata)
+	if err != nil {
+		return err
+	}
+	txn.AcceptDistributedTraceHeaders(t, hdrs)
+	return nil
+}
+
+//
+// DistributedTraceHeadersFromJson() takes a set of distributed trace headers as a JSON-encoded string
+// and emits a http.Header value suitable for passing on to the
+// txn.AcceptDistributedTraceHeaders() function.
+//
+// For example, given the input string
+//   `{"traceparent": "frob", "tracestate": "blorfl", "newrelic": "xyzzy"}`
+// This will emit an http.Header value with headers "traceparent", "tracestate", and "newrelic".
+//
+// This is a convenience function provided for cases where you receive the trace header data
+// already as a JSON string and want to avoid manually converting that to an http.Header.
+//
+// The JSON string must be a single object whose values may be strings or arrays of strings.
+// These are translated directly to http headers with singleton or multiple values.
+//
+func DistributedTraceHeadersFromJson(jsondata string) (hdrs http.Header, err error) {
+	var raw interface{}
+	hdrs = http.Header{}
+	if jsondata == "" {
+		return
+	}
+	err = json.Unmarshal([]byte(jsondata), &raw)
+	if err != nil {
+		return
+	}
+
+	switch d := raw.(type) {
+	case map[string]interface{}:
+		for k, v := range d {
+			switch hval := v.(type) {
+			case string:
+				hdrs.Set(k, hval)
+			case []interface{}:
+				for _, subval := range hval {
+					switch sval := subval.(type) {
+					case string:
+						hdrs.Add(k, sval)
+					default:
+						err = fmt.Errorf("JSON object must have only strings or arrays of strings.")
+						return
+					}
+				}
+			default:
+				err = fmt.Errorf("JSON object must have only strings or arrays of strings.")
+				return
+			}
+		}
+	default:
+		err = fmt.Errorf("JSON string must be a single object.")
+		return
+	}
+	return
 }
 
 // Application returns the Application which started the transaction.


### PR DESCRIPTION
## Summary
When making calls to a transaction's `AcceptDistributedTraceHeaders()` you are required to pass a valid `http.Header` value holding the distributed trace headers you want the current transaction to use. However, sometimes this data arrives in a text form such as a JSON string.

This requires the programmer to perform multiple steps to build up the `http.Header` value, which can be prone to errors. I propose a convenience function that constructs this value in one step.

## Changes
This PR adds two functions. `DistributedTraceHeadersFromJson()` converts a JSON representation of the trace headers to an `http.Header` object.

`AcceptDistributedTraceHeadersFromJson()` does the above plus calls `AcceptDistributedTraceHeaders()` on the result for you.

## Details
Given a JSON string such as:
```
{
   "traceparent": "frob",
   "tracestate": "blorfl",
   "newrelic": "xyzzy"
}
```
it will output the `http.Header` value with three header keys (`traceparent`, `tracestate`, and `newrelic`) with corresponding values as provided in the JSON string.

It will also appropriately handle the case where multiple values are provided in the JSON string for a single key.

An error will be returned if it was unable to parse the JSON string or ran into other difficulties.