### PR TITLE
Get test running on Mac workstation

### DIFF
--- a/v3/integrations/nrmongo/go.mod
+++ b/v3/integrations/nrmongo/go.mod
@@ -6,7 +6,7 @@ go 1.10
 
 require (
 	github.com/go-stack/stack v1.8.0 // indirect
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/newrelic/go-agent/v3 v3.6.0
 	// mongo-driver does not support modules as of Nov 2019.
 	go.mongodb.org/mongo-driver v1.0.0
 )


### PR DESCRIPTION
The call to internal.Hostname in the nrmongodb test file was using an older version of the function on a development Mac. This is to keep that error from happening.