### PR TITLE
(fix issue #397) incorrect table name reported

### DIFF
--- a/v3/newrelic/sqlparse/sqlparse.go
+++ b/v3/newrelic/sqlparse/sqlparse.go
@@ -25,9 +25,9 @@ var (
 	extractTableRegex = regexp.MustCompile(`[\s` + "`" + `"'\(\)\{\}\[\]]*`)
 	updateRegex       = regexp.MustCompile(`(?is)^update(?:\s+(?:low_priority|ignore|or|rollback|abort|replace|fail|only))*` + tablePattern)
 	sqlOperations     = map[string]*regexp.Regexp{
-		"select":   regexp.MustCompile(`(?is)^.*?\sfrom` + tablePattern),
-		"delete":   regexp.MustCompile(`(?is)^.*?\sfrom` + tablePattern),
-		"insert":   regexp.MustCompile(`(?is)^.*?\sinto?` + tablePattern),
+		"select":   regexp.MustCompile(`(?is)^.*\sfrom` + tablePattern),
+		"delete":   regexp.MustCompile(`(?is)^.*\sfrom` + tablePattern),
+		"insert":   regexp.MustCompile(`(?is)^.*\sinto?` + tablePattern),
 		"update":   updateRegex,
 		"call":     nil,
 		"create":   nil,

--- a/v3/newrelic/sqlparse/sqlparse_test.go
+++ b/v3/newrelic/sqlparse/sqlparse_test.go
@@ -56,6 +56,7 @@ func TestParseSQLSubQuery(t *testing.T) {
 		{Input: "SELECT * FROM (SELECT * FROM foobar)", Operation: "select", Table: "foobar"},
 		{Input: "SELECT * FROM (SELECT * FROM foobar) WHERE x > y", Operation: "select", Table: "foobar"},
 		{Input: "SELECT * FROM(SELECT * FROM foobar) WHERE x > y", Operation: "select", Table: "foobar"},
+		{Input: "SELECT substring('spam' FROM 2 FOR 3) AS x FROM FROMAGE) FROM fromagier", Operation: "select", Table: "fromagier"},
 	} {
 		tc.test(t)
 	}
@@ -71,6 +72,9 @@ func TestParseSQLOther(t *testing.T) {
 		{Input: "SELECT * FROM[ `something`.'foo' ]", Operation: "select", Table: "foo"},
 		// Test that we handle the cheese.
 		{Input: "SELECT fromage FROM fromagier", Operation: "select", Table: "fromagier"},
+		{Input: "SELECT (x from fromage) FROM fromagier", Operation: "select", Table: "fromagier"},
+		{Input: "SELECT (x FROM FROMAGE) FROM fromagier", Operation: "select", Table: "fromagier"},
+		{Input: "SELECT substring('spam' FROM 2 FOR 3) AS x FROM FROMAGE) FROM fromagier", Operation: "select", Table: "fromagier"},
 	} {
 		tc.test(t)
 	}


### PR DESCRIPTION
## Links
[Issue 397](https://github.com/newrelic/go-agent/issues/397)

## Details
Changes the regular expression used to recognize table name when doing simple SQL command parsing. Previously it looked for the first `FROM` but this was confused by subexpressions such as `SUBSTRING('foo' FROM x TO y)`. This changes the code to look for the last `FROM` instead.