### PR TITLE
Harvest Limit Increase + Patch for DT Spans

### DIFF
--- a/v3/internal/connect_reply.go
+++ b/v3/internal/connect_reply.go
@@ -125,6 +125,7 @@ type EventHarvestConfig struct {
 	} `json:"harvest_limits"`
 }
 
+// SpanEventHarvestConfig contains the Reporting period time and the given harvest limit.
 type SpanEventHarvestConfig struct {
 	ReportPeriod *uint `json:"report_period_ms"`
 	HarvestLimit *uint `json:"harvest_limit"`

--- a/v3/internal/connect_reply.go
+++ b/v3/internal/connect_reply.go
@@ -104,7 +104,8 @@ type ConnectReply struct {
 	} `json:"agent_config"`
 
 	// Faster Event Harvest
-	EventData EventHarvestConfig `json:"event_harvest_config"`
+	EventData              EventHarvestConfig `json:"event_harvest_config"`
+	SpanEventHarvestConfig `json:"span_event_harvest_config"`
 }
 
 // EventHarvestConfig contains fields relating to faster event harvest.
@@ -122,6 +123,11 @@ type EventHarvestConfig struct {
 		ErrorEvents  *uint `json:"error_event_data,omitempty"`
 		SpanEvents   *uint `json:"span_event_data,omitempty"`
 	} `json:"harvest_limits"`
+}
+
+type SpanEventHarvestConfig struct {
+	ReportPeriod *uint `json:"report_period_ms"`
+	HarvestLimit *uint `json:"harvest_limit"`
 }
 
 // ConfigurablePeriod returns the Faster Event Harvest configurable reporting period if it is set, or the default

--- a/v3/internal/connect_reply_test.go
+++ b/v3/internal/connect_reply_test.go
@@ -5,6 +5,7 @@ package internal
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -178,7 +179,7 @@ func TestDefaultEventHarvestConfigJSON(t *testing.T) {
 		t.Error(err)
 	}
 
-	expect := `{"report_period_ms":60000,"harvest_limits":{"analytic_event_data":10000,"custom_event_data":10000,"log_event_data":10000,"error_event_data":100}}`
+	expect := fmt.Sprintf(`{"report_period_ms":60000,"harvest_limits":{"analytic_event_data":10000,"custom_event_data":%d,"log_event_data":%d,"error_event_data":100}}`, MaxCustomEvents, MaxLogEvents)
 	if string(js) != expect {
 		t.Errorf("DefaultEventHarvestConfig does not match expected valued:\nExpected:\t%s\nActual:\t\t%s", expect, string(js))
 	}

