### PR TITLE
updates to release 3.17.0 of the agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 	* Resolves [issue 178](https://github.com/newrelic/go-agent/issues/178), [issue 488](https://github.com/newrelic/go-agent/issues/488), [issue 489](https://github.com/newrelic/go-agent/issues/489), [issue 490](https://github.com/newrelic/go-agent/issues/490), and [issue 491](https://github.com/newrelic/go-agent/issues/491) .
 * Added integration for MS SQL Server ([PR 425](https://github.com/newrelic/go-agent/pull/425); thanks @ishahid91!)
 	* This introduces the `nrmssql` integration v1.0.0.
+* Added config function `ConfigCustomInsightsEventsMaxSamplesStored` for limiting the number of samples stored in a custom insights event. Fixes [issue 476](https://github.com/newrelic/go-agent/issues/476)
 
 ### Fixed
 * Improved speed of building distributed trace header JSON payload. Fixes [issue 505](https://github.com/newrelic/go-agent/issues/505).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 3.17.0
+### Added
+* Logs in context now supported for zerolog.
+* This is a quick way to view logs no matter where you are in the platform.
+	* Adds support for logging metrics which shows the rate of log messages by severity in the Logs chart in the APM Summary view. This is enabled by default in this release.
+	* Adds support for forwarding application logs to New Relic. This automatically sends application logs that have been enriched to power APM logs in context. This is disabled by default in this release. This will be on by default in a future release.
+	* To learn more about APM logs in context see the documentation [here](https://docs.newrelic.com/docs/logs/logs-context/logs-in-context).
+	* Includes the `RecordLog` function for recording log data from a single log entry
+	* An integrated plugin for zerolog to automatically ingest log data with the Go Agent.
+	* Resolves [issue 178](https://github.com/newrelic/go-agent/issues/178), [issue 488](https://github.com/newrelic/go-agent/issues/488), [issue 489](https://github.com/newrelic/go-agent/issues/489), [issue 490](https://github.com/newrelic/go-agent/issues/490), and [issue 491](https://github.com/newrelic/go-agent/issues/491) .
+* Added integration for MS SQL Server ([PR 425](https://github.com/newrelic/go-agent/pull/425); thanks @ishahid91!)
+	* This introduces the `nrmssql` integration v1.0.0.
+
+### Fixed
+* Improved speed of building distributed trace header JSON payload. Fixes [issue 505](https://github.com/newrelic/go-agent/issues/505).
+* Renamed the gRPC attribute names from  `GrpcStatusLevel`, `GrpcStatusMessage`, and `GrpcStatusCode` to `grpcStatusLevel`, `grpcStatusMessage`, and `grpcStatusCode` respectively, to conform to existing naming conventions for New Relic agents. Fixes [issue 492](https://github.com/newrelic/go-agent/issues/492).
+* Updated `go.mod` for the `nrgin` integration to mitigate security issue in 3rd party dependency.
+* Updated `go.mod` for the `nrawssdk-v1` integration to properly reflect its dependency on version 3.16.0 of the Go Agent.
+* Updated `go.mod` for the `nrlambda` integration to require `aws-lambda-go` version 1.20.0. ([PR 356](https://github.com/newrelic/go-agent/pull/356); thanks MattWhelan!)
+
+### Support Statement
+New Relic recommends that you upgrade the agent regularly to ensure that you’re getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach end-of-life.
+* Note that the oldest supported version of the Go Agent is 3.6.0.
+
 # ChangeLog
 ## 3.16.1
 ### Fixed

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -67,7 +67,7 @@ Now, add instrumentation to your Go application to get additional performance da
 * Import any of our [integration packages](https://github.com/newrelic/go-agent#integrations) for out-of-the box support for many popular Go web 
 frameworks and libraries. 
 * [Instrument Transactions](#transactions)
-* [Use Distributed Tracing](#distributed-tracing)
+* [Use Distributed Tracing](#distributed-tracing) (Note that this is on by default.)
 * [(Optional) Instrument Segments](#segments) for an extra level of timing detail
   * External segments are needed for Distributed Tracing
 * Read through the rest of this GUIDE for more instrumentation
@@ -101,6 +101,9 @@ app, err := newrelic.NewApplication(
 
 
 ## Logging
+
+For information about logs in context, please see [the documentation here](https://docs.newrelic.com/docs/logs/logs-context/logs-in-context).
+As of Go Agent version 3.17.0, we support logs in context with the zerolog integration.
 
 The agent's logging system is designed to be easily extensible.  By default, no
 logging will occur.  To enable logging, use the following config functions

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Go is a compiled language, and doesn’t use a virtual machine. This means that 
 ### Compatibility and Requirements
 
 For the latest version of the agent, Go 1.7+ is required, due to the use of `context.Context`.
-(For versions 2.X and earlier of the Go agent, Go 1.3+ is required.)
 
 Linux, OS X, and Windows (Vista, Server 2008 and later) are supported.
 
@@ -91,6 +90,7 @@ package primitives can be found [here](GUIDE.md#datastore-segments).
 | ------------- | ------------- | - |
 | [lib/pq](https://github.com/lib/pq) | [v3/integrations/nrpq](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrpq) | Instrument PostgreSQL driver (`pq` driver for `database/sql`) |
 | [jackc/pgx](https://github.com/jackc/pgx) | [v3/integrations/nrpgx](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrpgx) | Instrument PostgreSQL driver (`pgx` driver for `database/sql`)|
+| [go-mssqldb](github.com/denisenkom/go-mssqldb) | [v3/integrations/nrmssql](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrmssql) | Instrument MS SQL driver |
 | [go-sql-driver/mysql](https://github.com/go-sql-driver/mysql) | [v3/integrations/nrmysql](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrmysql) | Instrument MySQL driver |
 | [elastic/go-elasticsearch](https://github.com/elastic/go-elasticsearch) | [v3/integrations/nrelasticsearch-v7](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrelasticsearch-v7) | Instrument Elasticsearch datastore calls |
 | [database/sql](https://godoc.org/database/sql) | Use a supported database driver or [builtin instrumentation](https://godoc.org/github.com/newrelic/go-agent/v3/newrelic#InstrumentSQLConnector) | Instrument database calls with SQL |

--- a/v3/newrelic/version.go
+++ b/v3/newrelic/version.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Version is the full string version of this Go Agent.
-	Version = "3.16.1"
+	Version = "3.17.0"
 )
 
 var (


### PR DESCRIPTION
## 3.17.0
### Added
* Logs in context now supported for zerolog.
* This is a quick way to view logs no matter where you are in the platform.
        * Adds support for logging metrics which shows the rate of log messages by severity in the Logs chart in the APM Summary view. This is enabled by default in this release.
        * Adds support for forwarding application logs to New Relic. This automatically sends application logs that have been enriched to power APM logs in context. This is disabled by default in this release. This will be on by default in a future release.
        * To learn more about APM logs in context see the documentation [here](https://docs.newrelic.com/docs/logs/logs-context/logs-in-context).
        * Includes the `RecordLog` function for recording log data from a single log entry
        * An integrated plugin for zerolog to automatically ingest log data with the Go Agent.
        * Resolves [issue 178](https://github.com/newrelic/go-agent/issues/178), [issue 488](https://github.com/newrelic/go-agent/issues/488), [issue 489](https://github.com/newrelic/go-agent/issues/489), [issue 490](https://github.com/newrelic/go-agent/issues/490), and [issue 491](https://github.com/newrelic/go-agent/issues/491) .
* Added integration for MS SQL Server ([PR 425](https://github.com/newrelic/go-agent/pull/425); thanks @ishahid91!)
        * This introduces the `nrmssql` integration v1.0.0.

### Fixed
* Improved speed of building distributed trace header JSON payload. Fixes [issue 505](https://github.com/newrelic/go-agent/issues/505).
* Renamed the gRPC attribute names from  `GrpcStatusLevel`, `GrpcStatusMessage`, and `GrpcStatusCode` to `grpcStatusLevel`, `grpcStatusMessage`, and `grpcStatusCode` respectively, to conform to existing naming conventions for New Relic agents. Fixes [issue 492](https://github.com/newrelic/go-agent/issues/492).
* Updated `go.mod` for the `nrgin` integration to mitigate security issue in 3rd party dependency.
* Updated `go.mod` for the `nrawssdk-v1` integration to properly reflect its dependency on version 3.16.0 of the Go Agent.
* Updated `go.mod` for the `nrlambda` integration to require `aws-lambda-go` version 1.20.0. ([PR 356](https://github.com/newrelic/go-agent/pull/356); thanks MattWhelan!)

### Support Statement
New Relic recommends that you upgrade the agent regularly to ensure that you’re getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach end-of-life.
* Note that the oldest supported version of the Go Agent is 3.6.0.