### PR TITLE
update version of nats-streaming-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # ChangeLog
+
+## Unreleased
+
+### Changed
+* Updated version of `nats-streaming-server` in the nrstan integration to patch vulnerability mentioned in [this Dependabot alert](https://github.com/newrelic/go-agent/security/dependabot/3).
+
 ## 3.15.2
 ### Added
 * Strings logged via the Go Agent's built-in logger will have strings of the form `license_key=`*hex-string* changed to `license_key=[redacted]` before they are output, regardless of severity level, where *hex-string* means a sequence of upper- or lower-case hexadecimal digits and dots ('.'). This incorporates [PR #415](https://github.com/newrelic/go-agent/pull/415).

--- a/v3/integrations/nrstan/test/go.mod
+++ b/v3/integrations/nrstan/test/go.mod
@@ -6,8 +6,8 @@ module github.com/newrelic/go-agent/v3/integrations/nrstan/test
 go 1.13
 
 require (
-	github.com/nats-io/nats-streaming-server v0.16.2
-	github.com/nats-io/stan.go v0.5.0
+	github.com/nats-io/nats-streaming-server v0.24.1
+	github.com/nats-io/stan.go v0.10.2
 	github.com/newrelic/go-agent/v3 v3.4.0
 	github.com/newrelic/go-agent/v3/integrations/nrstan v0.0.0
 )


### PR DESCRIPTION
This is to resolve [this Dependabot alert](https://github.com/newrelic/go-agent/security/dependabot/3). Some versions of nats-streaming-server are insecure, this puts the version of nats-streaming-server required by the test up to the fixed version.