### PR TITLE
350 go get

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -44,7 +44,7 @@ Then, installing the Go Agent is the same as installing any other Go library.  T
 simplest way is to run:
 
 ```
-go get github.com/newrelic/go-agent
+go get github.com/newrelic/go-agent/v3/newrelic
 ```
 
 Then import the package in your application:


### PR DESCRIPTION
Corrects our `GUIDE.md` document's advice on the proper `go get` command to obtain the Go agent code from github.
It now explicitly requests the v3 version.
This fixes Issue [#350](https://github.com/newrelic/go-agent/issues/350)
