### PR TITLE
Added support for API Gateway V2 HTTP requests and responses

### DIFF
--- a/v3/integrations/nrlambda/events.go
+++ b/v3/integrations/nrlambda/events.go
@@ -54,6 +54,10 @@ func eventWebRequest(event interface{}) *newrelic.WebRequest {
 		request.Method = r.HTTPMethod
 		path = r.Path
 		headers = r.Headers
+	case events.APIGatewayV2HTTPRequest:
+		request.Method = r.RequestContext.HTTP.Method
+		path = r.RawPath
+		headers = r.Headers
 	case events.ALBTargetGroupRequest:
 		// https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#receive-event-from-load-balancer
 		request.Method = r.HTTPMethod
@@ -96,6 +100,9 @@ func eventResponse(event interface{}) *response {
 
 	switch r := event.(type) {
 	case events.APIGatewayProxyResponse:
+		code = r.StatusCode
+		headers = r.Headers
+	case events.APIGatewayV2HTTPResponse:
 		code = r.StatusCode
 		headers = r.Headers
 	case events.ALBTargetGroupResponse:

--- a/v3/integrations/nrlambda/events_test.go
+++ b/v3/integrations/nrlambda/events_test.go
@@ -109,6 +109,33 @@ func TestEventWebRequest(t *testing.T) {
 			transport:  newrelic.TransportHTTPS,
 		},
 		{
+			testname:   "empty api gateway v2 request",
+			input:      events.APIGatewayV2HTTPRequest{},
+			numHeaders: 0,
+			method:     "",
+			urlString:  "",
+			transport:  newrelic.TransportUnknown,
+		},
+		{
+			testname: "populated api gateway v2 request",
+			input: events.APIGatewayV2HTTPRequest{
+				Headers: map[string]string{
+					"x-forwarded-port":  "4000",
+					"x-forwarded-proto": "HTTPS",
+				},
+				RequestContext: events.APIGatewayV2HTTPRequestContext{
+					HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
+						Method: "GET",
+					},
+				},
+				RawPath: "the/path",
+			},
+			numHeaders: 2,
+			method:     "GET",
+			urlString:  "//:4000/the/path",
+			transport:  newrelic.TransportHTTPS,
+		},
+		{
 			testname:   "empty alb request",
 			input:      events.ALBTargetGroupRequest{},
 			numHeaders: 0,
@@ -176,6 +203,23 @@ func TestEventResponse(t *testing.T) {
 		{
 			testname: "populated proxy response",
 			input: events.APIGatewayProxyResponse{
+				StatusCode: 200,
+				Headers: map[string]string{
+					"x-custom-header": "my custom header value",
+				},
+			},
+			numHeaders: 1,
+			code:       200,
+		},
+		{
+			testname:   "empty http v2 response",
+			input:      events.APIGatewayV2HTTPResponse{},
+			numHeaders: 0,
+			code:       0,
+		},
+		{
+			testname: "populated http v2 response",
+			input: events.APIGatewayV2HTTPResponse{
 				StatusCode: 200,
 				Headers: map[string]string{
 					"x-custom-header": "my custom header value",

--- a/v3/integrations/nrlambda/go.mod
+++ b/v3/integrations/nrlambda/go.mod
@@ -5,6 +5,6 @@ module github.com/newrelic/go-agent/v3/integrations/nrlambda
 go 1.12
 
 require (
-	github.com/aws/aws-lambda-go v1.26.0
+	github.com/aws/aws-lambda-go v1.16.0
 	github.com/newrelic/go-agent/v3 v3.4.0
 )

--- a/v3/integrations/nrlambda/go.mod
+++ b/v3/integrations/nrlambda/go.mod
@@ -5,6 +5,6 @@ module github.com/newrelic/go-agent/v3/integrations/nrlambda
 go 1.12
 
 require (
-	github.com/aws/aws-lambda-go v1.11.0
+	github.com/aws/aws-lambda-go v1.26.0
 	github.com/newrelic/go-agent/v3 v3.4.0
 )


### PR DESCRIPTION
## Links

https://github.com/aws/aws-lambda-go/blob/master/events/apigw.go#L51

## Details

Detech when API Gateway V2 HTTP requests/responses are returned from the lambda handler and do the same reporting as the normal API Gateway proxy requests/responses.

Bumped the version of `github.com/aws/aws-lambda-go` to 1.26.0, which is the latest at the time of this PR.