### PR TITLE
Corrections to CLM data collection code

### DIFF
--- a/v3/examples/server/main.go
+++ b/v3/examples/server/main.go
@@ -290,7 +290,7 @@ func main() {
 	http.HandleFunc(newrelic.WrapHandleFunc(app, "/log", logTxnMessage))
 
 	//loc := newrelic.ThisCodeLocation()
-	var backgroundCache newrelic.CachedCodeLocation
+	backgroundCache := newrelic.NewCachedCodeLocation()
 	http.HandleFunc("/background", func(w http.ResponseWriter, req *http.Request) {
 		// Transactions started without an http.Request are classified as
 		// background transactions.

--- a/v3/examples/server/main.go
+++ b/v3/examples/server/main.go
@@ -290,10 +290,11 @@ func main() {
 	http.HandleFunc(newrelic.WrapHandleFunc(app, "/log", logTxnMessage))
 
 	//loc := newrelic.ThisCodeLocation()
+	var backgroundCache newrelic.CachedCodeLocation
 	http.HandleFunc("/background", func(w http.ResponseWriter, req *http.Request) {
 		// Transactions started without an http.Request are classified as
 		// background transactions.
-		txn := app.StartTransaction("background", newrelic.WithThisCodeLocation())
+		txn := app.StartTransaction("background", backgroundCache.WithThisCodeLocation())
 		defer txn.End()
 
 		io.WriteString(w, "background transaction")

--- a/v3/newrelic/code_level_metrics.go
+++ b/v3/newrelic/code_level_metrics.go
@@ -73,6 +73,11 @@ func (c *CachedCodeLocation) IsValid() bool {
 	return c != nil && c.once != nil
 }
 
+//
+// NewCachedCodeLocation returns a pointer to a newly-created
+// CachedCodeLocation value, suitable for use with the methods
+// defined for that type.
+//
 func NewCachedCodeLocation() *CachedCodeLocation {
 	return &CachedCodeLocation{
 		once: new(sync.Once),

--- a/v3/newrelic/code_level_metrics.go
+++ b/v3/newrelic/code_level_metrics.go
@@ -247,7 +247,7 @@ func (c *CachedCodeLocation) WithFunctionLocation(function interface{}) TraceOpt
 // set a code location first. This is useful, for example, if you want to
 // provide a default code location value to be used but not pay the overhead
 // of resolving that location until it's clear that you will need to. This
-// should appear at the end of a TraceOption list (or at least before any
+// should appear at the end of a TraceOption list (or at least after any
 // other options that want to specify the code location).
 //
 func WithDefaultFunctionLocation(function interface{}) TraceOption {

--- a/v3/newrelic/code_level_metrics.go
+++ b/v3/newrelic/code_level_metrics.go
@@ -388,7 +388,7 @@ func thisCodeLocationCommon(skip int, skipInternal bool) *CodeLocation {
 		stillMore := true
 		skipCLM := true
 
-		frames := runtime.CallersFrames(pcs)
+		frames := runtime.CallersFrames(pcs[:depth])
 		for stillMore {
 			frame, stillMore = frames.Next()
 			//
@@ -507,7 +507,7 @@ func reportCodeLevelMetrics(tOpts traceOptSet, run *appRun, setAttr func(string,
 	if tOpts.LocationOverride != nil {
 		location = *tOpts.LocationOverride
 	} else {
-		pcs := make([]uintptr, 10)
+		pcs := make([]uintptr, 20)
 		depth := runtime.Callers(2, pcs)
 		if depth > 0 {
 			frames := runtime.CallersFrames(pcs[:depth])

--- a/v3/newrelic/code_level_metrics_test.go
+++ b/v3/newrelic/code_level_metrics_test.go
@@ -4,6 +4,7 @@
 package newrelic
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -15,7 +16,7 @@ func anotherFunction() {
 
 func TestCodeLocation(t *testing.T) {
 	loc1 := ThisCodeLocation()
-	if loc1.LineNo != 17 || loc1.Function != "github.com/newrelic/go-agent/v3/newrelic.TestCodeLocation" || !strings.HasSuffix(loc1.FilePath, "/go-agent/v3/newrelic/code_level_metrics_test.go") {
+	if loc1.LineNo != 18 || loc1.Function != "github.com/newrelic/go-agent/v3/newrelic.TestCodeLocation" || !strings.HasSuffix(loc1.FilePath, "/go-agent/v3/newrelic/code_level_metrics_test.go") {
 		t.Errorf("CodeLocation() returned %v", loc1)
 	}
 
@@ -23,7 +24,7 @@ func TestCodeLocation(t *testing.T) {
 	if err != nil {
 		t.Errorf("FunctionLocation() returned error %v", err)
 	}
-	if loc2.LineNo != 12 || loc2.Function != "github.com/newrelic/go-agent/v3/newrelic.anotherFunction" || !strings.HasSuffix(loc2.FilePath, "/go-agent/v3/newrelic/code_level_metrics_test.go") {
+	if loc2.LineNo != 13 || loc2.Function != "github.com/newrelic/go-agent/v3/newrelic.anotherFunction" || !strings.HasSuffix(loc2.FilePath, "/go-agent/v3/newrelic/code_level_metrics_test.go") {
 		t.Errorf("FunctionLocation() returned %v", loc2)
 	}
 }
@@ -42,7 +43,128 @@ func TestClosureCLM(t *testing.T) {
 	if err != nil {
 		t.Errorf("FunctionLocation of closure: %v", err)
 	}
-	if l.LineNo != 39 || l.Function != "github.com/newrelic/go-agent/v3/newrelic.TestClosureCLM.func1" || !strings.HasSuffix(l.FilePath, "/go-agent/v3/newrelic/code_level_metrics_test.go") {
+	if l.LineNo != 40 || l.Function != "github.com/newrelic/go-agent/v3/newrelic.TestClosureCLM.func1" || !strings.HasSuffix(l.FilePath, "/go-agent/v3/newrelic/code_level_metrics_test.go") {
 		t.Errorf("closure FunctionLocation() returned %v", l)
+	}
+}
+
+func TestBasicCaching(t *testing.T) {
+	var c CachedCodeLocation
+
+	l, err := c.FunctionLocation(anotherFunction)
+	if err != nil {
+		t.Errorf("cached FunctionLocation error %v", err)
+	}
+
+	if l.LineNo != 13 || l.Function != "github.com/newrelic/go-agent/v3/newrelic.anotherFunction" || !strings.HasSuffix(l.FilePath, "/go-agent/v3/newrelic/code_level_metrics_test.go") {
+		t.Errorf("FunctionLocation() returned %v", l)
+	}
+
+	if c.Location == nil {
+		t.Errorf("FunctionLocation cache location is nil")
+	} else if c.Location.LineNo != 13 || c.Location.Function != "github.com/newrelic/go-agent/v3/newrelic.anotherFunction" || !strings.HasSuffix(c.Location.FilePath, "/go-agent/v3/newrelic/code_level_metrics_test.go") {
+		t.Errorf("FunctionLocation cache value is wrong %v", *c.Location)
+	}
+
+	if c.Err != nil {
+		t.Errorf("FunctionLocation cache error %v", c.Err)
+	}
+}
+
+func TestCachedCodeLocation(t *testing.T) {
+	var c CachedCodeLocation
+	var c2 CachedCodeLocation
+
+	loc1 := c.ThisCodeLocation()
+	if loc1.LineNo != 78 || loc1.Function != "github.com/newrelic/go-agent/v3/newrelic.TestCachedCodeLocation" || !strings.HasSuffix(loc1.FilePath, "/go-agent/v3/newrelic/code_level_metrics_test.go") {
+		t.Errorf("CodeLocation() returned %v", loc1)
+	}
+
+	// This should give us the previously cached value, not the new
+	// function passed. This is actually an example of a user error in the
+	// code since they're reusing the cache for one code location on a call
+	// to determine the location of an entirely different function. However,
+	// since they specified a cache that now has a value cached in it, the defined
+	// behavior is to use the cache.
+	loc2, err := c.FunctionLocation(anotherFunction)
+	if err != nil {
+		t.Errorf("FunctionLocation() returned error %v", err)
+	}
+	if loc2.LineNo != 78 || loc2.Function != "github.com/newrelic/go-agent/v3/newrelic.TestCachedCodeLocation" || !strings.HasSuffix(loc2.FilePath, "/go-agent/v3/newrelic/code_level_metrics_test.go") {
+		t.Errorf("FunctionLocation() returned %v", loc2)
+	}
+
+	// This is how we should have done it, using a separate cache for each
+	// function location we're measuring. This should give us the true location
+	loc2, err = c2.FunctionLocation(anotherFunction)
+	if err != nil {
+		t.Errorf("FunctionLocation() returned error %v", err)
+	}
+	if loc2.LineNo != 13 || loc2.Function != "github.com/newrelic/go-agent/v3/newrelic.anotherFunction" || !strings.HasSuffix(loc2.FilePath, "/go-agent/v3/newrelic/code_level_metrics_test.go") {
+		t.Errorf("FunctionLocation() returned %v", loc2)
+	}
+}
+
+func TestTraceOptions(t *testing.T) {
+	var o traceOptSet
+	WithCodeLocation(ThisCodeLocation())(&o)
+	WithIgnoredPrefix("foo", "bar")(&o)
+	WithPathPrefix("alpha", "beta", "gamma")(&o)
+	WithoutCodeLevelMetrics()(&o)
+	WithDefaultFunctionLocation(anotherFunction)(&o)
+
+	if o.LocationOverride == nil {
+		t.Errorf("failed to set a location")
+	} else {
+		if o.LocationOverride.LineNo != 110 || o.LocationOverride.Function != "github.com/newrelic/go-agent/v3/newrelic.TestTraceOptions" || !strings.HasSuffix(o.LocationOverride.FilePath, "/go-agent/v3/newrelic/code_level_metrics_test.go") {
+			t.Errorf("function location set to %v", *o.LocationOverride)
+		}
+	}
+
+	if !o.SuppressCLM {
+		t.Errorf("asked to suppress CLM but that didn't show up")
+	}
+
+	if o.DemandCLM {
+		t.Errorf("was not asked to demand CLM but that didn't show up")
+	}
+
+	if !reflect.DeepEqual(o.IgnoredPrefixes, []string{"foo", "bar"}) {
+		t.Errorf("ignored prefixes wrong: %v", o.IgnoredPrefixes)
+	}
+
+	if !reflect.DeepEqual(o.PathPrefixes, []string{"alpha", "beta", "gamma"}) {
+		t.Errorf("ignored prefixes wrong: %v", o.PathPrefixes)
+	}
+}
+
+func TestTraceOptions2(t *testing.T) {
+	var o traceOptSet
+	WithPathPrefix("alpha")(&o)
+	WithDefaultFunctionLocation(anotherFunction)(&o)
+	WithCodeLevelMetrics()(&o)
+
+	if o.LocationOverride == nil {
+		t.Errorf("failed to set a location")
+	} else {
+		if o.LocationOverride.LineNo != 13 || o.LocationOverride.Function != "github.com/newrelic/go-agent/v3/newrelic.anotherFunction" || !strings.HasSuffix(o.LocationOverride.FilePath, "/go-agent/v3/newrelic/code_level_metrics_test.go") {
+			t.Errorf("function location set to %v", *o.LocationOverride)
+		}
+	}
+
+	if o.SuppressCLM {
+		t.Errorf("was not asked to suppress CLM but that didn't show up")
+	}
+
+	if !o.DemandCLM {
+		t.Errorf("asked to demand CLM but that didn't show up")
+	}
+
+	if o.IgnoredPrefixes != nil {
+		t.Errorf("ignored prefixes wrong: %v", o.IgnoredPrefixes)
+	}
+
+	if !reflect.DeepEqual(o.PathPrefixes, []string{"alpha"}) {
+		t.Errorf("ignored prefixes wrong: %v", o.PathPrefixes)
 	}
 }

--- a/v3/newrelic/code_level_metrics_test.go
+++ b/v3/newrelic/code_level_metrics_test.go
@@ -49,7 +49,7 @@ func TestClosureCLM(t *testing.T) {
 }
 
 func TestBasicCaching(t *testing.T) {
-	var c CachedCodeLocation
+	c := NewCachedCodeLocation()
 
 	l, err := c.FunctionLocation(anotherFunction)
 	if err != nil {
@@ -60,20 +60,20 @@ func TestBasicCaching(t *testing.T) {
 		t.Errorf("FunctionLocation() returned %v", l)
 	}
 
-	if c.Location == nil {
+	if c.location == nil {
 		t.Errorf("FunctionLocation cache location is nil")
-	} else if c.Location.LineNo != 13 || c.Location.Function != "github.com/newrelic/go-agent/v3/newrelic.anotherFunction" || !strings.HasSuffix(c.Location.FilePath, "/go-agent/v3/newrelic/code_level_metrics_test.go") {
-		t.Errorf("FunctionLocation cache value is wrong %v", *c.Location)
+	} else if c.location.LineNo != 13 || c.location.Function != "github.com/newrelic/go-agent/v3/newrelic.anotherFunction" || !strings.HasSuffix(c.location.FilePath, "/go-agent/v3/newrelic/code_level_metrics_test.go") {
+		t.Errorf("FunctionLocation cache value is wrong %v", *c.location)
 	}
 
-	if c.Err != nil {
-		t.Errorf("FunctionLocation cache error %v", c.Err)
+	if c.Err() != nil {
+		t.Errorf("FunctionLocation cache error %v", c.Err())
 	}
 }
 
 func TestCachedCodeLocation(t *testing.T) {
-	var c CachedCodeLocation
-	var c2 CachedCodeLocation
+	c := NewCachedCodeLocation()
+	c2 := NewCachedCodeLocation()
 
 	loc1 := c.ThisCodeLocation()
 	if loc1.LineNo != 78 || loc1.Function != "github.com/newrelic/go-agent/v3/newrelic.TestCachedCodeLocation" || !strings.HasSuffix(loc1.FilePath, "/go-agent/v3/newrelic/code_level_metrics_test.go") {

--- a/v3/newrelic/config.go
+++ b/v3/newrelic/config.go
@@ -466,18 +466,13 @@ func CodeLevelMetricsScopeLabelToValue(labels ...string) (CodeLevelMetricsScope,
 }
 
 //
-// UnmarshalJSON allows for a CodeLevelMetricsScope value to be read from a JSON
-// string whose value is a comma-separated list of scope labels.
+// UnmarshalText allows for a CodeLevelMetricsScope value to be read from a JSON
+// string (or other text encodings) whose value is a comma-separated list of scope labels.
 //
-func (s *CodeLevelMetricsScope) UnmarshalJSON(b []byte) error {
-	var sv string
+func (s *CodeLevelMetricsScope) UnmarshalText(b []byte) error {
 	var ok bool
 
-	if err := json.Unmarshal(b, &sv); err != nil {
-		return err
-	}
-
-	if *s, ok = CodeLevelMetricsScopeLabelListToValue(sv); !ok {
+	if *s, ok = CodeLevelMetricsScopeLabelListToValue(string(b)); !ok {
 		return fmt.Errorf("invalid code level metrics scope label value")
 	}
 
@@ -485,15 +480,16 @@ func (s *CodeLevelMetricsScope) UnmarshalJSON(b []byte) error {
 }
 
 //
-// MarshalJSON allows for a CodeLevelMetrics value to be encoded into JSON string.
+// MarshalText allows for a CodeLevelMetrics value to be encoded into JSON strings and other
+// text encodings.
 //
-func (s CodeLevelMetricsScope) MarshalJSON() ([]byte, error) {
+func (s CodeLevelMetricsScope) MarshalText() ([]byte, error) {
 	if s == 0 || s == AllCLM {
-		return json.Marshal("all")
+		return []byte("all"), nil
 	}
 
 	if (s & TransactionCLM) != 0 {
-		return json.Marshal("transaction")
+		return []byte("transaction"), nil
 	}
 
 	return nil, fmt.Errorf("unrecognized bit pattern in CodeLevelMetricsScope value")

--- a/v3/newrelic/config_options.go
+++ b/v3/newrelic/config_options.go
@@ -76,6 +76,12 @@ func ConfigCodeLevelMetricsEnabled(enabled bool) ConfigOption {
 func ConfigCodeLevelMetricsIgnoredPrefix(prefix ...string) ConfigOption {
 	return func(cfg *Config) {
 		cfg.CodeLevelMetrics.IgnoredPrefixes = prefix
+
+		// Correct things if the user populated the old IgnoredPrefix value in the struct
+		if cfg.CodeLevelMetrics.IgnoredPrefix != "" {
+			cfg.CodeLevelMetrics.IgnoredPrefixes = append(cfg.CodeLevelMetrics.IgnoredPrefixes, cfg.CodeLevelMetrics.IgnoredPrefix)
+			cfg.CodeLevelMetrics.IgnoredPrefix = ""
+		}
 	}
 }
 
@@ -94,15 +100,31 @@ func ConfigCodeLevelMetricsScope(scope CodeLevelMetricsScope) ConfigOption {
 	}
 }
 
-// ConfigCodeLevelMetricsPathPrefix specifies the filename pattern that describes the start of
-// the project area. Any text before this pattern is ignored. Thus, if
-// the path prefix is set to "myproject/src", then a function located in a file
+// ConfigCodeLevelMetricsPathPrefix specifies the filename pattern(s) that describe(s) the start of
+// the project area(s). When reporting a source filename for Code Level Metrics, and any of the
+// values in the path prefix list are found in the source filename, anything before that prefix
+// is discarded from the file pathname. This will be based on the first value in the prefix list
+// that is found in the pathname.
+//
+// For example, if
+// the path prefix list is set to ["myproject/src", "myproject/extra"], then a function located in a file
 // called "/usr/local/src/myproject/src/foo.go" will be reported with the
-// pathname "myproject/src/foo.go". If this value is empty, the full path
+// pathname "myproject/src/foo.go". If this value is empty or none of the prefix strings
+// are found in a file's pathname, the full path
 // will be reported (e.g., "/usr/local/src/myproject/src/foo.go").
-func ConfigCodeLevelMetricsPathPrefix(prefix string) ConfigOption {
+//
+// In agent versions 3.18.0 and 3.18.1, this took a single string parameter.
+// It now takes a variable number of parameters, preserving the old call semantics
+// for backward compatibility while allowing for multiple PathPrefix values now.
+func ConfigCodeLevelMetricsPathPrefix(prefix ...string) ConfigOption {
 	return func(cfg *Config) {
-		cfg.CodeLevelMetrics.PathPrefix = prefix
+		cfg.CodeLevelMetrics.PathPrefixes = prefix
+
+		// Correct things if the user populated the old PathPrefix value in the struct
+		if cfg.CodeLevelMetrics.PathPrefix != "" {
+			cfg.CodeLevelMetrics.PathPrefixes = append(cfg.CodeLevelMetrics.PathPrefixes, cfg.CodeLevelMetrics.PathPrefix)
+			cfg.CodeLevelMetrics.PathPrefix = ""
+		}
 	}
 }
 
@@ -190,9 +212,9 @@ func ConfigDebugLogger(w io.Writer) ConfigOption {
 //  NEW_RELIC_ATTRIBUTES_EXCLUDE                      sets Attributes.Exclude using a comma-separated list, eg. "request.headers.host,request.method"
 //  NEW_RELIC_ATTRIBUTES_INCLUDE                      sets Attributes.Include using a comma-separated list
 //  NEW_RELIC_CODE_LEVEL_METRICS_ENABLED              sets CodeLevelMetrics.Enabled
-//  NEW_RELIC_CODE_LEVEL_METRICS_SCOPE                sets CodeLevelMetrics.Scope using a comma-separated list, e.g. "transaction,datastore"
-//  NEW_RELIC_CODE_LEVEL_METRICS_PATH_PREFIX          sets CodeLevelMetrics.PathPrefix
-//  NEW_RELIC_CODE_LEVEL_METRICS_IGNORED_PREFIX       sets CodeLevelMetrics.IgnoredPrefixes
+//  NEW_RELIC_CODE_LEVEL_METRICS_SCOPE                sets CodeLevelMetrics.Scope using a comma-separated list, e.g. "transaction"
+//  NEW_RELIC_CODE_LEVEL_METRICS_PATH_PREFIX          sets CodeLevelMetrics.PathPrefixes using a comma-separated list
+//  NEW_RELIC_CODE_LEVEL_METRICS_IGNORED_PREFIX       sets CodeLevelMetrics.IgnoredPrefixes using a comma-separated list
 //  NEW_RELIC_DISTRIBUTED_TRACING_ENABLED             sets DistributedTracer.Enabled using strconv.ParseBool
 //  NEW_RELIC_ENABLED                                 sets Enabled using strconv.ParseBool
 //  NEW_RELIC_HIGH_SECURITY                           sets HighSecurity using strconv.ParseBool
@@ -249,7 +271,6 @@ func configFromEnvironment(getenv func(string) string) ConfigOption {
 		assignString(&cfg.AppName, "NEW_RELIC_APP_NAME")
 		assignString(&cfg.License, "NEW_RELIC_LICENSE_KEY")
 		assignBool(&cfg.CodeLevelMetrics.Enabled, "NEW_RELIC_CODE_LEVEL_METRICS_ENABLED")
-		assignString(&cfg.CodeLevelMetrics.PathPrefix, "NEW_RELIC_CODE_LEVEL_METRICS_PATH_PREFIX")
 		assignBool(&cfg.DistributedTracer.Enabled, "NEW_RELIC_DISTRIBUTED_TRACING_ENABLED")
 		assignBool(&cfg.Enabled, "NEW_RELIC_ENABLED")
 		assignBool(&cfg.HighSecurity, "NEW_RELIC_HIGH_SECURITY")
@@ -291,6 +312,10 @@ func configFromEnvironment(getenv func(string) string) ConfigOption {
 
 		if env := getenv("NEW_RELIC_CODE_LEVEL_METRICS_IGNORED_PREFIX"); env != "" {
 			cfg.CodeLevelMetrics.IgnoredPrefixes = strings.Split(env, ",")
+		}
+
+		if env := getenv("NEW_RELIC_CODE_LEVEL_METRICS_PATH_PREFIX"); env != "" {
+			cfg.CodeLevelMetrics.PathPrefixes = strings.Split(env, ",")
 		}
 
 		if env := getenv("NEW_RELIC_LOG"); env != "" {

--- a/v3/newrelic/config_options.go
+++ b/v3/newrelic/config_options.go
@@ -300,13 +300,10 @@ func configFromEnvironment(getenv func(string) string) ConfigOption {
 		}
 
 		if env := getenv("NEW_RELIC_CODE_LEVEL_METRICS_SCOPE"); env != "" {
-			for _, label := range strings.Split(env, ",") {
-				bit, ok := codeLevelMetricsScopeLabelToValue(label)
-				if ok {
-					cfg.CodeLevelMetrics.Scope |= bit
-				} else {
-					cfg.Error = fmt.Errorf("invalid NEW_RELIC_CODE_LEVEL_METRICS_SCOPE value \"%s\" in \"%s\"", label, env)
-				}
+			var ok bool
+			cfg.CodeLevelMetrics.Scope, ok = CodeLevelMetricsScopeLabelListToValue(env)
+			if !ok {
+				cfg.Error = fmt.Errorf("invalid NEW_RELIC_CODE_LEVEL_METRICS_SCOPE value")
 			}
 		}
 

--- a/v3/newrelic/config_options_test.go
+++ b/v3/newrelic/config_options_test.go
@@ -45,6 +45,12 @@ func TestConfigFromEnvironment(t *testing.T) {
 			return "456"
 		case "NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_QUEUE_SIZE":
 			return "98765"
+		case "NEW_RELIC_CODE_LEVEL_METRICS_SCOPE":
+			return "all"
+		case "NEW_RELIC_CODE_LEVEL_METRICS_PATH_PREFIX":
+			return "/foo/bar,/spam/spam/spam/frotz"
+		case "NEW_RELIC_CODE_LEVEL_METRICS_IGNORED_PREFIX":
+			return "/a/b,/c/d"
 		}
 		return ""
 	})
@@ -66,6 +72,9 @@ func TestConfigFromEnvironment(t *testing.T) {
 	expect.InfiniteTracing.TraceObserver.Host = "myhost.com"
 	expect.InfiniteTracing.TraceObserver.Port = 456
 	expect.InfiniteTracing.SpanEvents.QueueSize = 98765
+	expect.CodeLevelMetrics.Scope = AllCLM
+	expect.CodeLevelMetrics.PathPrefixes = []string{"/foo/bar", "/spam/spam/spam/frotz"}
+	expect.CodeLevelMetrics.IgnoredPrefixes = []string{"/a/b", "/c/d"}
 
 	cfg := defaultConfig()
 	cfgOpt(&cfg)

--- a/v3/newrelic/config_test.go
+++ b/v3/newrelic/config_test.go
@@ -148,7 +148,7 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 				"Attributes":{"Enabled":false,"Exclude":["10"],"Include":["9"]},
 				"Enabled":true
 			},
-			"CodeLevelMetrics":{"Enabled":false,"IgnoredPrefix":"","IgnoredPrefixes":null,"PathPrefix":"","Scope":0},
+			"CodeLevelMetrics":{"Enabled":false,"IgnoredPrefix":"","IgnoredPrefixes":null,"PathPrefix":"","PathPrefixes":null,"Scope":0},
 			"CrossApplicationTracer":{"Enabled":false},
 			"CustomInsightsEvents":{
 				"Enabled":true,
@@ -343,7 +343,7 @@ func TestCopyConfigReferenceFieldsAbsent(t *testing.T) {
 				},
 				"Enabled":true
 			},
-			"CodeLevelMetrics":{"Enabled":false,"IgnoredPrefix":"","IgnoredPrefixes":null,"PathPrefix":"","Scope":0},
+			"CodeLevelMetrics":{"Enabled":false,"IgnoredPrefix":"","IgnoredPrefixes":null,"PathPrefix":"","PathPrefixes":null,"Scope":0},
 			"CrossApplicationTracer":{"Enabled":false},
 			"CustomInsightsEvents":{
 				"Enabled":true,

--- a/v3/newrelic/config_test.go
+++ b/v3/newrelic/config_test.go
@@ -148,7 +148,7 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 				"Attributes":{"Enabled":false,"Exclude":["10"],"Include":["9"]},
 				"Enabled":true
 			},
-			"CodeLevelMetrics":{"Enabled":false,"IgnoredPrefix":"","IgnoredPrefixes":null,"PathPrefix":"","PathPrefixes":null,"Scope":0},
+			"CodeLevelMetrics":{"Enabled":false,"IgnoredPrefix":"","IgnoredPrefixes":null,"PathPrefix":"","PathPrefixes":null,"Scope":"all"},
 			"CrossApplicationTracer":{"Enabled":false},
 			"CustomInsightsEvents":{
 				"Enabled":true,
@@ -343,7 +343,7 @@ func TestCopyConfigReferenceFieldsAbsent(t *testing.T) {
 				},
 				"Enabled":true
 			},
-			"CodeLevelMetrics":{"Enabled":false,"IgnoredPrefix":"","IgnoredPrefixes":null,"PathPrefix":"","PathPrefixes":null,"Scope":0},
+			"CodeLevelMetrics":{"Enabled":false,"IgnoredPrefix":"","IgnoredPrefixes":null,"PathPrefix":"","PathPrefixes":null,"Scope":"all"},
 			"CrossApplicationTracer":{"Enabled":false},
 			"CustomInsightsEvents":{
 				"Enabled":true,
@@ -820,5 +820,101 @@ func TestConfigurableMaxCustomEvents(t *testing.T) {
 	result := cfg.maxCustomEvents()
 	if result != expected {
 		t.Errorf("Unexpected max number of custom events, expected %d but got %d", expected, result)
+	}
+}
+
+func TestCLMScopeLabels(t *testing.T) {
+	for i, tc := range []struct {
+		L  []string
+		LL string
+		V  CodeLevelMetricsScope
+		OK bool
+	}{
+		{V: AllCLM, OK: true},
+		{L: []string{"all"}, LL: "all", V: AllCLM, OK: true},
+		{L: []string{"transactions"}, LL: "transactions", V: TransactionCLM, OK: true},
+		{L: []string{"transaction"}, LL: "transaction", V: TransactionCLM, OK: true},
+		{L: []string{"txn"}, LL: "txn", V: TransactionCLM, OK: true},
+		{L: []string{"all", "txn"}, LL: "all,txn", V: AllCLM, OK: true},
+		{L: []string{"undefined"}, LL: "undefined", OK: false},
+	} {
+		s, ok := CodeLevelMetricsScopeLabelToValue(tc.L...)
+		if ok != tc.OK {
+			t.Errorf("#%d for \"%v\" expected ok=%v", i, tc.L, tc.OK)
+		}
+		if s != tc.V {
+			t.Errorf("#%d for \"%v\" expected output %v, but got %v", i, tc.L, tc.V, s)
+		}
+
+		ss, ok := CodeLevelMetricsScopeLabelListToValue(tc.LL)
+		if ok != tc.OK {
+			t.Errorf("#%d for \"%v\" expected ok=%v", i, tc.L, tc.OK)
+		}
+		if ss != tc.V {
+			t.Errorf("#%d for \"%v\" expected output %v, but got %v", i, tc.L, tc.V, ss)
+		}
+	}
+}
+
+func TestCLMJsonMarshalling(t *testing.T) {
+	var s CodeLevelMetricsScope
+
+	for i, tc := range []struct {
+		S CodeLevelMetricsScope
+		J string
+		E bool
+	}{
+		{S: AllCLM, J: `"all"`},
+		{S: TransactionCLM, J: `"transaction"`},
+		{S: 0x500, E: true},
+	} {
+		s = tc.S
+		j, err := json.Marshal(s)
+		if err != nil {
+			if !tc.E {
+				t.Errorf("#%d generated unexpected error %v", i, err)
+			}
+		} else {
+			if tc.E {
+				t.Errorf("#%d was supposed to generate an error but didn't", i)
+			}
+			if tc.J != string(j) {
+				t.Errorf("#%d expected \"%v\" but got \"%v\"", i, tc.J, string(j))
+			}
+		}
+	}
+}
+
+func TestCLMJsonUnmarshalling(t *testing.T) {
+	var s CodeLevelMetricsScope
+
+	for i, tc := range []struct {
+		S CodeLevelMetricsScope
+		J string
+		E bool
+	}{
+		{S: AllCLM, J: `"all"`},
+		{S: TransactionCLM, J: `"transaction"`},
+		{S: TransactionCLM, J: `"transaction,"`},
+		{S: TransactionCLM, J: `"transaction,txn"`},
+		{S: AllCLM, J: `"transaction,all,txn"`},
+		{S: AllCLM, J: `""`},
+		{S: AllCLM, J: `null`},
+		{S: AllCLM, J: `"blorfl"`, E: true},
+	} {
+		err := json.Unmarshal([]byte(tc.J), &s)
+
+		if err != nil {
+			if !tc.E {
+				t.Errorf("#%d generated unexpected error %v", i, err)
+			}
+		} else {
+			if tc.E {
+				t.Errorf("#%d was supposed to generate an error but didn't", i)
+			}
+			if tc.S != s {
+				t.Errorf("#%d expected \"%v\" but got \"%v\"", i, tc.S, s)
+			}
+		}
 	}
 }

--- a/v3/newrelic/instrumentation.go
+++ b/v3/newrelic/instrumentation.go
@@ -40,6 +40,8 @@ func WrapHandle(app *Application, pattern string, handler http.Handler, options 
 	// add the wrapped function to the trace options as the source code reference point
 	// (but only if we know we're collecting CLM for this transaction and the user didn't already
 	// specify a different code location explicitly).
+	var cache CachedCodeLocation
+	var cache2 CachedCodeLocation
 
 	return pattern, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var tOptions *traceOptSet
@@ -48,9 +50,15 @@ func WrapHandle(app *Application, pattern string, handler http.Handler, options 
 		if app.app != nil && app.app.run != nil && app.app.run.Config.CodeLevelMetrics.Enabled {
 			tOptions = resolveCLMTraceOptions(options)
 			if tOptions != nil && !tOptions.SuppressCLM && (tOptions.DemandCLM || app.app.run.Config.CodeLevelMetrics.Scope == 0 || (app.app.run.Config.CodeLevelMetrics.Scope&TransactionCLM) != 0) {
-				// we are for sure collecting CLM here, so go to the trouble of collecting this code location.
+				// we are for sure collecting CLM here, so go to the trouble of collecting this code location if nothing else has yet.
 				if tOptions.LocationOverride == nil {
-					WithThisCodeLocation()(tOptions)
+					if loc, err := cache.FunctionLocation(handler); err == nil {
+						// if handler is itself a function, use that
+						WithCodeLocation(loc)(tOptions)
+					} else if loc, err := cache2.FunctionLocation(handler.ServeHTTP); err == nil {
+						// otherwise, use the ServeHTTP method it has
+						WithCodeLocation(loc)(tOptions)
+					}
 				}
 			}
 		}
@@ -104,7 +112,6 @@ func WrapHandleFunc(app *Application, pattern string, handler func(http.Response
 	// add the wrapped function to the trace options as the source code reference point
 	// (to the beginning of the option list, so that the user can override this)
 
-	options = append(options, WithDefaultFunctionLocation(handler))
 	p, h := WrapHandle(app, pattern, http.HandlerFunc(handler), options...)
 	return p, func(w http.ResponseWriter, r *http.Request) { h.ServeHTTP(w, r) }
 }

--- a/v3/newrelic/internal_txn.go
+++ b/v3/newrelic/internal_txn.go
@@ -111,7 +111,7 @@ func newTxn(app *app, run *appRun, name string, opts ...TraceOption) *thread {
 	txn.Name = name
 	txn.Attrs = newAttributes(run.AttributeConfig)
 
-	if !txnOpts.SuppressCLM && run.Config.CodeLevelMetrics.Enabled && (run.Config.CodeLevelMetrics.Scope == 0 || (run.Config.CodeLevelMetrics.Scope&TransactionCLM) != 0) {
+	if !txnOpts.SuppressCLM && run.Config.CodeLevelMetrics.Enabled && (txnOpts.DemandCLM || run.Config.CodeLevelMetrics.Scope == 0 || (run.Config.CodeLevelMetrics.Scope&TransactionCLM) != 0) {
 		reportCodeLevelMetrics(txnOpts, run, txn.Attrs.Agent.Add)
 	}
 


### PR DESCRIPTION
Updates and corrects CLM collection code.

Fixes [issue 557](https://github.com/newrelic/go-agent/issues/557) by correcting where we were unconditionally calling functions to resolve the code location even when code level metrics were disabled globally, as well as doing redundant work in some cases if the user passed their own code locations in. There was also a race condition and thread incompatibility for wrapped function handlers that has been corrected.

Now the agent will never try to resolve code locations unless explicitly asked to (e.g., by the user directly calling `ThisCodeLocation` or similar function), until it knows for sure it needs to collect CLM for that transaction. It will also look to see if code level metrics are locally suppressed (`WithoutCodeLevelMetrics()`) or disabled globally and avoid going through the overhead of collecting anything in those cases. It will also avoid adding its own calls to `ThisCodeLocation` or `WithFunctionLocation` (etc) if the user supplied their own explicit function location in the option list. (Previously, it would call one or both of those and discard the results if overridden downstream by user-set options.)

Additionally, this PR includes some trivial enhancements that were prompted by the above corrections, and/or we expect will be needed once more users start using the CLM feature so it's better to head that off and get them implemented now:

Like we did with `IgnoredPrefix`, we expanded `PathPrefix` from a single `string` value to a new `[]string` field `PathPrefixes` (which deprecates the old `PathPrefix` field). Congruent with that, `ConfigCodeLevelMetricsPathPrefix` now takes any number of `string` values and `NEW_RELIC_CODE_LEVEL_METRICS_PATH_PREFIX` environment variable interprets its value as a comma-separated list of path prefix strings.

A transaction-specific `WithPathPrefix` option allows the specification of a different set of source path prefixes to be given for individual transactions instead of the globally configured list.

A `WithCodeLevelMetrics` option has been added for transactions as the complement to `WithoutCodeLevelMetrics`. This allows for individual transactions to report CLM even if they wouldn't have otherwise (due, for example, to a narrower scope being globally configured which would have excluded this trace). Note that this will *never* enable CLM for any transaction which also carries a `WithoutCodeLevelMetrics` option, or if CLM are disabled globally for the application.

A `WithDefaultFunctionLocation` option has been added which is identical to `WithFunctionLocation` except that it will only _evaluate_ the location of the given function value if no other option has set the code location to be reported before `WithDefaultFunctionLocation` was encountered in the option list.
