### PR TITLE
update to logger redaction

### DIFF
--- a/v3/internal/logger/logger.go
+++ b/v3/internal/logger/logger.go
@@ -79,7 +79,9 @@ func (f *logFile) fire(level, msg string, ctx map[string]interface{}) {
 		sanitized := re.ReplaceAllLiteralString(string(js), "license_key=[redacted]")
 		f.l.Print(sanitized)
 	} else {
-		f.l.Printf("unable to marshal log entry: %v", err)
+		f.l.Printf("unable to marshal log entry")
+		// error value removed from message to avoid possibility of sensitive
+		// content being leaked that way
 	}
 }
 


### PR DESCRIPTION
Removes error message text from log messages where JSON string marshalling failed to avoid possible leak of sensitive information.