### PR TITLE
Fixes for multiple broken tests

### DIFF
--- a/v3/integrations/logcontext/nrlogrusplugin/go.mod
+++ b/v3/integrations/logcontext/nrlogrusplugin/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/newrelic/go-agent/v3 v3.16.1
 	// v1.4.0 is required for for the log.WithContext.
 	github.com/sirupsen/logrus v1.4.0
+	golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68 // indirect
 )

--- a/v3/integrations/logcontext/nrlogrusplugin/go.mod
+++ b/v3/integrations/logcontext/nrlogrusplugin/go.mod
@@ -5,7 +5,7 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext/nrlogrusplugin
 go 1.13
 
 require (
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/newrelic/go-agent/v3 v3.16.1
 	// v1.4.0 is required for for the log.WithContext.
 	github.com/sirupsen/logrus v1.4.0
 )

--- a/v3/integrations/logcontext/nrlogrusplugin/nrlogrusplugin_test.go
+++ b/v3/integrations/logcontext/nrlogrusplugin/nrlogrusplugin_test.go
@@ -93,7 +93,15 @@ func BenchmarkTextFormatter(b *testing.B) {
 }
 
 func BenchmarkWithTransaction(b *testing.B) {
-	app := integrationsupport.NewTestApp(nil, nil)
+	app := integrationsupport.NewTestApp(
+		func(reply *internal.ConnectReply) {
+			reply.SetSampleNothing()
+			// reply.TraceIDGenerator = internal.NewTraceIDGenerator(12345)
+		},
+		func(cfg *newrelic.Config) {
+			cfg.DistributedTracer.Enabled = false
+			cfg.CrossApplicationTracer.Enabled = false
+		})
 	txn := app.StartTransaction("TestLogDistributedTracingDisabled")
 	log := newTestLogger(bytes.NewBuffer([]byte("")))
 	ctx := newrelic.NewContext(context.Background(), txn)
@@ -135,7 +143,15 @@ func TestLogNoTxn(t *testing.T) {
 }
 
 func TestLogDistributedTracingDisabled(t *testing.T) {
-	app := integrationsupport.NewTestApp(nil, nil)
+	app := integrationsupport.NewTestApp(
+		func(reply *internal.ConnectReply) {
+			reply.SetSampleNothing()
+			// reply.TraceIDGenerator = internal.NewTraceIDGenerator(12345)
+		},
+		func(cfg *newrelic.Config) {
+			cfg.DistributedTracer.Enabled = false
+			cfg.CrossApplicationTracer.Enabled = false
+		})
 	txn := app.StartTransaction("TestLogDistributedTracingDisabled")
 	out := bytes.NewBuffer([]byte{})
 	log := newTestLogger(out)
@@ -286,6 +302,7 @@ func TestEntryError(t *testing.T) {
 		"message":     "Hello World!",
 		"method.name": matchAnything,
 		"timestamp":   float64(1417136460000),
+		"trace.id":    matchAnything,
 	})
 }
 
@@ -307,6 +324,7 @@ func TestWithCustomField(t *testing.T) {
 		"method.name": matchAnything,
 		"timestamp":   float64(1417136460000),
 		"zip":         "zap",
+		"trace.id":    matchAnything,
 	})
 }
 

--- a/v3/integrations/nrecho-v3/go.mod
+++ b/v3/integrations/nrecho-v3/go.mod
@@ -4,10 +4,11 @@ module github.com/newrelic/go-agent/v3/integrations/nrecho-v3
 // https://github.com/labstack/echo/blob/v3.1.0/.travis.yml
 go 1.7
 
+
 require (
 	// v3.1.0 is the earliest v3 version of Echo that works with modules due
 	// to the github.com/rsc/letsencrypt import of v3.0.0.
 	github.com/labstack/echo v3.1.0+incompatible
 	github.com/labstack/gommon v0.3.0 // indirect
-	github.com/newrelic/go-agent/v3 v3.16.1
+	github.com/newrelic/go-agent/v3 v3.0.0
 )

--- a/v3/integrations/nrecho-v3/go.mod
+++ b/v3/integrations/nrecho-v3/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/go-agent/v3/integrations/nrecho-v3
 
-// 1.7 is the earliest version of Go tested by v3.1.0:
+// 1.7 is the earliest version of Go tested by v3.16.1:
 // https://github.com/labstack/echo/blob/v3.1.0/.travis.yml
 go 1.7
 
