### PR TITLE
Handle attributes in nrpkgerrors

### DIFF
--- a/v3/integrations/nrpkgerrors/nrkpgerrors_test.go
+++ b/v3/integrations/nrpkgerrors/nrkpgerrors_test.go
@@ -31,6 +31,7 @@ func gamma(e error) error { return errors.WithStack(e) }
 
 func theta(e error) error { return errors.WithMessage(e, "theta") }
 
+func basicNRError(e error) newrelic.Error { return newrelic.Error{Message: e.Error()} }
 func withAttributes(e error) newrelic.Error {
 	return newrelic.Error{
 		Message: e.Error(),
@@ -54,6 +55,7 @@ func TestWrappedStackTrace(t *testing.T) {
 		{Error: alpha(theta(beta(basicError{}))), ExpectTopFrame: "beta"},
 		{Error: alpha(theta(beta(theta(basicError{})))), ExpectTopFrame: "beta"},
 		{Error: theta(basicError{}), ExpectTopFrame: ""},
+		{Error: basicNRError(basicError{}), ExpectTopFrame: ""},
 		{Error: withAttributes(basicError{}), ExpectTopFrame: "", ExpectAttributes: map[string]interface{}{"testAttribute": 1, "foo": 2}},
 	}
 

--- a/v3/integrations/nrpkgerrors/nrkpgerrors_test.go
+++ b/v3/integrations/nrpkgerrors/nrkpgerrors_test.go
@@ -31,10 +31,21 @@ func gamma(e error) error { return errors.WithStack(e) }
 
 func theta(e error) error { return errors.WithMessage(e, "theta") }
 
+func withAttributes(e error) newrelic.Error {
+	return newrelic.Error{
+		Message: e.Error(),
+		Attributes: map[string]interface{}{
+			"testAttribute": 1,
+			"foo":           2,
+		},
+	}
+}
+
 func TestWrappedStackTrace(t *testing.T) {
 	testcases := []struct {
-		Error          error
-		ExpectTopFrame string
+		Error            error
+		ExpectTopFrame   string
+		ExpectAttributes map[string]interface{}
 	}{
 		{Error: basicError{}, ExpectTopFrame: ""},
 		{Error: alpha(basicError{}), ExpectTopFrame: "alpha"},
@@ -43,6 +54,7 @@ func TestWrappedStackTrace(t *testing.T) {
 		{Error: alpha(theta(beta(basicError{}))), ExpectTopFrame: "beta"},
 		{Error: alpha(theta(beta(theta(basicError{})))), ExpectTopFrame: "beta"},
 		{Error: theta(basicError{}), ExpectTopFrame: ""},
+		{Error: withAttributes(basicError{}), ExpectTopFrame: "", ExpectAttributes: map[string]interface{}{"testAttribute": 1, "foo": 2}},
 	}
 
 	for idx, tc := range testcases {
@@ -52,6 +64,20 @@ func TestWrappedStackTrace(t *testing.T) {
 		if !strings.Contains(fn, tc.ExpectTopFrame) {
 			t.Errorf("testcase %d: expected %s got %s",
 				idx, tc.ExpectTopFrame, fn)
+		}
+		// check that error attributes are equal if they are expected
+		if tc.ExpectAttributes != nil {
+			errorAttributes := e.(newrelic.Error).ErrorAttributes()
+			if len(tc.ExpectAttributes) != len(errorAttributes) {
+				t.Errorf("testcase %d: error attribute size expected %d got %d",
+					idx, len(tc.ExpectAttributes), len(errorAttributes))
+			}
+			for k, v := range errorAttributes {
+				if tc.ExpectAttributes[k] != v {
+					t.Errorf("testcase %d: expected attribute %s:%v got %s:%v",
+						idx, k, tc.ExpectAttributes[k], k, v)
+				}
+			}
 		}
 	}
 }

--- a/v3/integrations/nrpkgerrors/nrpkgerrors.go
+++ b/v3/integrations/nrpkgerrors/nrpkgerrors.go
@@ -83,7 +83,7 @@ func Wrap(e error) error {
 	attributes := make(map[string]interface{})
 	switch error := e.(type) {
 	case newrelic.Error:
-		// if e is type newrelic.Error, copy attributes into wrapped errror
+		// if e is type newrelic.Error, copy attributes into wrapped error
 		for key, value := range error.ErrorAttributes() {
 			attributes[key] = value
 		}

--- a/v3/integrations/nrpkgerrors/nrpkgerrors.go
+++ b/v3/integrations/nrpkgerrors/nrpkgerrors.go
@@ -80,9 +80,18 @@ func errorClass(e error) string {
 // newrelic.Transaction.NoticeError it gives an improved stacktrace and class
 // type.
 func Wrap(e error) error {
+	attributes := make(map[string]interface{})
+	switch error := e.(type) {
+	case newrelic.Error:
+		// if e is type newrelic.Error, copy attributes into wrapped errror
+		for key, value := range error.ErrorAttributes() {
+			attributes[key] = value
+		}
+	}
 	return newrelic.Error{
-		Message: e.Error(),
-		Class:   errorClass(e),
-		Stack:   stackTrace(e),
+		Message:    e.Error(),
+		Class:      errorClass(e),
+		Stack:      stackTrace(e),
+		Attributes: attributes,
 	}
 }

--- a/v3/newrelic/trace_observer_test.go
+++ b/v3/newrelic/trace_observer_test.go
@@ -902,7 +902,7 @@ func TestTrObsOKSendBackoffNo(t *testing.T) {
 	}
 	// If the default backoff of 15 seconds is used, the second span will not
 	// be received in time.
-	if !s.DidSpansArrive(t, 2, 4*time.Second) {
+	if !s.DidSpansArrive(t, 2, 8*time.Second) {
 		t.Error("server did not receive 2 spans")
 	}
 }


### PR DESCRIPTION
## Details

Fixes #409. nrpkgerrors.Wrap() now checks if the error it is passed has attributes, and if it does, copies them into the New Relic error it creates.
