### PR TITLE
Release v3.19.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,8 +85,41 @@ jobs:
             dirs: _integrations/nrb3
           - go-version: 1.13.x
             dirs: _integrations/nrmongo
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go-version }}
 
-          # v3 agent
+    - name: Checkout Code
+      uses: actions/checkout@v1
+      with:
+        # Required when using older versions of Go that do not support gomod.
+        # Note the required presence of the /go-agent/ directory at the
+        # beginning of this path.  It is required in order to match the
+        # ${{ github.workspace }} used by the GOPATH env var.  pwd when cloning
+        # the repo is <something>/go-agent/ whereas ${{ github.workspace }}
+        # returns <something/go-agent/go-agent/.
+        path: ./go-agent/src/github.com/newrelic/go-agent
+
+    - name: Run Tests
+      run: bash build-script.sh
+      env:
+        DIRS: ${{ matrix.dirs }}
+        EXTRATESTING: ${{ matrix.extratesting }}
+        PIN: ${{ matrix.pin }}
+
+  go-agent-v3:
+    runs-on: ubuntu-18.04
+    env:
+      # Required when using older versions of Go that do not support gomod.
+      GOPATH: ${{ github.workspace }}
+
+    strategy:
+      # if one test fails, do not abort the rest
+      fail-fast: false
+      matrix:
+        include:
           - go-version: 1.17.x
             dirs: v3/newrelic,v3/internal,v3/examples
           - go-version: 1.18.x
@@ -183,16 +216,13 @@ jobs:
             extratesting: go get -u github.com/nats-io/nats.go/@master
           - go-version: 1.17.x
             dirs: v3/integrations/nrnats/test
-            extratesting: go get -u github.com/nats-io/nats.go/@master
           - go-version: 1.17.x
             dirs: v3/integrations/nrstan
             extratesting: go get -u github.com/nats-io/stan.go/@master
           - go-version: 1.17.x
             dirs: v3/integrations/nrstan/test
-            extratesting: go get -u github.com/nats-io/stan.go/@master
           - go-version: 1.17.x
             dirs: v3/integrations/nrstan/examples
-            extratesting: go get -u github.com/nats-io/stan.go/@master
           - go-version: 1.17.x
             dirs: v3/integrations/logcontext
             extratesting: go get -u github.com/sirupsen/logrus@master
@@ -233,7 +263,7 @@ jobs:
         path: ./go-agent/src/github.com/newrelic/go-agent
 
     - name: Run Tests
