### PR TITLE
Default Custom Event Harvest Increase from 10,000 to 30,000 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,8 @@ jobs:
             dirs: _integrations/nrecho
             pin: github.com/labstack/echo@v3.3.10
           - go-version: 1.13.x
+            dirs: _integrations/nrgin/v1
+          - go-version: 1.13.x
             dirs: _integrations/nrgorilla/v1
           - go-version: 1.13.x
             dirs: _integrations/nrlogrus

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,8 +52,6 @@ jobs:
             dirs: _integrations/nrecho
             pin: github.com/labstack/echo@v3.3.10
           - go-version: 1.13.x
-            dirs: _integrations/nrgin/v1
-          - go-version: 1.13.x
             dirs: _integrations/nrgorilla/v1
           - go-version: 1.13.x
             dirs: _integrations/nrlogrus

--- a/v3/internal/connect_reply.go
+++ b/v3/internal/connect_reply.go
@@ -255,6 +255,30 @@ func CreateFullTxnName(input string, reply *ConnectReply, isWeb bool) string {
 	return reply.SegmentTerms.apply(afterNameRules)
 }
 
+type RequestEventLimits struct {
+	CustomEvents int
+}
+
+const (
+	//CustomEventHarvestsPerMinute is the number of times per minute custom events are harvested
+	CustomEventHarvestsPerMinute = 5
+)
+
+func (r *ConnectReply) MockConnectReplyEventLimits(limits *RequestEventLimits) {
+	r.SetSampleEverything()
+
+	r.EventData.Limits.CustomEvents = uintPtr(uint(limits.CustomEvents) / (60 / CustomEventHarvestsPerMinute))
+
+	// The mock server will be limited to a maximum of 100,000 events per minute
+	if limits.CustomEvents > 100000 {
+		r.EventData.Limits.CustomEvents = uintPtr(uint(100000) / (60 / CustomEventHarvestsPerMinute))
+	}
+
+	if limits.CustomEvents <= 0 {
+		r.EventData.Limits.CustomEvents = uintPtr(uint(0) / (60 / CustomEventHarvestsPerMinute))
+	}
+}
+
 // SetSampleEverything is used for testing to ensure span events get saved.
 func (r *ConnectReply) SetSampleEverything() {
 	// These constants are not large enough to sample everything forever,

--- a/v3/internal/connect_reply.go
+++ b/v3/internal/connect_reply.go
@@ -255,17 +255,17 @@ func CreateFullTxnName(input string, reply *ConnectReply, isWeb bool) string {
 	return reply.SegmentTerms.apply(afterNameRules)
 }
 
-// Limits set by reservior testing
+// RequestEventLimits sets limits for reservior testing
 type RequestEventLimits struct {
 	CustomEvents int
 }
 
 const (
-	//CustomEventHarvestsPerMinute is the number of times per minute custom events are harvested
+	// CustomEventHarvestsPerMinute is the number of times per minute custom events are harvested
 	CustomEventHarvestsPerMinute = 5
 )
 
-// Sets up a mock connect reply to test event limits
+// MockConnectReplyEventLimits sets up a mock connect reply to test event limits
 func (r *ConnectReply) MockConnectReplyEventLimits(limits *RequestEventLimits) {
 	r.SetSampleEverything()
 

--- a/v3/internal/connect_reply.go
+++ b/v3/internal/connect_reply.go
@@ -255,6 +255,7 @@ func CreateFullTxnName(input string, reply *ConnectReply, isWeb bool) string {
 	return reply.SegmentTerms.apply(afterNameRules)
 }
 
+// Limits set by reservior testing
 type RequestEventLimits struct {
 	CustomEvents int
 }
@@ -264,6 +265,7 @@ const (
 	CustomEventHarvestsPerMinute = 5
 )
 
+// Sets up a mock connect reply to test event limits
 func (r *ConnectReply) MockConnectReplyEventLimits(limits *RequestEventLimits) {
 	r.SetSampleEverything()
 

--- a/v3/internal/limits.go
+++ b/v3/internal/limits.go
@@ -15,7 +15,7 @@ const (
 	MaxPayloadSizeInBytes = 1000 * 1000
 	// MaxCustomEvents is the maximum number of Transaction Events that can be captured
 	// per 60-second harvest cycle
-	MaxCustomEvents = 10 * 1000
+	MaxCustomEvents = 30 * 1000
 	// MaxLogEvents is the maximum number of Log Events that can be captured per
 	// 60-second harvest cycle
 	MaxLogEvents = 10 * 1000

--- a/v3/newrelic/config_options.go
+++ b/v3/newrelic/config_options.go
@@ -47,6 +47,11 @@ func ConfigCustomInsightsEventsMaxSamplesStored(limit int) ConfigOption {
 	return func(cfg *Config) { cfg.CustomInsightsEvents.MaxSamplesStored = limit }
 }
 
+// ConfigCustomInsightsEventsEnabled enables or disables the collection of custom insight events.
+func ConfigCustomInsightsEventsEnabled(enabled bool) ConfigOption {
+	return func(cfg *Config) { cfg.CustomInsightsEvents.Enabled = enabled }
+}
+
 // ConfigDistributedTracerReservoirLimit alters the sample reservoir size (maximum
 // number of span events to be collected) for distributed tracing instead of
 // using the built-in default.

--- a/v3/newrelic/reservoir_limits_test.go
+++ b/v3/newrelic/reservoir_limits_test.go
@@ -1,0 +1,118 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package newrelic
+
+import (
+	"testing"
+
+	"github.com/newrelic/go-agent/v3/internal"
+)
+
+// Check Default Value
+func TestCustomLimitsBasic(t *testing.T) {
+	limit := internal.MaxCustomEvents
+	limits := &internal.RequestEventLimits{
+		CustomEvents: limit,
+	}
+	// This function will mock a connect reply from the server
+	mockReplyFunction := func(reply *internal.ConnectReply) {
+		reply.MockConnectReplyEventLimits(limits)
+	}
+	testApp := newTestApp(
+		mockReplyFunction,
+		ConfigCustomInsightsEventsMaxSamplesStored(limit),
+	)
+
+	customEventRate := limit / (60 / internal.CustomEventHarvestsPerMinute)
+
+	// Check if custom event queue capacity == rate
+	if customEventRate != testApp.app.testHarvest.CustomEvents.capacity() {
+		t.Errorf("Custom Events Rate is not equal to harvest: expected %d, actual %d", customEventRate, testApp.app.testHarvest.CustomEvents.capacity())
+	}
+}
+func TestCustomEventLimitUserSet(t *testing.T) {
+	limit := 7000
+	limits := &internal.RequestEventLimits{
+		CustomEvents: limit,
+	}
+	mockReplyFunction := func(reply *internal.ConnectReply) {
+		reply.MockConnectReplyEventLimits(limits)
+	}
+	testApp := newTestApp(
+		mockReplyFunction,
+		ConfigCustomInsightsEventsMaxSamplesStored(limit),
+	)
+
+	customEventRate := limit / (60 / internal.CustomEventHarvestsPerMinute)
+
+	if customEventRate != testApp.app.testHarvest.CustomEvents.capacity() {
+		t.Errorf("Custom Events Rate is not equal to harvest: expected %d, actual %d", customEventRate, testApp.app.testHarvest.CustomEvents.capacity())
+	}
+}
+
+func TestCustomLimitEnthusiast(t *testing.T) {
+	limit := 100000
+	limits := &internal.RequestEventLimits{
+		CustomEvents: limit,
+	}
+	// This function will mock a connect reply from the server
+	mockReplyFunction := func(reply *internal.ConnectReply) {
+		reply.MockConnectReplyEventLimits(limits)
+	}
+	testApp := newTestApp(
+		mockReplyFunction,
+		ConfigCustomInsightsEventsMaxSamplesStored(limit),
+	)
+
+	customEventRate := limit / (60 / internal.CustomEventHarvestsPerMinute)
+
+	// Check if custom event queue capacity == rate
+	if customEventRate != testApp.app.testHarvest.CustomEvents.capacity() {
+		t.Errorf("Custom Events Rate is not equal to harvest: expected %d, actual %d", customEventRate, testApp.app.testHarvest.CustomEvents.capacity())
+	}
+}
+
+func TestCustomLimitsTypo(t *testing.T) {
+	limit := 1000000
+	limits := &internal.RequestEventLimits{
+		CustomEvents: limit,
+	}
+	// This function will mock a connect reply from the server
+	mockReplyFunction := func(reply *internal.ConnectReply) {
+		reply.MockConnectReplyEventLimits(limits)
+	}
+	testApp := newTestApp(
+		mockReplyFunction,
+		ConfigCustomInsightsEventsMaxSamplesStored(limit),
+	)
+
+	customEventRate := limit / (60 / internal.CustomEventHarvestsPerMinute)
+
+	// Check if custom event queue capacity == rate
+	if customEventRate != testApp.app.testHarvest.CustomEvents.capacity() {
+		t.Errorf("Custom Events Rate is not equal to harvest: expected %d, actual %d", 8333, testApp.app.testHarvest.CustomEvents.capacity())
+	}
+}
+
+func TestCustomLimitZero(t *testing.T) {
+	limit := 0
+	limits := &internal.RequestEventLimits{
+		CustomEvents: limit,
+	}
+	// This function will mock a connect reply from the server
+	mockReplyFunction := func(reply *internal.ConnectReply) {
+		reply.MockConnectReplyEventLimits(limits)
+	}
+	testApp := newTestApp(
+		mockReplyFunction,
+		ConfigCustomInsightsEventsMaxSamplesStored(limit),
+	)
+
+	customEventRate := limit / (60 / internal.CustomEventHarvestsPerMinute)
+
+	// Check if custom event queue capacity == rate
+	if customEventRate != testApp.app.testHarvest.CustomEvents.capacity() {
+		t.Errorf("Custom Events Rate is not equal to harvest: expected %d, actual %d", customEventRate, testApp.app.testHarvest.CustomEvents.capacity())
+	}
+}

--- a/v3/newrelic/reservoir_limits_test.go
+++ b/v3/newrelic/reservoir_limits_test.go
@@ -87,7 +87,7 @@ func TestCustomLimitsTypo(t *testing.T) {
 		ConfigCustomInsightsEventsMaxSamplesStored(limit),
 	)
 
-	customEventRate := limit / (60 / internal.CustomEventHarvestsPerMinute)
+	customEventRate := 100000 / (60 / internal.CustomEventHarvestsPerMinute)
 
 	// Check if custom event queue capacity == rate
 	if customEventRate != testApp.app.testHarvest.CustomEvents.capacity() {


### PR DESCRIPTION
To help our customers see more of the custom events they're producing, the default Custom Events reservoir limit has been increased from 10,000 events per minute to 30,000 events per minute.