### PR TITLE
Upgraded echo/v4 dependency version

### DIFF
--- a/v3/integrations/nrecho-v4/go.mod
+++ b/v3/integrations/nrecho-v4/go.mod
@@ -5,6 +5,6 @@ module github.com/newrelic/go-agent/v3/integrations/nrecho-v4
 go 1.12
 
 require (
-	github.com/labstack/echo/v4 v4.0.0
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/labstack/echo/v4 v4.5.0
+	github.com/newrelic/go-agent/v3 v3.15.0
 )


### PR DESCRIPTION
# Summary
Upgrades echo/v4 minimum version 

## Details

Fixes [Issue #394](https://github.com/newrelic/go-agent/issues/394) by bumping the required version number for the echo/v4 package. This addresses a security issue in the dependencies of that package as discussed in [the release notes for echo v4.5.0](https://github.com/labstack/echo/releases/tag/v4.5.0).
