### PR TITLE
Logger license

### DIFF
--- a/v3/internal/logger/logger.go
+++ b/v3/internal/logger/logger.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"regexp"
 )
 
 // Logger matches newrelic.Logger to allow implementations to be passed to
@@ -72,8 +73,11 @@ func (f *logFile) fire(level, msg string, ctx map[string]interface{}) {
 		msg,
 		ctx,
 	})
-	if nil == err {
-		f.l.Print(string(js))
+	if err == nil {
+		// scrub license keys from any portion of the log message
+		re := regexp.MustCompile(`license_key=[a-fA-F0-9]+`)
+		sanitized := re.ReplaceAllLiteralString(string(js), "license_key=[redacted]")
+		f.l.Print(sanitized)
 	} else {
 		f.l.Printf("unable to marshal log entry: %v", err)
 	}

--- a/v3/internal/logger/logger.go
+++ b/v3/internal/logger/logger.go
@@ -75,7 +75,7 @@ func (f *logFile) fire(level, msg string, ctx map[string]interface{}) {
 	})
 	if err == nil {
 		// scrub license keys from any portion of the log message
-		re := regexp.MustCompile(`license_key=[a-fA-F0-9]+`)
+		re := regexp.MustCompile(`license_key=[a-fA-F0-9.]+`)
 		sanitized := re.ReplaceAllLiteralString(string(js), "license_key=[redacted]")
 		f.l.Print(sanitized)
 	} else {


### PR DESCRIPTION
## Details

This PR adds a filter to messages logged through the go agent's `v3/internal/logger` facility, for all severity levels, to redact license key information from the message being logged. Since the log message may include the license key embedded in a URL string or other marshalled text, we do not try to limit the filter by parsing the strings. Rather, we simply replace the text "`license_key=`" followed by a hex digit sequence, such that the hex digits are removed.
