### PR TITLE
Release 3.15.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -231,3 +231,52 @@ jobs:
       env:
         DIRS: ${{ matrix.dirs }}
         EXTRATESTING: ${{ matrix.extratesting }}
+
+  go-agent-arm64:
+    # Run all unit tests on aarch64 emulator to ensure compatibility with AWS
+    # Graviton instances
+    runs-on: ubuntu-18.04
+    strategy:
+    # if one test fails, do not abort the rest
+      fail-fast: false
+      matrix:
+        include:
+          - go-version: 1.17.1
+          - go-version: 1.16.8
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        # Required when using older versions of Go that do not support gomod.
+        # Note the required presence of the /go-agent/ directory at the
+        # beginning of this path.  It is required in order to match the
+        # ${{ github.workspace }} used by the GOPATH env var.  pwd when cloning
+        # the repo is <something>/go-agent/ whereas ${{ github.workspace }}
+        # returns <something/go-agent/go-agent/.
+        path: ./go-agent/src/github.com/newrelic/go-agent
+    - uses: uraimo/run-on-arch-action@v2.0.5
+      name: Run Tests
+      id: runcmd
+      with:
+        arch: aarch64
+        distro: ubuntu20.04
+        githubToken: ${{ github.token }}
+        install: |
+          DEBIAN_FRONTEND=noninteractive apt-get -qq update
+          DEBIAN_FRONTEND=noninteractive apt-get -qq install -y wget build-essential
+          wget -nv https://golang.org/dl/go${{ matrix.go-version }}.linux-arm64.tar.gz
+          rm -rf /usr/local/go
+          tar -C /usr/local -xzf go${{ matrix.go-version }}.linux-arm64.tar.gz
+        run: |
+          export PATH=$PATH:/usr/local/go/bin
+          go version
+          cd v3/newrelic
+          go mod download github.com/golang/protobuf
+          go get
+          echo ==== v3/newrelic tests ====
+          go test ./...
+          cd ../internal
+          echo ==== v3/internal tests ====
+          go test ./...
+          cd ../examples
+          echo ==== v3/examples tests ====
+          go test ./...

--- a/v3/newrelic/trace_observer_test.go
+++ b/v3/newrelic/trace_observer_test.go
@@ -1,7 +1,9 @@
 // Copyright 2020 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build go1.9
 // +build go1.9
+
 // This build tag is necessary because Infinite Tracing is only supported for Go version 1.9 and up
 
 package newrelic
@@ -258,6 +260,12 @@ func TestTraceObserverRestart(t *testing.T) {
 	waitForTrObs(t, to)
 	defer s.Close()
 
+	// Make sure the server has received the new data
+	to.consumeSpan(&spanEvent{})
+	if !s.DidSpansArrive(t, 1, 150*time.Millisecond) {
+		t.Error("Did not receive expected spans before timeout -- before restart")
+	}
+
 	s.ExpectMetadata(t, map[string]string{
 		"agent_run_token": runToken,
 		"license_key":     testLicenseKey,
@@ -268,8 +276,8 @@ func TestTraceObserverRestart(t *testing.T) {
 
 	// Make sure the server has received the new data
 	to.consumeSpan(&spanEvent{})
-	if !s.DidSpansArrive(t, 1, 50*time.Millisecond) {
-		t.Error("Did not receive expected spans before timeout")
+	if !s.DidSpansArrive(t, 1, 150*time.Millisecond) {
+		t.Error("Did not receive expected spans before timeout -- after restart")
 	}
 
 	s.ExpectMetadata(t, map[string]string{
@@ -894,7 +902,7 @@ func TestTrObsOKSendBackoffNo(t *testing.T) {
 	}
 	// If the default backoff of 15 seconds is used, the second span will not
 	// be received in time.
-	if !s.DidSpansArrive(t, 2, time.Second) {
+	if !s.DidSpansArrive(t, 2, 2*time.Second) {
 		t.Error("server did not receive 2 spans")
 	}
 }


### PR DESCRIPTION
## 3.15.2
### Added
* Strings logged via the Go Agent's built-in logger will have strings of the form `license_key=`*hex-string* changed to `license_key=[redacted]` before they are output, regardless of severity level, where *hex-string* means a sequence of upper- or lower-case hexadecimal digits and dots ('.'). This incorporates [PR #415](https://github.com/newrelic/go-agent/pull/415).

### Support Statement
New Relic recommends that you upgrade the agent regularly to ensure that you’re getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach end-of-life.