--- a/v3/internal/limits.go
+++ b/v3/internal/limits.go
@@ -13,10 +13,10 @@ const (
 	// MaxPayloadSizeInBytes specifies the maximum payload size in bytes that
 	// should be sent to any endpoint
 	MaxPayloadSizeInBytes = 1000 * 1000
-
 	// MaxCustomEvents is the maximum number of Transaction Events that can be captured
 	// per 60-second harvest cycle
-	MaxCustomEvents = 10 * 1000
+	MaxCustomEvents = 30 * 1000
+	// MaxCustomEvents
 	// MaxLogEvents is the maximum number of Log Events that can be captured per
 	// 60-second harvest cycle
 	MaxLogEvents = 10 * 1000
@@ -25,5 +25,7 @@ const (
 	MaxTxnEvents = 10 * 1000
 	// MaxErrorEvents is the maximum number of Error Events that can be captured
 	// per 60-second harvest cycle
-	MaxErrorEvents = 100
+	MaxErrorEvents                 = 100
+	DefaultCustomEventsLimit       = 30 * 1000
+	DefaultCustomEventsLimitLegacy = 10 * 10000
 )

--- a/v3/internal/limits.go
+++ b/v3/internal/limits.go
@@ -15,7 +15,7 @@ const (
 	MaxPayloadSizeInBytes = 1000 * 1000
 	// MaxCustomEvents is the maximum number of Transaction Events that can be captured
 	// per 60-second harvest cycle
-	MaxCustomEvents = 30 * 1000
+	MaxCustomEvents = 10 * 1000
 	// MaxLogEvents is the maximum number of Log Events that can be captured per
 	// 60-second harvest cycle
 	MaxLogEvents = 10 * 1000

--- a/v3/internal/limits.go
+++ b/v3/internal/limits.go
@@ -16,7 +16,6 @@ const (
 	// MaxCustomEvents is the maximum number of Transaction Events that can be captured
 	// per 60-second harvest cycle
 	MaxCustomEvents = 30 * 1000
-	// MaxCustomEvents
 	// MaxLogEvents is the maximum number of Log Events that can be captured per
 	// 60-second harvest cycle
 	MaxLogEvents = 10 * 1000
@@ -25,7 +24,5 @@ const (
 	MaxTxnEvents = 10 * 1000
 	// MaxErrorEvents is the maximum number of Error Events that can be captured
 	// per 60-second harvest cycle
-	MaxErrorEvents                 = 100
-	DefaultCustomEventsLimit       = 30 * 1000
-	DefaultCustomEventsLimitLegacy = 10 * 10000
+	MaxErrorEvents = 100
 )

--- a/v3/newrelic/app_run.go
+++ b/v3/newrelic/app_run.go
@@ -190,7 +190,7 @@ func (run *appRun) ptrTxnEvents() *uint    { return run.Reply.EventData.Limits.T
 func (run *appRun) ptrCustomEvents() *uint { return run.Reply.EventData.Limits.CustomEvents }
 func (run *appRun) ptrLogEvents() *uint    { return run.Reply.EventData.Limits.LogEvents }
 func (run *appRun) ptrErrorEvents() *uint  { return run.Reply.EventData.Limits.ErrorEvents }
-func (run *appRun) ptrSpanEvents() *uint   { return run.Reply.EventData.Limits.SpanEvents }
+func (run *appRun) ptrSpanEvents() *uint   { return run.Reply.SpanEventHarvestConfig.HarvestLimit }
 
 func (run *appRun) MaxTxnEvents() int { return run.limit(run.Config.maxTxnEvents(), run.ptrTxnEvents) }
 func (run *appRun) MaxCustomEvents() int {

--- a/v3/newrelic/app_run_test.go
+++ b/v3/newrelic/app_run_test.go
@@ -147,9 +147,12 @@ func TestEventHarvestFieldsAllPopulated(t *testing.T) {
 					"analytic_event_data": 1,
 					"custom_event_data": 2,
 					"log_event_data": 3,
-					"span_event_data": 4,
-					"error_event_data": 5
+					"error_event_data": 4
 				}
+			},
+			"span_event_harvest_config":{
+				"report_period_ms": 10000,
+				"harvest_limit": 5
 			}
 		}}`), internal.PreconnectReply{})
 	if nil != err {
@@ -160,8 +163,8 @@ func TestEventHarvestFieldsAllPopulated(t *testing.T) {
 		maxTxnEvents:    1,
 		maxCustomEvents: 2,
 		maxLogEvents:    3,
-		maxSpanEvents:   4,
-		maxErrorEvents:  5,
+		maxErrorEvents:  4,
+		maxSpanEvents:   5,
 		periods: map[harvestTypes]time.Duration{
 			harvestMetricsTraces: 60 * time.Second,
 			harvestTypesEvents:   5 * time.Second,
@@ -184,7 +187,7 @@ func TestZeroReportPeriod(t *testing.T) {
 		maxCustomEvents: internal.MaxCustomEvents,
 		maxLogEvents:    internal.MaxLogEvents,
 		maxErrorEvents:  internal.MaxErrorEvents,
-		maxSpanEvents:   run.Config.DistributedTracer.ReservoirLimit,
+		maxSpanEvents:   defaultMaxSpanEvents,
 		periods: map[harvestTypes]time.Duration{
 			harvestTypesAll: 60 * time.Second,
 			0:               60 * time.Second,
@@ -192,11 +195,11 @@ func TestZeroReportPeriod(t *testing.T) {
 	})
 }
 
-func TestEventHarvestFieldsOnlySpanEvents(t *testing.T) {
+func TestConnectResponseOnlySpanEvents(t *testing.T) {
 	reply, err := internal.UnmarshalConnectReply([]byte(`{"return_value":{
-			"event_harvest_config": {
-				"report_period_ms": 5000,
-				"harvest_limits": { "span_event_data": 3 }
+			"span_event_harvest_config":{
+				"report_period_ms": 10000,
+				"harvest_limit": 3
 			}}}`), internal.PreconnectReply{})
 	if nil != err {
 		t.Fatal(err)
@@ -210,7 +213,7 @@ func TestEventHarvestFieldsOnlySpanEvents(t *testing.T) {
 		maxSpanEvents:   3,
 		periods: map[harvestTypes]time.Duration{
 			harvestTypesAll ^ harvestSpanEvents: 60 * time.Second,
-			harvestSpanEvents:                   5 * time.Second,
+			2:                                   60 * time.Second,
 		},
 	})
 }
@@ -283,6 +286,29 @@ func TestEventHarvestFieldsOnlyCustomEvents(t *testing.T) {
 		},
 	})
 }
+
+/*
+func TestCustomEventsReservoirLimit(t *testing.T) {
+	reply, err := internal.UnmarshalConnectReply([]byte(
+		`{"return_value":{
+			"event_harvest_config": {
+				"report_period_ms": 10000
+			}
+        }}`), internal.PreconnectReply{})
+	if nil != err {
+		t.Fatal(err)
+	}
+	expected := 10
+	cfg := config{Config:}
+	cfg.TransactionEvents.MaxSamplesStored = expected
+	result := newAppRun(cfg, reply)
+	t.Error(fmt.Print(result))
+
+	if result != expected {
+		t.Error(fmt.Sprintf("Unexpected max number of txn events, expected %d but got %d", expected, result))
+	}
+}
+*/
 
 func TestConfigurableHarvestNegativeReportPeriod(t *testing.T) {
 	h, err := internal.UnmarshalConnectReply([]byte(`{"return_value":{
@@ -379,8 +405,8 @@ type expectHarvestConfig struct {
 	periods         map[harvestTypes]time.Duration
 }
 
-func errorExpectNotEqualActual(value string, expect, actual interface{}) error {
-	return fmt.Errorf("Expected %s value does not match actual; expected: %+v actual: %+v", value, expect, actual)
+func errorExpectNotEqualActual(value string, actual, expect interface{}) error {
+	return fmt.Errorf("Expected %s value does not match actual; actual: %+v expect: %+v", value, actual, expect)
 }
 func assertHarvestConfig(t testing.TB, hc harvestConfig, expect expectHarvestConfig) {
 	if h, ok := t.(interface {

--- a/v3/newrelic/app_run_test.go
+++ b/v3/newrelic/app_run_test.go
@@ -286,30 +286,6 @@ func TestEventHarvestFieldsOnlyCustomEvents(t *testing.T) {
 		},
 	})
 }
-
-/*
-func TestCustomEventsReservoirLimit(t *testing.T) {
-	reply, err := internal.UnmarshalConnectReply([]byte(
-		`{"return_value":{
-			"event_harvest_config": {
-				"report_period_ms": 10000
-			}
-        }}`), internal.PreconnectReply{})
-	if nil != err {
-		t.Fatal(err)
-	}
-	expected := 10
-	cfg := config{Config:}
-	cfg.TransactionEvents.MaxSamplesStored = expected
-	result := newAppRun(cfg, reply)
-	t.Error(fmt.Print(result))
-
-	if result != expected {
-		t.Error(fmt.Sprintf("Unexpected max number of txn events, expected %d but got %d", expected, result))
-	}
-}
-*/
-
 func TestConfigurableHarvestNegativeReportPeriod(t *testing.T) {
 	h, err := internal.UnmarshalConnectReply([]byte(`{"return_value":{
 			"event_harvest_config": {

--- a/v3/newrelic/config.go
+++ b/v3/newrelic/config.go
@@ -722,7 +722,7 @@ func configConnectJSONInternal(c Config, pid int, util *utilization.Data, e envi
 		Util:             util,
 		SecurityPolicies: securityPolicies,
 		Metadata:         metadata,
-		EventData:        internal.DefaultEventHarvestConfigWithDT(c.maxTxnEvents(), c.maxLogEvents(), c.maxCustomEvents(), c.DistributedTracer.ReservoirLimit, c.DistributedTracer.Enabled),
+		EventData:        internal.DefaultEventHarvestConfigWithDT(c.TransactionEvents.MaxSamplesStored, c.ApplicationLogging.Forwarding.MaxSamplesStored, c.CustomInsightsEvents.MaxSamplesStored, c.DistributedTracer.ReservoirLimit, c.DistributedTracer.Enabled),
 	}})
 }
 

--- a/v3/newrelic/config_options.go
+++ b/v3/newrelic/config_options.go
@@ -39,8 +39,13 @@ func ConfigDistributedTracerEnabled(enabled bool) ConfigOption {
 // ConfigCustomInsightsEventsMaxSamplesStored alters the sample size allowing control
 // of how many custom events are stored in an agent for a given harvest cycle.
 // Alters the CustomInsightsEvents.MaxSamplesStored setting.
+// Note: As of Jul 2022, the absolute maximum events that can be sent each minute is 100000.
 func ConfigCustomInsightsEventsMaxSamplesStored(limit int) ConfigOption {
-	return func(cfg *Config) { cfg.CustomInsightsEvents.MaxSamplesStored = limit }
+	if limit > 100000 {
+		return func(cfg *Config) { cfg.CustomInsightsEvents.MaxSamplesStored = 100000 }
+	} else {
+		return func(cfg *Config) { cfg.CustomInsightsEvents.MaxSamplesStored = limit }
+	}
 }
 
 // ConfigDistributedTracerReservoirLimit alters the sample reservoir size (maximum

--- a/v3/newrelic/config_options.go
+++ b/v3/newrelic/config_options.go
@@ -43,9 +43,8 @@ func ConfigDistributedTracerEnabled(enabled bool) ConfigOption {
 func ConfigCustomInsightsEventsMaxSamplesStored(limit int) ConfigOption {
 	if limit > 100000 {
 		return func(cfg *Config) { cfg.CustomInsightsEvents.MaxSamplesStored = 100000 }
-	} else {
-		return func(cfg *Config) { cfg.CustomInsightsEvents.MaxSamplesStored = limit }
 	}
+	return func(cfg *Config) { cfg.CustomInsightsEvents.MaxSamplesStored = limit }
 }
 
 // ConfigDistributedTracerReservoirLimit alters the sample reservoir size (maximum

--- a/v3/newrelic/config_test.go
+++ b/v3/newrelic/config_test.go
@@ -5,6 +5,7 @@ package newrelic
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"reflect"
@@ -121,7 +122,7 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 	cfg.TransactionTracer.Segments.Attributes.Include[0] = "zap"
 	cfg.TransactionTracer.Segments.Attributes.Exclude[0] = "zap"
 
-	expect := internal.CompactJSONString(`[
+	expect := internal.CompactJSONString(fmt.Sprintf(`[
 	{
 		"pid":123,
 		"language":"go",
@@ -133,7 +134,7 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 				"Enabled":true,
 				"Forwarding": {
 					"Enabled": false,
-					"MaxSamplesStored": 10000
+					"MaxSamplesStored": %d
 				},
 				"Metrics": {
 					"Enabled": true
@@ -147,7 +148,7 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 			"CrossApplicationTracer":{"Enabled":false},
 			"CustomInsightsEvents":{
 				"Enabled":true,
-				"MaxSamplesStored":10000
+				"MaxSamplesStored":%d
 			},
 			"DatastoreTracer":{
 				"DatabaseNameReporting":{"Enabled":true},
@@ -202,7 +203,7 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 			"TransactionEvents":{
 				"Attributes":{"Enabled":true,"Exclude":["4"],"Include":["3"]},
 				"Enabled":true,
-				"MaxSamplesStored": 10000
+				"MaxSamplesStored": %d
 			},
 			"TransactionTracer":{
 				"Attributes":{"Enabled":true,"Exclude":["8"],"Include":["7"]},
@@ -262,13 +263,13 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 			"report_period_ms": 60000,
 			"harvest_limits": {
 				"analytic_event_data": 10000,
-				"custom_event_data": 10000,
-				"log_event_data": 10000,
+				"custom_event_data": %d,
+				"log_event_data": %d,
 				"error_event_data": 100,
 				"span_event_data": 2000
 			}
 		}
-	}]`)
+	}]`, internal.MaxLogEvents, internal.MaxCustomEvents, internal.MaxTxnEvents, internal.MaxCustomEvents, internal.MaxTxnEvents))
 
 	securityPoliciesInput := []byte(`{
 		"record_sql":                    { "enabled": false, "required": false },
@@ -308,7 +309,7 @@ func TestCopyConfigReferenceFieldsAbsent(t *testing.T) {
 
 	cp := copyConfigReferenceFields(cfg)
 
-	expect := internal.CompactJSONString(`[
+	expect := internal.CompactJSONString(fmt.Sprintf(`[
 	{
 		"pid":123,
 		"language":"go",
@@ -320,7 +321,7 @@ func TestCopyConfigReferenceFieldsAbsent(t *testing.T) {
 				"Enabled": true,
 				"Forwarding": {
 					"Enabled": false,
-					"MaxSamplesStored": 10000
+					"MaxSamplesStored": %d
 				},
 				"Metrics": {
 					"Enabled": true
@@ -338,7 +339,7 @@ func TestCopyConfigReferenceFieldsAbsent(t *testing.T) {
 			"CrossApplicationTracer":{"Enabled":false},
 			"CustomInsightsEvents":{
 				"Enabled":true,
-				"MaxSamplesStored":10000
+				"MaxSamplesStored":%d
 			},
 			"DatastoreTracer":{
 				"DatabaseNameReporting":{"Enabled":true},
@@ -391,7 +392,7 @@ func TestCopyConfigReferenceFieldsAbsent(t *testing.T) {
 			"TransactionEvents":{
 				"Attributes":{"Enabled":true,"Exclude":null,"Include":null},
 				"Enabled":true,
-				"MaxSamplesStored": 10000
+				"MaxSamplesStored": %d
 			},
 			"TransactionTracer":{
 				"Attributes":{"Enabled":true,"Exclude":null,"Include":null},
@@ -441,13 +442,13 @@ func TestCopyConfigReferenceFieldsAbsent(t *testing.T) {
 			"report_period_ms": 60000,
 			"harvest_limits": {
 				"analytic_event_data": 10000,
-				"custom_event_data": 10000,
-				"log_event_data": 10000,
+				"custom_event_data": %d,
+				"log_event_data": %d,
 				"error_event_data": 100,
 				"span_event_data": 2000
 			}
 		}
-	}]`)
+	}]`, internal.MaxLogEvents, internal.MaxCustomEvents, internal.MaxTxnEvents, internal.MaxCustomEvents, internal.MaxTxnEvents))
 
 	metadata := map[string]string{}
 	js, err := configConnectJSONInternal(cp, 123, &utilization.SampleData, sampleEnvironment, "0.2.2", nil, metadata)

--- a/v3/newrelic/errors.go
+++ b/v3/newrelic/errors.go
@@ -38,6 +38,7 @@ type Error struct {
 	// or leave it nil to indicate that Transaction.NoticeError should
 	// generate one.
 	Stack []uintptr
+	// Expected indicates if the error is
 }
 
 // NewStackTrace generates a stack trace for the newrelic.Error struct's Stack

--- a/v3/newrelic/errors.go
+++ b/v3/newrelic/errors.go
@@ -38,7 +38,6 @@ type Error struct {
 	// or leave it nil to indicate that Transaction.NoticeError should
 	// generate one.
 	Stack []uintptr
-	// Expected indicates if the error is
 }
 
 // NewStackTrace generates a stack trace for the newrelic.Error struct's Stack

--- a/v3/newrelic/harvest_test.go
+++ b/v3/newrelic/harvest_test.go
@@ -165,7 +165,7 @@ func TestCreateFinalMetrics(t *testing.T) {
 		{Name: "rename_me", Scope: "", Forced: false, Data: []float64{1.0, 0, 0, 0, 0, 0}},
 		{Name: "Supportability/EventHarvest/ReportPeriod", Scope: "", Forced: true, Data: []float64{1, 60, 60, 60, 60, 60 * 60}},
 		{Name: "Supportability/EventHarvest/AnalyticEventData/HarvestLimit", Scope: "", Forced: true, Data: []float64{1, 10 * 1000, 10 * 1000, 10 * 1000, 10 * 1000, 10 * 1000 * 10 * 1000}},
-		{Name: "Supportability/EventHarvest/CustomEventData/HarvestLimit", Scope: "", Forced: true, Data: []float64{1, 10 * 1000, 10 * 1000, 10 * 1000, 10 * 1000, 10 * 1000 * 10 * 1000}},
+		{Name: "Supportability/EventHarvest/CustomEventData/HarvestLimit", Scope: "", Forced: true, Data: []float64{1, internal.MaxCustomEvents, internal.MaxCustomEvents, internal.MaxCustomEvents, internal.MaxCustomEvents, internal.MaxCustomEvents * internal.MaxCustomEvents}},
 		{Name: "Supportability/EventHarvest/ErrorEventData/HarvestLimit", Scope: "", Forced: true, Data: []float64{1, 100, 100, 100, 100, 100 * 100}},
 		{Name: "Supportability/EventHarvest/SpanEventData/HarvestLimit", Scope: "", Forced: true, Data: []float64{1, 2000, 2000, 2000, 2000, 2000 * 2000}},
 		{Name: "Supportability/EventHarvest/LogEventData/HarvestLimit", Scope: "", Forced: true, Data: []float64{1, 10000, 10000, 10000, 10000, 10000 * 10000}},


### PR DESCRIPTION
## Harvest Limit Increase
- Users can use `newrelic.ConfigCustomInsightsEventsMaxSamplesStored()` to change the Harvest Limit to their choosing
- Increased Default Custom Events Harvest Limit from 10k to 30k
- Set a Max Custom Events Harvest Limit at 100k
- Changed static values of samples being stored to dynamic value 
## DT Spans Patch

-  Changed DT Spans being read from `event_harvest_config` to `span_event_harvest_config`