@@ -9,6 +9,5 @@ require (
 	// to the github.com/rsc/letsencrypt import of v3.0.0.
 	github.com/labstack/echo v3.1.0+incompatible
 	github.com/labstack/gommon v0.3.0 // indirect
-	github.com/newrelic/go-agent/v3 v3.0.0
-	golang.org/x/crypto v0.0.0-20191119213627-4f8c1d86b1ba // indirect
+	github.com/newrelic/go-agent/v3 v3.16.1
 )

--- a/v3/integrations/nrecho-v3/nrecho_test.go
+++ b/v3/integrations/nrecho-v3/nrecho_test.go
@@ -34,13 +34,19 @@ func TestBasicRoute(t *testing.T) {
 		t.Error("wrong response body", respBody)
 	}
 	app.ExpectTxnMetrics(t, internal.WantTxn{
-		Name:  "GET /hello",
-		IsWeb: true,
+		Name:          "GET /hello",
+		IsWeb:         true,
+		UnknownCaller: true,
 	})
 	app.ExpectTxnEvents(t, []internal.WantEvent{{
 		Intrinsics: map[string]interface{}{
 			"name":             "WebTransaction/Go/GET /hello",
 			"nr.apdexPerfZone": "S",
+			"sampled":          false,
+			// Note: "*" is a wildcard value
+			"guid":     "*",
+			"traceId":  "*",
+			"priority": "*",
 		},
 		AgentAttributes: map[string]interface{}{
 			"httpResponseCode":             "200",
@@ -94,9 +100,11 @@ func TestTransactionContext(t *testing.T) {
 		t.Error("wrong response body", respBody)
 	}
 	app.ExpectTxnMetrics(t, internal.WantTxn{
-		Name:      "GET /hello",
-		IsWeb:     true,
-		NumErrors: 1,
+		Name:          "GET /hello",
+		IsWeb:         true,
+		NumErrors:     1,
+		UnknownCaller: true,
+		ErrorByCaller: true,
 	})
 }
 
@@ -114,8 +122,9 @@ func TestNotFoundHandler(t *testing.T) {
 
 	e.ServeHTTP(response, req)
 	app.ExpectTxnMetrics(t, internal.WantTxn{
-		Name:  "NotFoundHandler",
-		IsWeb: true,
+		Name:          "NotFoundHandler",
+		IsWeb:         true,
+		UnknownCaller: true,
 	})
 }
 
@@ -136,9 +145,11 @@ func TestMethodNotAllowedHandler(t *testing.T) {
 
 	e.ServeHTTP(response, req)
 	app.ExpectTxnMetrics(t, internal.WantTxn{
-		Name:      "MethodNotAllowedHandler",
-		IsWeb:     true,
-		NumErrors: 1,
+		Name:          "MethodNotAllowedHandler",
+		IsWeb:         true,
+		NumErrors:     1,
+		UnknownCaller: true,
+		ErrorByCaller: true,
 	})
 }
 
@@ -159,14 +170,20 @@ func TestReturnsHTTPError(t *testing.T) {
 
 	e.ServeHTTP(response, req)
 	app.ExpectTxnMetrics(t, internal.WantTxn{
-		Name:      "GET /hello",
-		IsWeb:     true,
-		NumErrors: 1,
+		Name:          "GET /hello",
+		IsWeb:         true,
+		NumErrors:     1,
+		UnknownCaller: true,
+		ErrorByCaller: true,
 	})
 	app.ExpectTxnEvents(t, []internal.WantEvent{{
 		Intrinsics: map[string]interface{}{
 			"name":             "WebTransaction/Go/GET /hello",
 			"nr.apdexPerfZone": "F",
+			"sampled":          false,
+			"guid":             "*",
+			"traceId":          "*",
+			"priority":         "*",
 		},
 		AgentAttributes: map[string]interface{}{
 			"httpResponseCode": "418",
@@ -195,14 +212,20 @@ func TestReturnsError(t *testing.T) {
 
 	e.ServeHTTP(response, req)
 	app.ExpectTxnMetrics(t, internal.WantTxn{
-		Name:      "GET /hello",
-		IsWeb:     true,
-		NumErrors: 1,
+		Name:          "GET /hello",
+		IsWeb:         true,
+		NumErrors:     1,
+		UnknownCaller: true,
+		ErrorByCaller: true,
 	})
 	app.ExpectTxnEvents(t, []internal.WantEvent{{
 		Intrinsics: map[string]interface{}{
 			"name":             "WebTransaction/Go/GET /hello",
 			"nr.apdexPerfZone": "F",
+			"sampled":          false,
+			"guid":             "*",
+			"traceId":          "*",
+			"priority":         "*",
 		},
 		AgentAttributes: map[string]interface{}{
 			"httpResponseCode": "500",
@@ -231,14 +254,20 @@ func TestResponseCode(t *testing.T) {
 
 	e.ServeHTTP(response, req)
 	app.ExpectTxnMetrics(t, internal.WantTxn{
-		Name:      "GET /hello",
-		IsWeb:     true,
-		NumErrors: 1,
+		Name:          "GET /hello",
+		IsWeb:         true,
+		NumErrors:     1,
+		UnknownCaller: true,
+		ErrorByCaller: true,
 	})
 	app.ExpectTxnEvents(t, []internal.WantEvent{{
 		Intrinsics: map[string]interface{}{
 			"name":             "WebTransaction/Go/GET /hello",
 			"nr.apdexPerfZone": "F",
+			"sampled":          false,
+			"guid":             "*",
+			"traceId":          "*",
+			"priority":         "*",
 		},
 		AgentAttributes: map[string]interface{}{
 			"httpResponseCode":             "418",

--- a/v3/integrations/nrgraphqlgo/example/go.mod
+++ b/v3/integrations/nrgraphqlgo/example/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/graphql-go/graphql v0.7.9
 	github.com/graphql-go/graphql-go-handler v0.2.3
+	github.com/graphql-go/handler v0.2.3 // indirect
 	github.com/newrelic/go-agent/v3 v3.3.0
 	github.com/newrelic/go-agent/v3/integrations/nrgraphqlgo v1.0.0
 )

--- a/v3/integrations/nrgraphqlgo/go.mod
+++ b/v3/integrations/nrgraphqlgo/go.mod
@@ -1,8 +1,18 @@
 module github.com/newrelic/go-agent/v3/integrations/nrgraphqlgo
 
-go 1.13
+go 1.17
 
 require (
-	github.com/graphql-go/graphql v0.7.9
-	github.com/newrelic/go-agent/v3 v3.3.0
+	github.com/graphql-go/graphql v0.8.0
+	github.com/newrelic/go-agent/v3 v3.16.1
+)
+
+require (
+	github.com/golang/protobuf v1.5.2 // indirect
+	golang.org/x/net v0.0.0-20220615171555-694bf12d69de // indirect
+	golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90 // indirect
+	google.golang.org/grpc v1.47.0 // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
 )

--- a/v3/integrations/nrgraphqlgo/nrgraphqlgo_test.go
+++ b/v3/integrations/nrgraphqlgo/nrgraphqlgo_test.go
@@ -95,9 +95,10 @@ func TestExtensionWithTransaction(t *testing.T) {
 		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransactionTotalTime/Go/query", Scope: "", Forced: false, Data: nil},
+		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
+		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
 	})
 }
-
 func TestExtensionResolveError(t *testing.T) {
 	app := integrationsupport.NewBasicTestApp()
 	txn := app.StartTransaction("query")
@@ -140,12 +141,21 @@ func TestExtensionResolveError(t *testing.T) {
 		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransactionTotalTime/Go/query", Scope: "", Forced: false, Data: nil},
+		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
+		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
+		{Name: "ErrorsByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
+		{Name: "ErrorsByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
 	})
 	app.ExpectErrorEvents(t, []internal.WantEvent{{
 		Intrinsics: map[string]interface{}{
 			"error.message":   "ooooooops",
 			"error.class":     internal.MatchAnything,
 			"transactionName": "OtherTransaction/Go/query",
+			"sampled":         false,
+			// Note: "*" is a wildcard value
+			"guid":     "*",
+			"traceId":  "*",
+			"priority": "*",
 		},
 	}})
 }
@@ -177,12 +187,20 @@ func TestExtensionParseError(t *testing.T) {
 		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransactionTotalTime/Go/query", Scope: "", Forced: false, Data: nil},
+		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
+		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
+		{Name: "ErrorsByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
+		{Name: "ErrorsByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
 	})
 	app.ExpectErrorEvents(t, []internal.WantEvent{{
 		Intrinsics: map[string]interface{}{
 			"error.message":   internal.MatchAnything,
 			"error.class":     internal.MatchAnything,
 			"transactionName": "OtherTransaction/Go/query",
+			"sampled":         false,
+			"guid":            "*",
+			"traceId":         "*",
+			"priority":        "*",
 		},
 	}})
 }
@@ -216,12 +234,20 @@ func TestExtensionValidationError(t *testing.T) {
 		{Name: "OtherTransaction/all", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransactionTotalTime", Scope: "", Forced: true, Data: nil},
 		{Name: "OtherTransactionTotalTime/Go/query", Scope: "", Forced: false, Data: nil},
+		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
+		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
+		{Name: "ErrorsByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: nil},
+		{Name: "ErrorsByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: nil},
 	})
 	app.ExpectErrorEvents(t, []internal.WantEvent{{
 		Intrinsics: map[string]interface{}{
 			"error.message":   internal.MatchAnything,
 			"error.class":     internal.MatchAnything,
 			"transactionName": "OtherTransaction/Go/query",
+			"sampled":         false,
+			"guid":            "*",
+			"traceId":         "*",
+			"priority":        "*",
 		},
 	}})
 }

--- a/v3/integrations/nrhttprouter/go.mod
+++ b/v3/integrations/nrhttprouter/go.mod
@@ -3,9 +3,8 @@ module github.com/newrelic/go-agent/v3/integrations/nrhttprouter
 // As of Dec 2019, the httprouter go.mod file uses 1.7:
 // https://github.com/julienschmidt/httprouter/blob/master/go.mod
 go 1.7
-
 require (
 	// v1.3.0 is the earliest version of httprouter using modules.
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/newrelic/go-agent/v3 v3.16.1
 )

--- a/v3/integrations/nrhttprouter/nrhttprouter_test.go
+++ b/v3/integrations/nrhttprouter/nrhttprouter_test.go
@@ -48,9 +48,11 @@ func TestMethodFunctions(t *testing.T) {
 			t.Error("wrong response body", respBody)
 		}
 		app.ExpectTxnMetrics(t, internal.WantTxn{
-			Name:      md.Method + " /hello/:name",
-			IsWeb:     true,
-			NumErrors: 1,
+			Name:          md.Method + " /hello/:name",
+			IsWeb:         true,
+			NumErrors:     1,
+			UnknownCaller: true,
+			ErrorByCaller: true,
 		})
 	}
 }
@@ -93,15 +95,22 @@ func TestHandle(t *testing.T) {
 		t.Error("wrong response body", respBody)
 	}
 	app.ExpectTxnMetrics(t, internal.WantTxn{
-		Name:      "GET /hello/:name",
-		IsWeb:     true,
-		NumErrors: 1,
+		Name:          "GET /hello/:name",
+		IsWeb:         true,
+		NumErrors:     1,
+		UnknownCaller: true,
+		ErrorByCaller: true,
 	})
 	app.ExpectTxnEvents(t, []internal.WantEvent{
 		{
 			Intrinsics: map[string]interface{}{
 				"name":             "WebTransaction/Go/GET /hello/:name",
 				"nr.apdexPerfZone": internal.MatchAnything,
+				"sampled":          false,
+				// Note: "*" is a wildcard value
+				"guid":     "*",
+				"traceId":  "*",
+				"priority": "*",
 			},
 			UserAttributes: map[string]interface{}{
 				"color": "purple",
@@ -137,15 +146,22 @@ func TestHandler(t *testing.T) {
 		t.Error("wrong response body", respBody)
 	}
 	app.ExpectTxnMetrics(t, internal.WantTxn{
-		Name:      "GET /hello/",
-		IsWeb:     true,
-		NumErrors: 1,
+		Name:          "GET /hello/",
+		IsWeb:         true,
+		NumErrors:     1,
+		UnknownCaller: true,
+		ErrorByCaller: true,
 	})
 	app.ExpectTxnEvents(t, []internal.WantEvent{
 		{
 			Intrinsics: map[string]interface{}{
 				"name":             "WebTransaction/Go/GET /hello/",
 				"nr.apdexPerfZone": internal.MatchAnything,
+				"sampled":          false,
+				// Note: "*" is a wildcard value
+				"guid":     "*",
+				"traceId":  "*",
+				"priority": "*",
 			},
 			UserAttributes: map[string]interface{}{
 				"color": "purple",
@@ -197,9 +213,11 @@ func TestHandlerFunc(t *testing.T) {
 		t.Error("wrong response body", respBody)
 	}
 	app.ExpectTxnMetrics(t, internal.WantTxn{
-		Name:      "GET /hello/",
-		IsWeb:     true,
-		NumErrors: 1,
+		Name:          "GET /hello/",
+		IsWeb:         true,
+		NumErrors:     1,
+		UnknownCaller: true,
+		ErrorByCaller: true,
 	})
 }
 
@@ -224,15 +242,22 @@ func TestNotFound(t *testing.T) {
 		t.Error("wrong response body", respBody)
 	}
 	app.ExpectTxnMetrics(t, internal.WantTxn{
-		Name:      "NotFound",
-		IsWeb:     true,
-		NumErrors: 1,
+		Name:          "NotFound",
+		IsWeb:         true,
+		NumErrors:     1,
+		UnknownCaller: true,
+		ErrorByCaller: true,
 	})
 	app.ExpectTxnEvents(t, []internal.WantEvent{
 		{
 			Intrinsics: map[string]interface{}{
 				"name":             "WebTransaction/Go/NotFound",
 				"nr.apdexPerfZone": internal.MatchAnything,
+				"sampled":          false,
+				// Note: "*" is a wildcard value
+				"guid":     "*",
+				"traceId":  "*",
+				"priority": "*",
 			},
 			UserAttributes: map[string]interface{}{
 				"color": "purple",
@@ -280,7 +305,8 @@ func TestNotFoundNotSet(t *testing.T) {
 		t.Error(response.Code)
 	}
 	app.ExpectTxnMetrics(t, internal.WantTxn{
-		Name:  "NotFound",
-		IsWeb: true,
+		Name:          "NotFound",
+		IsWeb:         true,
+		UnknownCaller: true,
 	})
 }

--- a/v3/integrations/nrzap/go.mod
+++ b/v3/integrations/nrzap/go.mod
@@ -5,7 +5,20 @@ module github.com/newrelic/go-agent/v3/integrations/nrzap
 go 1.13
 
 require (
-	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/BurntSushi/toml v1.1.0 // indirect
+	github.com/google/renameio v0.1.0 // indirect
+	github.com/kisielk/gotool v1.0.0 // indirect
+	github.com/newrelic/go-agent/v3 v3.16.1
+	github.com/rogpeppe/go-internal v1.3.0 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/multierr v1.8.0 // indirect
+	go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee // indirect
 	// v1.12.0 is the earliest version of zap using modules.
-	go.uber.org/zap v1.12.0
+	go.uber.org/zap v1.21.0
+	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
+	golang.org/x/net v0.0.0-20220615171555-694bf12d69de // indirect
+	golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c // indirect
+	golang.org/x/tools v0.1.11 // indirect
+	google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90 // indirect
+	honnef.co/go/tools v0.3.2 // indirect
 )

--- a/v3/integrations/nrzap/go.mod
+++ b/v3/integrations/nrzap/go.mod
@@ -1,9 +1,8 @@
 module github.com/newrelic/go-agent/v3/integrations/nrzap
 
-// As of Dec 2019, zap has 1.13 in their go.mod file:
+// As of Jun 2022, zap has 1.18 in their go.mod file:
 // https://github.com/uber-go/zap/blob/master/go.mod
-go 1.13
-
+go 1.18
 require (
 	github.com/BurntSushi/toml v1.1.0 // indirect
 	github.com/google/renameio v0.1.0 // indirect
@@ -13,7 +12,7 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee // indirect
-	// v1.12.0 is the earliest version of zap using modules.
+	// v1.21.0 is the earliest version of zap using modules.
 	go.uber.org/zap v1.21.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/net v0.0.0-20220615171555-694bf12d69de // indirect

--- a/v3/integrations/nrzap/go.mod
+++ b/v3/integrations/nrzap/go.mod
@@ -3,21 +3,20 @@ module github.com/newrelic/go-agent/v3/integrations/nrzap
 // As of Jun 2022, zap has 1.18 in their go.mod file:
 // https://github.com/uber-go/zap/blob/master/go.mod
 go 1.18
+
 require (
-	github.com/BurntSushi/toml v1.1.0 // indirect
-	github.com/google/renameio v0.1.0 // indirect
-	github.com/kisielk/gotool v1.0.0 // indirect
 	github.com/newrelic/go-agent/v3 v3.16.1
-	github.com/rogpeppe/go-internal v1.3.0 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
-	go.uber.org/multierr v1.8.0 // indirect
-	go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee // indirect
-	// v1.21.0 is the earliest version of zap using modules.
 	go.uber.org/zap v1.21.0
-	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
-	golang.org/x/net v0.0.0-20220615171555-694bf12d69de // indirect
-	golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c // indirect
-	golang.org/x/tools v0.1.11 // indirect
-	google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90 // indirect
-	honnef.co/go/tools v0.3.2 // indirect
+)
+
+require (
+	github.com/golang/protobuf v1.4.3 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/grpc v1.39.0 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
 )


### PR DESCRIPTION


## Details
Includes fixes/dependancy bumps for nrgraphqlgo_test, nrecho-v3, and nrhttprouter tests. All of these tests required additional distributed tracing tests in a similar fashion to nrecho-v4.