### PR TITLE
do not include distributed trace headers in AWS SDK requests

### DIFF
--- a/v3/integrations/nrawssdk-v1/nrawssdk.go
+++ b/v3/integrations/nrawssdk-v1/nrawssdk.go
@@ -5,8 +5,6 @@
 package nrawssdk
 
 import (
-	"net/http"
-
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/newrelic/go-agent/v3/internal"
 	"github.com/newrelic/go-agent/v3/internal/awssupport"
@@ -26,14 +24,7 @@ func startSegment(req *request.Request) {
 }
 
 func endSegment(req *request.Request) {
-	ctx := req.HTTPRequest.Context()
-
-	hdr := http.Header{}
-	if req.HTTPRequest != nil {
-		hdr = req.HTTPRequest.Header
-	}
-
-	awssupport.EndSegment(ctx, hdr)
+	awssupport.EndSegment(req.HTTPRequest.Context(), req.HTTPResponse)
 }
 
 // InstrumentHandlers will add instrumentation to the given *request.Handlers.

--- a/v3/integrations/nrawssdk-v1/nrawssdk_test.go
+++ b/v3/integrations/nrawssdk-v1/nrawssdk_test.go
@@ -93,11 +93,12 @@ var (
 		},
 		UserAttributes: map[string]interface{}{},
 		AgentAttributes: map[string]interface{}{
-			"aws.operation": "Invoke",
-			"aws.region":    "us-west-2",
-			"aws.requestId": requestID,
-			"http.method":   "POST",
-			"http.url":      "https://lambda.us-west-2.amazonaws.com/2015-03-31/functions/non-existent-function/invocations",
+			"aws.operation":   "Invoke",
+			"aws.region":      "us-west-2",
+			"aws.requestId":   requestID,
+			"http.method":     "POST",
+			"http.url":        "https://lambda.us-west-2.amazonaws.com/2015-03-31/functions/non-existent-function/invocations",
+			"http.statusCode": 200,
 		},
 	}
 	externalSpanNoRequestID = internal.WantEvent{
@@ -115,10 +116,33 @@ var (
 		},
 		UserAttributes: map[string]interface{}{},
 		AgentAttributes: map[string]interface{}{
-			"aws.operation": "Invoke",
-			"aws.region":    "us-west-2",
-			"http.method":   "POST",
-			"http.url":      "https://lambda.us-west-2.amazonaws.com/2015-03-31/functions/non-existent-function/invocations",
+			"aws.operation":   "Invoke",
+			"aws.region":      "us-west-2",
+			"http.method":     "POST",
+			"http.url":        "https://lambda.us-west-2.amazonaws.com/2015-03-31/functions/non-existent-function/invocations",
+			"http.statusCode": 200,
+		},
+	}
+	externalSpanSendFailure = internal.WantEvent{
+		Intrinsics: map[string]interface{}{
+			"name":          "External/lambda.us-west-2.amazonaws.com/http/POST",
+			"sampled":       true,
+			"category":      "http",
+			"priority":      internal.MatchAnything,
+			"guid":          internal.MatchAnything,
+			"transactionId": internal.MatchAnything,
+			"traceId":       internal.MatchAnything,
+			"parentId":      internal.MatchAnything,
+			"component":     "http",
+			"span.kind":     "client",
+		},
+		UserAttributes: map[string]interface{}{},
+		AgentAttributes: map[string]interface{}{
+			"aws.operation":   "Invoke",
+			"aws.region":      "us-west-2",
+			"http.method":     "POST",
+			"http.url":        "https://lambda.us-west-2.amazonaws.com/2015-03-31/functions/non-existent-function/invocations",
+			"http.statusCode": 0,
 		},
 	}
 	datastoreSpan = internal.WantEvent{
@@ -493,7 +517,7 @@ func TestRetrySend(t *testing.T) {
 
 	app.ExpectMetrics(t, externalMetrics)
 	app.ExpectSpanEvents(t, []internal.WantEvent{
-		externalSpanNoRequestID, externalSpan, genericSpan})
+		externalSpanSendFailure, externalSpan, genericSpan})
 }
 
 func TestRequestSentTwice(t *testing.T) {


### PR DESCRIPTION
Fixes #427 and #432. Sending the distributed trace headers to AWS is rather pointless, and can cause the request signature to be corrupted on retries. Also, previously the AWS request id and response status code were not being properly captured.

Note: Due to breaking changes in the v3/internal package, the new release of nrawssdk-v1 will depend on the new release of v3. Not sure how this is normally dealt with.