### PR TITLE
use Host from http.Request

### DIFF
--- a/v3/newrelic/segments.go
+++ b/v3/newrelic/segments.go
@@ -286,6 +286,7 @@ func StartExternalSegment(txn *Transaction, request *http.Request) *ExternalSegm
 	s := &ExternalSegment{
 		StartTime: txn.StartSegmentNow(),
 		Request:   request,
+		Host:      request.Host,
 	}
 
 	if request != nil && request.Header != nil {


### PR DESCRIPTION
## Details

Currently we use `localhost` in the url to point to envoy, and add host header to the request so that envoy would route to the appropriate cluster.

Since the url always has localhost, our external segment is rather confusing. by using Host from http.Request the external segment should properly distinguish for different external services.