### PR TITLE
Test Dependency Pinning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,7 @@ jobs:
             dirs: _integrations/nrawssdk
           - go-version: 1.13.x
             dirs: _integrations/nrecho
+            pin: github.com/labstack/echo@v3.3.10
           - go-version: 1.13.x
             dirs: _integrations/nrgin/v1
           - go-version: 1.13.x

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -231,6 +231,7 @@ jobs:
       env:
         DIRS: ${{ matrix.dirs }}
         EXTRATESTING: ${{ matrix.extratesting }}
+        PIN: ${{ matrix.pin }}
 
   go-agent-arm64:
     # Run all unit tests on aarch64 emulator to ensure compatibility with AWS
@@ -271,7 +272,7 @@ jobs:
           go version
           cd v3/newrelic
           go mod download github.com/golang/protobuf
-          go get
+          go get -t
           echo ==== v3/newrelic tests ====
           go test ./...
           cd ../internal

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,8 @@ jobs:
 
           # v2 integrations
           - go-version: 1.13.x
+            # only versions up to 0.24.0 of awssdkv2 are supported by this code
+            pin: github.com/aws/aws-sdk-go-v2@v0.24.0
             dirs: _integrations/nrawssdk
           - go-version: 1.13.x
             dirs: _integrations/nrecho

--- a/build-script.sh
+++ b/build-script.sh
@@ -22,14 +22,14 @@ pwd=$(pwd)
 # inputs
 # 1: repo pin; example: github.com/rewrelic/go-agent@v1.9.0
 pin_go_dependency() {
-  echo "Pinning: $1"
   if [[ ! -z "$1" ]]; then
+    echo "Pinning: $1"
     repo=$(echo "$1" | cut -d '@' -f1)
     pinTo=$(echo "$1" | cut -d '@' -f2)
     set +e
     go get -u "$repo" # this go get will fail to build
     set -e
-    cd $GOPATH/src/"$repo"
+    cd "$GOPATH"/src/"$repo"
     git checkout "$pinTo"
     cd -
   fi
@@ -40,18 +40,13 @@ for dir in $DIRS; do
   cd "$pwd/$dir"
 
   if [ -f "go.mod" ]; then
-    go mod edit -replace github.com/newrelic/go-agent/v3=$pwd/v3
+    go mod edit -replace github.com/newrelic/go-agent/v3="$pwd"/v3
   fi
 
   pin_go_dependency "$PIN"
 
-  # go get is necessary for testing v2 integrations since they do not have
-  # a go.mod file.
-  if [[ $dir =~ "_integrations" ]]; then
-    go get -t ./...
-  fi
   # avoid testing v3 code when testing v2 newrelic package
-  if [ $dir == "." ]; then
+  if [ "$dir" == "." ]; then
     rm -rf v3/
   else
     # Only v3 code version 1.9+ needs GRPC dependencies
@@ -77,6 +72,12 @@ for dir in $DIRS; do
       go get -u github.com/golang/protobuf/protoc-gen-go
       go get -u google.golang.org/grpc
     fi
+  fi
+
+  # go get is necessary for testing v2 integrations since they do not have
+  # a go.mod file.
+  if [[ $dir =~ "_integrations" ]]; then
+    go get -t ./...
   fi
 
   go test -race -benchtime=1ms -bench=. ./...

--- a/build-script.sh
+++ b/build-script.sh
@@ -44,9 +44,11 @@ for dir in $DIRS; do
     V1_10="1.10"
     V1_11="1.11"
     V1_12="1.12"
+    V1_13="1.13"
+    V1_14="1.14"
     if [[ "$VERSION" =~ .*"$V1_7".* || "$VERSION" =~ .*"$V1_8".* ]]; then
       echo "Not installing GRPC for old versions"
-    elif [[ "$VERSION" =~ .*"$V1_9" || "$VERSION" =~ .*"$V1_10" || "$VERSION" =~ .*"$V1_11" || "$VERSION" =~ .*"$V1_12" ]]; then
+    elif [[ "$VERSION" =~ .*"$V1_9" || "$VERSION" =~ .*"$V1_10" || "$VERSION" =~ .*"$V1_11" || "$VERSION" =~ .*"$V1_12" ||  "$VERSION" =~ .*"$V1_13" || "$VERSION" =~ .*"$V1_14" ]]; then
       # install v3 dependencies that support this go version
       set +e
       go get -u google.golang.org/grpc # this go get will fail to build

--- a/build-script.sh
+++ b/build-script.sh
@@ -66,7 +66,7 @@ for dir in $DIRS; do
       pin_go_dependency "google.golang.org/grpc@v1.31.0"
       pin_go_dependency "golang.org/x/net/http2@7fd8e65b642006927f6cec5cb4241df7f98a2210"
 
-      # install protobuff once dependencies are resolved
+      # install protobuf once dependencies are resolved
       go get -u github.com/golang/protobuf/protoc-gen-go
     else
       go get -u github.com/golang/protobuf/protoc-gen-go


### PR DESCRIPTION
Creates a new directive in the test matrix, "pin", that allows you to pin the version of a library imported during that test to a specific version. This is best used in cases where that specific test needs a version pin of something. Pins that affect a number of tests are cleaner to implement in the bash script directly.