### PR TITLE
fix issue #427: move segment start from aws `send` step to `sign` step

### DIFF
--- a/v3/integrations/nrawssdk-v1/nrawssdk.go
+++ b/v3/integrations/nrawssdk-v1/nrawssdk.go
@@ -84,7 +84,7 @@ func endSegment(req *request.Request) {
 //    req.HTTPRequest = newrelic.RequestWithTransactionContext(req.HTTPRequest, txn)
 //    err := req.Send()
 func InstrumentHandlers(handlers *request.Handlers) {
-	handlers.Send.SetFrontNamed(request.NamedHandler{
+	handlers.Sign.SetFrontNamed(request.NamedHandler{
 		Name: "StartNewRelicSegment",
 		Fn:   startSegment,
 	})

--- a/v3/integrations/nrawssdk-v1/nrawssdk_test.go
+++ b/v3/integrations/nrawssdk-v1/nrawssdk_test.go
@@ -432,13 +432,19 @@ func TestDoublyInstrumented(t *testing.T) {
 	}
 
 	InstrumentHandlers(hs)
-	if found := hs.Send.Len(); 2 != found {
+	if found := hs.Send.Len(); 1 != found {
 		t.Error("unexpected number of Send handlers found:", found)
+	}
+	if found := hs.Sign.Len(); 1 != found {
+		t.Error("unexpected number of Sign handlers found:", found)
 	}
 
 	InstrumentHandlers(hs)
-	if found := hs.Send.Len(); 2 != found {
+	if found := hs.Send.Len(); 1 != found {
 		t.Error("unexpected number of Send handlers found:", found)
+	}
+	if found := hs.Sign.Len(); 1 != found {
+		t.Error("unexpected number of Sign handlers found:", found)
 	}
 }
 


### PR DESCRIPTION
Add New Relic headers in a "Sign" aws handler rather than in a "Send" handler. This ensures the signature always includes the correct header values and therefore fixes issue #427 