### PR TITLE
Updated gin version for security reasons.

### DIFF
--- a/v3/integrations/nrgin/go.mod
+++ b/v3/integrations/nrgin/go.mod
@@ -5,6 +5,6 @@ module github.com/newrelic/go-agent/v3/integrations/nrgin
 go 1.12
 
 require (
-	github.com/gin-gonic/gin v1.4.0
+	github.com/gin-gonic/gin v1.7.0
 	github.com/newrelic/go-agent/v3 v3.0.0
 )


### PR DESCRIPTION
This is to address CVE-2020-28483, and was brought to our attention by Dependabot.