### PR TITLE
Json speed issue 505

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -4,6 +4,5 @@ go 1.7
 
 require (
 	github.com/golang/protobuf v1.4.3
-	github.com/pkg/profile v1.6.0 // indirect
 	google.golang.org/grpc v1.39.0
 )

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -4,5 +4,6 @@ go 1.7
 
 require (
 	github.com/golang/protobuf v1.4.3
+	github.com/pkg/profile v1.6.0 // indirect
 	google.golang.org/grpc v1.39.0
 )

--- a/v3/internal/jsonx/encode.go
+++ b/v3/internal/jsonx/encode.go
@@ -118,6 +118,21 @@ func AppendFloat(buf *bytes.Buffer, x float64) error {
 	return nil
 }
 
+func AppendFloat32(buf *bytes.Buffer, x float32) error {
+	var scratch [64]byte
+	x64 := float64(x)
+
+	if math.IsInf(x64, 0) || math.IsNaN(x64) {
+		return &json.UnsupportedValueError{
+			Value: reflect.ValueOf(x64),
+			Str:   strconv.FormatFloat(x64, 'g', -1, 32),
+		}
+	}
+
+	buf.Write(strconv.AppendFloat(scratch[:0], x64, 'g', -1, 32))
+	return nil
+}
+
 // AppendFloatArray appends an array of numeric literals to buf.
 func AppendFloatArray(buf *bytes.Buffer, a ...float64) error {
 	buf.WriteByte('[')

--- a/v3/newrelic/distributed_tracing.go
+++ b/v3/newrelic/distributed_tracing.go
@@ -183,6 +183,8 @@ func (p payload) validateNewRelicData() error {
 	return nil
 }
 
+const payloadJSONStartingSizeEstimate = 256
+
 func (p payload) text(v distTraceVersion) []byte {
 	// TrustedAccountKey should only be attached to the outbound payload if its value differs
 	// from the Account field.
@@ -190,7 +192,7 @@ func (p payload) text(v distTraceVersion) []byte {
 		p.TrustedAccountKey = ""
 	}
 
-	js := bytes.NewBuffer(make([]byte, 0, 256))
+	js := bytes.NewBuffer(make([]byte, 0, payloadJSONStartingSizeEstimate))
 	w := jsonFieldsWriter{
 		buf: js,
 	}

--- a/v3/newrelic/distributed_tracing.go
+++ b/v3/newrelic/distributed_tracing.go
@@ -181,9 +181,9 @@ func (p payload) text(v distTraceVersion) []byte {
 		p.TrustedAccountKey = ""
 	}
 
-	var js bytes.Buffer
+	js := bytes.NewBuffer(make([]byte, 0, 256))
 	w := jsonFieldsWriter{
-		buf: &js,
+		buf: js,
 	}
 	js.WriteByte('{')
 	w.writerField("v", v)

--- a/v3/newrelic/json_object_writer.go
+++ b/v3/newrelic/json_object_writer.go
@@ -44,6 +44,11 @@ func (w *jsonFieldsWriter) floatField(key string, val float64) {
 	jsonx.AppendFloat(w.buf, val)
 }
 
+func (w *jsonFieldsWriter) float32Field(key string, val float32) {
+	w.addKey(key)
+	jsonx.AppendFloat32(w.buf, val)
+}
+
 func (w *jsonFieldsWriter) boolField(key string, val bool) {
 	w.addKey(key)
 	if val {


### PR DESCRIPTION
This PR addresses [issue 505](https://github.com/newrelic/go-agent/issues/505) by replacing the more expensive standard library `json.Marshal` calls with faster internal ones.
