### PR TITLE
Fix clm bugs

### DIFF
--- a/v3/newrelic/instrumentation.go
+++ b/v3/newrelic/instrumentation.go
@@ -36,15 +36,19 @@ func WrapHandle(app *Application, pattern string, handler http.Handler, options 
 	if app == nil {
 		return pattern, handler
 	}
-	// add the wrapped function to the trace options as the source code reference point
-	// (to the beginning of the option list, so that the user can override this)
-	// If we came here via WrapHandleFunc, that means it will have pushed the handler's
-	// code location if possible, so the options will be (this code location), (handler function location),
-	// (other options); that results in having a backup in case either failed, with preference
-	// given to the handler's function location. In any event, the user may override all of that
-	// with a location they choose.
+
+	if app.app != nil && app.app.run != nil && app.app.run.Config.CodeLevelMetrics.Enabled {
+		// add the wrapped function to the trace options as the source code reference point
+		// (to the beginning of the option list, so that the user can override this)
+		// If we came here via WrapHandleFunc, that means it will have pushed the handler's
+		// code location if possible, so the options will be (this code location), (handler function location),
+		// (other options); that results in having a backup in case either failed, with preference
+		// given to the handler's function location. In any event, the user may override all of that
+		// with a location they choose.
+		options = append([]TraceOption{WithFunctionLocation(handler.ServeHTTP)}, options...)
+	}
+
 	return pattern, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		options = append([]TraceOption{WithThisCodeLocation()}, options...)
 		txn := app.StartTransaction(r.Method+" "+pattern, options...)
 		defer txn.End()
 
@@ -85,8 +89,6 @@ func WrapHandle(app *Application, pattern string, handler http.Handler, options 
 // manually added to the transaction trace generated, in the same fashion as StartTransaction
 // does. For example, this can be used to control code level metrics generated for this transaction.
 func WrapHandleFunc(app *Application, pattern string, handler func(http.ResponseWriter, *http.Request), options ...TraceOption) (string, func(http.ResponseWriter, *http.Request)) {
-	// add the wrapped function to the trace options as the source code reference point
-	// (to the beginning of the option list, so that the user can override this)
 	options = append([]TraceOption{WithFunctionLocation(handler)}, options...)
 	p, h := WrapHandle(app, pattern, http.HandlerFunc(handler), options...)
 	return p, func(w http.ResponseWriter, r *http.Request) { h.ServeHTTP(w, r) }


### PR DESCRIPTION
Fixes #557. Changed `WrapHandle` to fetch the location of the original handler, as opposed to the caller of the wrapped handler, for consistency with `WrapHandleFunc`. Also moved the lookup outside the closure so it only happens once, which both improves performance and resolves a race condition. Also fixed both `WrapHandle` and `WrapHandleFunc` to not lookup the location if CLM is disabled for the app.