### PR TITLE
Fix #519: bump sql driver to v1.6.0

### DIFF
--- a/v3/integrations/nrmysql/go.mod
+++ b/v3/integrations/nrmysql/go.mod
@@ -1,11 +1,11 @@
 module github.com/newrelic/go-agent/v3/integrations/nrmysql
 
 // 1.10 is the Go version in mysql's go.mod
-go 1.10
+go 1.17
 
 require (
 	// v1.5.0 is the first mysql version to support gomod
-	github.com/go-sql-driver/mysql v1.5.0
+	github.com/go-sql-driver/mysql v1.6.0
 	// v3.3.0 includes the new location of ParseQuery
-	github.com/newrelic/go-agent/v3 v3.3.0
+	github.com/newrelic/go-agent/v3 v3.18.2
 )


### PR DESCRIPTION
Fixes #519 

not using this version of the sql driver may cause connection leaks 