### PR TITLE
Make Trace Observer test even slower for arm64 emulator

### DIFF
--- a/v3/newrelic/trace_observer_test.go
+++ b/v3/newrelic/trace_observer_test.go
@@ -902,7 +902,7 @@ func TestTrObsOKSendBackoffNo(t *testing.T) {
 	}
 	// If the default backoff of 15 seconds is used, the second span will not
 	// be received in time.
-	if !s.DidSpansArrive(t, 2, 2*time.Second) {
+	if !s.DidSpansArrive(t, 2, 4*time.Second) {
 		t.Error("server did not receive 2 spans")
 	}
 }


### PR DESCRIPTION
To accommodate the very slow arm64 emulator, we need to make our integrations tests for the Infinite Tracing Trace Observer slower. 

A long-term fix for this would be to run the tests on actual arm64 hardware.