### PR TITLE
Require 1.20.0 of aws-lambda-go

### DIFF
--- a/v3/integrations/nrlambda/go.mod
+++ b/v3/integrations/nrlambda/go.mod
@@ -5,6 +5,6 @@ module github.com/newrelic/go-agent/v3/integrations/nrlambda
 go 1.12
 
 require (
-	github.com/aws/aws-lambda-go v1.11.0
+	github.com/aws/aws-lambda-go v1.20.0
 	github.com/newrelic/go-agent/v3 v3.4.0
 )


### PR DESCRIPTION
This version has a fix that we need.

## Links

This PR resolved an issue in AWS's lambda runtime for Go: https://github.com/aws/aws-lambda-go/pull/313

It's present in 1.20.0, and we need that fix, or invocations just timeout.

## Details

While that fix happened a long time ago, I was a go novice at the time, and I'm only now figuring out how to get the dependency situation straitened out. 