-      run: bash build-script.sh
+      run: bash v3/build-script.sh
       env:
         DIRS: ${{ matrix.dirs }}
         EXTRATESTING: ${{ matrix.extratesting }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 3.19.2
+
+### Changed
+* Updated nrgin integration to more accurately report code locations when code level metrics are enabled.
+* The Go Agent and all integrations now require Go version 1.17 or later.
+* Updated minimum versions for third-party modules.
+  * nrawssdk-v2, nrecho-v4, nrgrpc, nrmongo, nrmysql, nrnats, and nrstan now require Go Agent 3.18.2 or later
+  * the Go Agent now requires protobuf 1.5.2 and grpc 1.49.0
+* Internal dev process and unit test improvements.
+
+### Support Statement
+New Relic recommends that you upgrade the agent regularly to ensure that you’re getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach end-of-life.
+
+We also recommend using the latest version of the Go language. At minimum, you should at least be using no version of Go older than what is supported by the Go team themselves.
+
+See the [Go Agent EOL Policy](https://docs.newrelic.com/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go Agent and third-party components.
+
+
 ## 3.19.1 - Hotfix Release
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Go is a compiled language, and doesn’t use a virtual machine. This means that 
 
 ### Compatibility and Requirements
 
-For the latest version of the agent, Go 1.7+ is required, due to the use of `context.Context`.
+For the latest version of the agent, Go 1.17+ is required.
 
 Linux, OS X, and Windows (Vista, Server 2008 and later) are supported.
 

--- a/v3/build-script.sh
+++ b/v3/build-script.sh
@@ -1,0 +1,62 @@
+# Copyright 2020 New Relic Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -x
+set -e
+
+# inputs
+# 1: repo pin; example: github.com/rewrelic/go-agent@v1.9.0
+pin_go_dependency() {
+  if [[ ! -z "$1" ]]; then
+    echo "Pinning: $1"
+    repo=$(echo "$1" | cut -d '@' -f1)
+    pinTo=$(echo "$1" | cut -d '@' -f2)
+    set +e
+    go get -u "$repo" # this go get will fail to build
+    set -e
+    cd "$GOPATH"/src/"$repo"
+    git checkout "$pinTo"
+    cd -
+  fi
+}
+
+verify_go_fmt() {
+  needsFMT=$(gofmt -d .)
+  if [ ! -z "$needsFMT" ]; then
+    echo "$needsFMT"
+    echo "Please format your code with \"gofmt .\""
+    # exit 1
+  fi
+}
+
+pwd=$(pwd)
+version=$(go version)
+echo $version
+
+tmp=$(echo $version | cut -d 'o' -f4)
+shortVersion=${tmp%.*}
+
+IFS=","
+for dir in $DIRS; do
+  cd "$pwd/$dir"
+
+  # replace go-agent with local pull
+  go mod edit -replace github.com/newrelic/go-agent/v3="$pwd"/v3
+
+  # manage dependencies
+  go mod tidy -go=$shortVersion -compat=$shortVersion
+  pin_go_dependency "$PIN"
+
+  # run tests
+  go test -race -benchtime=1ms -bench=. ./...
+  go vet ./...
+  verify_go_fmt
+  
+  # Test again against the latest version of the dependencies to ensure that
+  # our instrumentation is up to date.  TODO: Perhaps it is possible to
+  # upgrade all go.mod dependencies to latest master with a go command.
+  if [ -n "$EXTRATESTING" ]; then
+    eval "$EXTRATESTING"
+    go test -race -benchtime=1ms -bench=. ./...
+  fi
+done

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -1,8 +1,8 @@
 module github.com/newrelic/go-agent/v3
 
-go 1.7
+go 1.17
 
 require (
-	github.com/golang/protobuf v1.4.3
-	google.golang.org/grpc v1.39.0
+	github.com/golang/protobuf v1.5.2
+	google.golang.org/grpc v1.49.0
 )

--- a/v3/integrations/nrawssdk-v2/go.mod
+++ b/v3/integrations/nrawssdk-v2/go.mod
@@ -2,17 +2,14 @@ module github.com/newrelic/go-agent/v3/integrations/nrawssdk-v2
 
 // As of May 2021, the aws-sdk-go-v2 go.mod file uses 1.15:
 // https://github.com/aws/aws-sdk-go-v2/blob/master/go.mod
-go 1.15
-
-replace github.com/newrelic/go-agent/v3 => ../../
+go 1.17
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.4.0
-	github.com/aws/aws-sdk-go-v2/config v1.1.7
-	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.2.3
-	github.com/aws/aws-sdk-go-v2/service/lambda v1.2.3
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.6.0
-	github.com/aws/smithy-go v1.4.0
-	github.com/newrelic/go-agent/v3 v3.0.0
-	golang.org/x/tools v0.1.0 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.16.15
+	github.com/aws/aws-sdk-go-v2/config v1.17.6
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.17.0
+	github.com/aws/aws-sdk-go-v2/service/lambda v1.24.5
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.10
+	github.com/aws/smithy-go v1.13.3
+	github.com/newrelic/go-agent/v3 v3.18.2
 )

--- a/v3/integrations/nrecho-v4/go.mod
+++ b/v3/integrations/nrecho-v4/go.mod
@@ -4,24 +4,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrecho-v4
 // https://github.com/labstack/echo/blob/master/go.mod
 go 1.17
 
-
 require (
 	github.com/labstack/echo/v4 v4.5.0
-	github.com/newrelic/go-agent/v3 v3.16.1
-)
-
-require (
-	github.com/golang/protobuf v1.4.3 // indirect
-	github.com/labstack/gommon v0.3.0 // indirect
-	github.com/mattn/go-colorable v0.1.8 // indirect
-	github.com/mattn/go-isatty v0.0.12 // indirect
-	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasttemplate v1.2.1 // indirect
-	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
-	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
-	golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 // indirect
-	golang.org/x/text v0.3.6 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/grpc v1.39.0 // indirect
-	google.golang.org/protobuf v1.25.0 // indirect
+	github.com/newrelic/go-agent/v3 v3.18.2
 )

--- a/v3/integrations/nrgin/example/main.go
+++ b/v3/integrations/nrgin/example/main.go
@@ -58,6 +58,7 @@ func main() {
 		newrelic.ConfigAppName("Gin App"),
 		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
 		newrelic.ConfigDebugLogger(os.Stdout),
+		newrelic.ConfigCodeLevelMetricsEnabled(true),
 	)
 	if nil != err {
 		fmt.Println(err)

--- a/v3/integrations/nrgin/go.mod
+++ b/v3/integrations/nrgin/go.mod
@@ -6,5 +6,5 @@ go 1.12
 
 require (
 	github.com/gin-gonic/gin v1.8.0
-	github.com/newrelic/go-agent/v3 v3.17.0
+	github.com/newrelic/go-agent/v3 v3.18.2
 )

--- a/v3/integrations/nrgin/nrgin.go
+++ b/v3/integrations/nrgin/nrgin.go
@@ -144,7 +144,7 @@ func middleware(app *newrelic.Application, useNewNames bool) gin.HandlerFunc {
 			name := c.Request.Method + " " + getName(c, useNewNames)
 
 			w := &headerResponseWriter{w: c.Writer}
-			txn := app.StartTransaction(name)
+			txn := app.StartTransaction(name, newrelic.WithFunctionLocation(c.Handler()))
 			txn.SetWebRequestHTTP(c.Request)
 			defer txn.End()
 

--- a/v3/integrations/nrgrpc/go.mod
+++ b/v3/integrations/nrgrpc/go.mod
@@ -2,13 +2,21 @@ module github.com/newrelic/go-agent/v3/integrations/nrgrpc
 
 // As of Dec 2019, the grpc go.mod file uses 1.11:
 // https://github.com/grpc/grpc-go/blob/master/go.mod
-go 1.11
+go 1.17
 
 require (
 	// protobuf v1.3.0 is the earliest version using modules, we use v1.3.1
 	// because all dependencies were removed in this version.
-	github.com/golang/protobuf v1.3.3
-	github.com/newrelic/go-agent/v3 v3.12.0
+	github.com/golang/protobuf v1.5.2
+	github.com/newrelic/go-agent/v3 v3.18.2
 	// v1.15.0 is the earliest version of grpc using modules.
-	google.golang.org/grpc v1.39.0
+	google.golang.org/grpc v1.49.0
+)
+
+require (
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
+	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
 )

--- a/v3/integrations/nrmongo/go.mod
+++ b/v3/integrations/nrmongo/go.mod
@@ -2,10 +2,10 @@ module github.com/newrelic/go-agent/v3/integrations/nrmongo
 
 // As of Dec 2019, 1.10 is the mongo-driver requirement:
 // https://github.com/mongodb/mongo-go-driver#requirements
-go 1.10
+go 1.17
 
 require (
-	github.com/newrelic/go-agent/v3 v3.6.0
+	github.com/newrelic/go-agent/v3 v3.18.2
 	// mongo-driver does not support modules as of Nov 2019.
-	go.mongodb.org/mongo-driver v1.5.1
+	go.mongodb.org/mongo-driver v1.10.2
 )

--- a/v3/integrations/nrmysql/go.mod
+++ b/v3/integrations/nrmysql/go.mod
@@ -1,11 +1,11 @@
 module github.com/newrelic/go-agent/v3/integrations/nrmysql
 
 // 1.10 is the Go version in mysql's go.mod
-go 1.10
+go 1.17
 
 require (
 	// v1.5.0 is the first mysql version to support gomod
-	github.com/go-sql-driver/mysql v1.5.0
+	github.com/go-sql-driver/mysql v1.6.0
 	// v3.3.0 includes the new location of ParseQuery
-	github.com/newrelic/go-agent/v3 v3.3.0
+	github.com/newrelic/go-agent/v3 v3.18.2
 )

--- a/v3/integrations/nrnats/go.mod
+++ b/v3/integrations/nrnats/go.mod
@@ -2,10 +2,9 @@ module github.com/newrelic/go-agent/v3/integrations/nrnats
 
 // As of Dec 2019, 1.11 is the earliest version of Go tested by nats:
 // https://github.com/nats-io/nats.go/blob/master/.travis.yml
-go 1.11
+go 1.17
 
 require (
-	// v1.8.0 is the first nats version with a go.mod.
-	github.com/nats-io/nats.go v1.8.0
-	github.com/newrelic/go-agent/v3 v3.4.0
+	github.com/nats-io/nats.go v1.17.0
+	github.com/newrelic/go-agent/v3 v3.18.2
 )

--- a/v3/integrations/nrnats/test/go.mod
+++ b/v3/integrations/nrnats/test/go.mod
@@ -2,16 +2,31 @@ module github.com/newrelic/go-agent/v3/integrations/test
 
 // This module exists to avoid having extra nrnats module dependencies.
 
-go 1.13
+go 1.17
+
+replace github.com/newrelic/go-agent/v3/integrations/nrnats v1.0.0 => ../
+
+replace github.com/newrelic/go-agent/v3 v3.18.2 => ../../../
 
 require (
-	github.com/nats-io/gnatsd v1.4.1 // indirect
 	github.com/nats-io/nats-server v1.4.1
-	github.com/nats-io/nats.go v1.8.0
-	github.com/newrelic/go-agent/v3 v3.4.0
-	github.com/newrelic/go-agent/v3/integrations/nrnats v0.0.0
+	github.com/nats-io/nats.go v1.17.0
+	github.com/newrelic/go-agent/v3 v3.18.2
+	github.com/newrelic/go-agent/v3/integrations/nrnats v1.0.0
 )
 
-replace github.com/newrelic/go-agent/v3 => ../../../
-
-replace github.com/newrelic/go-agent/v3/integrations/nrnats => ../
+require (
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/nats-io/gnatsd v1.4.1 // indirect
+	github.com/nats-io/go-nats v1.7.2 // indirect
+	github.com/nats-io/nats-server/v2 v2.9.0 // indirect
+	github.com/nats-io/nkeys v0.3.0 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
+	golang.org/x/crypto v0.0.0-20220919173607-35f4265a4bc0 // indirect
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
+	golang.org/x/sys v0.0.0-20220906135438-9e1f76180b77 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/grpc v1.49.0 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+)

--- a/v3/integrations/nrstan/go.mod
+++ b/v3/integrations/nrstan/go.mod
@@ -2,9 +2,9 @@ module github.com/newrelic/go-agent/v3/integrations/nrstan
 
 // As of Dec 2019, 1.11 is the earliest Go version tested by Stan:
 // https://github.com/nats-io/stan.go/blob/master/.travis.yml
-go 1.11
+go 1.17
 
 require (
-	github.com/nats-io/stan.go v0.5.0
-	github.com/newrelic/go-agent/v3 v3.4.0
+	github.com/nats-io/stan.go v0.10.3
+	github.com/newrelic/go-agent/v3 v3.18.2
 )

--- a/v3/newrelic/version.go
+++ b/v3/newrelic/version.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Version is the full string version of this Go Agent.
-	Version = "3.19.1"
+	Version = "3.19.2"
 )
 
 var (


### PR DESCRIPTION
## 3.19.2

### Changed
* Updated nrgin integration to more accurately report code locations when code level metrics are enabled.
* The Go Agent and all integrations now require Go version 1.17 or later.
* Updated minimum versions for third-party modules.
  * nrawssdk-v2, nrecho-v4, nrgrpc, nrmongo, nrmysql, nrnats, and nrstan now require Go Agent 3.18.2 or later
  * the Go Agent now requires protobuf 1.5.2 and grpc 1.49.0
* Internal dev process and unit test improvements.

### Support Statement
New Relic recommends that you upgrade the agent regularly to ensure that you’re getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach end-of-life.

We also recommend using the latest version of the Go language. At minimum, you should at least be using no version of Go older than what is supported by the Go team themselves.

See the [Go Agent EOL Policy](https://docs.newrelic.com/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go Agent and third-party components.