### PR TITLE
More Defensive zerologWriter parsing

### DIFF
--- a/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer.go
+++ b/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer.go
@@ -128,19 +128,13 @@ func getStringValue(p []byte, indx int) (string, int) {
 	// parse value of string field
 	for i := indx; i < len(p); i++ {
 		if p[i] == '"' && i+1 < len(p) {
-			if p[i+1] == ',' {
-				if i+2 < len(p) && p[i+2] == '"' {
-					return value.String(), i + 2
-				} else {
-					value.WriteByte(p[i])
-				}
-			}
-			if p[i+1] == '}' {
+			if p[i+1] == ',' && i+2 < len(p) && p[i+2] == '"' {
+				return value.String(), i + 2
+			} else if p[i+1] == '}' {
 				return value.String(), -1
 			}
-		} else {
-			value.WriteByte(p[i])
 		}
+		value.WriteByte(p[i])
 	}
 
 	return "", -1
@@ -151,13 +145,10 @@ func getNumberValue(p []byte, indx int) (string, int) {
 
 	// parse value of string field
 	for i := indx; i < len(p); i++ {
-		if p[i] == ',' && i+1 < len(p) {
-			if p[i+1] == '"' {
-				return value.String(), i + 1
-			}
-			if p[i+1] == '}' {
-				return value.String(), -1
-			}
+		if p[i] == ',' && i+1 < len(p) && p[i+1] == '"' {
+			return value.String(), i + 1
+		} else if p[i] == '}' {
+			return value.String(), -1
 		} else {
 			value.WriteByte(p[i])
 		}
@@ -178,7 +169,7 @@ func getStackTrace(p []byte, indx int) (string, int) {
 				if p[i+1] == '}' {
 					return value.String(), -1
 				}
-				if p[i+1] == ',' {
+				if p[i+1] == ',' && i+2 < len(p) && p[i+2] == '"' {
 					return value.String(), i + 2
 				}
 			}

--- a/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer.go
+++ b/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer.go
@@ -123,7 +123,7 @@ func getKey(p []byte, indx int) (string, int) {
 }
 
 func isEOL(p []byte, i int) bool {
-	return p[i] == '}' && i+1 < len(p) && p[i+1] == '\n'
+	return p[i] == '}' && i+2 == len(p)
 }
 
 func getStringValue(p []byte, indx int) (string, int) {

--- a/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer.go
+++ b/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter"
@@ -52,6 +53,7 @@ func parseJSONLogData(log []byte) newrelic.LogData {
 	// For this iteration of the tool, the entire log gets captured as the message
 	data := newrelic.LogData{}
 	data.Message = string(log)
+	data.Timestamp = time.Now().UnixMilli()
 
 	for i := 0; i < len(log)-1; {
 		// get key; always a string field
@@ -131,8 +133,6 @@ func getStringValue(p []byte, indx int) (string, int) {
 					return value.String(), i + 2
 				} else {
 					value.WriteByte(p[i])
-					value.WriteByte(p[i+1])
-					value.WriteByte(p[i+2])
 				}
 			}
 			if p[i+1] == '}' {

--- a/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer.go
+++ b/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer.go
@@ -122,6 +122,10 @@ func getKey(p []byte, indx int) (string, int) {
 	return "", -1
 }
 
+func isEOL(p []byte, i int) bool {
+	return p[i] == '}' && i+1 < len(p) && p[i+1] == '\n'
+}
+
 func getStringValue(p []byte, indx int) (string, int) {
 	value := strings.Builder{}
 
@@ -130,7 +134,7 @@ func getStringValue(p []byte, indx int) (string, int) {
 		if p[i] == '"' && i+1 < len(p) {
 			if p[i+1] == ',' && i+2 < len(p) && p[i+2] == '"' {
 				return value.String(), i + 2
-			} else if p[i+1] == '}' {
+			} else if isEOL(p, i+1) {
 				return value.String(), -1
 			}
 		}
@@ -147,7 +151,7 @@ func getNumberValue(p []byte, indx int) (string, int) {
 	for i := indx; i < len(p); i++ {
 		if p[i] == ',' && i+1 < len(p) && p[i+1] == '"' {
 			return value.String(), i + 1
-		} else if p[i] == '}' {
+		} else if isEOL(p, i) {
 			return value.String(), -1
 		} else {
 			value.WriteByte(p[i])
@@ -166,7 +170,7 @@ func getStackTrace(p []byte, indx int) (string, int) {
 			value.WriteByte(p[i])
 
 			if i+1 < len(p) {
-				if p[i+1] == '}' {
+				if isEOL(p, i+1) {
 					return value.String(), -1
 				}
 				if p[i+1] == ',' && i+2 < len(p) && p[i+2] == '"' {

--- a/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer.go
+++ b/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer.go
@@ -125,8 +125,13 @@ func getStringValue(p []byte, indx int) (string, int) {
 
 	// parse value of string field
 	for i := indx; i < len(p); i++ {
-		if p[i] == '"' && i+1 < len(p) && p[i+1] == ',' {
-			return value.String(), i + 2
+		if p[i] == '"' && i+1 < len(p) {
+			if p[i+1] == ',' {
+				return value.String(), i + 2
+			}
+			if p[i+1] == '}' {
+				return value.String(), -1
+			}
 		} else {
 			value.WriteByte(p[i])
 		}
@@ -140,8 +145,13 @@ func getNumberValue(p []byte, indx int) (string, int) {
 
 	// parse value of string field
 	for i := indx; i < len(p); i++ {
-		if p[i] == ',' && i+1 < len(p) && p[i+1] == '"' {
-			return value.String(), i + 1
+		if p[i] == ',' && i+1 < len(p) {
+			if p[i+1] == '"' {
+				return value.String(), i + 1
+			}
+			if p[i+1] == '}' {
+				return value.String(), -1
+			}
 		} else {
 			value.WriteByte(p[i])
 		}
@@ -158,11 +168,13 @@ func getStackTrace(p []byte, indx int) (string, int) {
 		if p[i] == ']' {
 			value.WriteByte(p[i])
 
-			if i+1 <= len(p)-1 && p[i] == '}' {
-				return value.String(), -1
-			}
-			if i+1 < len(p) && p[i] == ',' {
-				return value.String(), i + 2
+			if i+1 < len(p) {
+				if p[i+1] == '}' {
+					return value.String(), -1
+				}
+				if p[i+1] == ',' {
+					return value.String(), i + 2
+				}
 			}
 		} else {
 			value.WriteByte(p[i])

--- a/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer.go
+++ b/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer.go
@@ -127,7 +127,13 @@ func getStringValue(p []byte, indx int) (string, int) {
 	for i := indx; i < len(p); i++ {
 		if p[i] == '"' && i+1 < len(p) {
 			if p[i+1] == ',' {
-				return value.String(), i + 2
+				if i+2 < len(p) && p[i+2] == '"' {
+					return value.String(), i + 2
+				} else {
+					value.WriteByte(p[i])
+					value.WriteByte(p[i+1])
+					value.WriteByte(p[i+2])
+				}
 			}
 			if p[i+1] == '}' {
 				return value.String(), -1

--- a/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer_test.go
+++ b/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer_test.go
@@ -79,6 +79,14 @@ func TestParseLogData(t *testing.T) {
 				Severity: "debug",
 			},
 		},
+		{
+			`{"Scale":"833 cents","Interval":833.09,"time":1562212768,"message":"Fibonacci is everywhere","level":"debug"}`,
+			"level",
+			newrelic.LogData{
+				Message:  `{"Scale":"833 cents","Interval":833.09,"time":1562212768,"message":"Fibonacci is everywhere","level":"debug"}`,
+				Severity: "debug",
+			},
+		},
 	}
 	for _, test := range tests {
 		if test.levelKey != "" {

--- a/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer_test.go
+++ b/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer_test.go
@@ -164,9 +164,9 @@ func TestParseLogDataEscapes(t *testing.T) {
 			`{"level":"info","message":"escape quote,\",\" hi"}`,
 		},
 		{
-			"escape bracket,\"}\" hi",
+			"escape bracket,\"}\n hi",
 			"info",
-			`{"level":"info","message":"escape bracket,\"}\" hi"}`,
+			`{"level":"info","message":"escape bracket,\"}\n hi"}`,
 		},
 	}
 

--- a/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer_test.go
+++ b/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer_test.go
@@ -26,76 +26,100 @@ func TestParseLogData(t *testing.T) {
 	}
 	tests := []logTest{
 		{
-			`{"time":1516134303,"level":"debug","message":"hello world"}`,
+			`{"time":1516134303,"level":"debug","message":"hello world"}` + "\n",
 			"level",
 			newrelic.LogData{
-				Message:  `{"time":1516134303,"level":"debug","message":"hello world"}`,
+				Message:  `{"time":1516134303,"level":"debug","message":"hello world"}` + "\n",
 				Severity: "debug",
 			},
 		},
 		{
-			`{"time":1516134303,"level":"info","message":"hello world"}`,
+			`{"time":1516134303,"level":"info","message":"hello world"}` + "\n",
 			"level",
 			newrelic.LogData{
-				Message:  `{"time":1516134303,"level":"info","message":"hello world"}`,
+				Message:  `{"time":1516134303,"level":"info","message":"hello world"}` + "\n",
 				Severity: "info",
 			},
 		},
 		{
-			`{"time":1516133263,"level":"fatal","error":"A repo man spends his life getting into tense situations","service":"myservice","message":"Cannot start myservice"}`,
+			`{"time":1516133263,"level":"fatal","error":"A repo man spends his life getting into tense situations","service":"myservice","message":"Cannot start myservice"}` + "\n",
 			"level",
 			newrelic.LogData{
-				Message:  `{"time":1516133263,"level":"fatal","error":"A repo man spends his life getting into tense situations","service":"myservice","message":"Cannot start myservice"}`,
+				Message:  `{"time":1516133263,"level":"fatal","error":"A repo man spends his life getting into tense situations","service":"myservice","message":"Cannot start myservice"}` + "\n",
 				Severity: "fatal",
 			},
 		},
 		{
-			`{"time":1516134303,"hi":"info","message":"hello world"}`,
+			`{"time":1516134303,"hi":"info","message":"hello world"}` + "\n",
 			"hi",
 			newrelic.LogData{
-				Message:  `{"time":1516134303,"hi":"info","message":"hello world"}`,
+				Message:  `{"time":1516134303,"hi":"info","message":"hello world"}` + "\n",
 				Severity: "info",
 			},
 		},
 		{
-			`{"time":1516134303,"level":"debug","message":"hello, world"}`,
+			`{"time":1516134303,"level":"debug","message":"hello, world"}` + "\n",
 			"level",
 			newrelic.LogData{
-				Message:  `{"time":1516134303,"level":"debug","message":"hello, world"}`,
+				Message:  `{"time":1516134303,"level":"debug","message":"hello, world"}` + "\n",
+				Severity: "debug",
+			},
+		},
+		{
+			`{"time":1516134303,"level":"debug","message":"hello, world { thing }"}` + "\n",
+			"level",
+			newrelic.LogData{
+				Message:  `{"time":1516134303,"level":"debug","message":"hello, world { thing }"}` + "\n",
+				Severity: "debug",
+			},
+		},
+		{
+			`{"time":1516134303,"level":"debug","message":"hello, world \"{ thing \"}"}` + "\n",
+			"level",
+			newrelic.LogData{
+				Message:  `{"time":1516134303,"level":"debug","message":"hello, world \"{ thing \"}"}` + "\n",
+				Severity: "debug",
+			},
+		},
+		{
+			`{"message":"hello, world \"{ thing \"}","time":1516134303,"level":"debug"}` + "\n",
+			"level",
+			newrelic.LogData{
+				Message:  `{"message":"hello, world \"{ thing \"}","time":1516134303,"level":"debug"}` + "\n",
 				Severity: "debug",
 			},
 		},
 		{
 			// basic stack trace test
-			`{"level":"error","stack":[{"func":"inner","line":"20","source":"errors.go"},{"func":"middle","line":"24","source":"errors.go"},{"func":"outer","line":"32","source":"errors.go"},{"func":"main","line":"15","source":"errors.go"},{"func":"main","line":"204","source":"proc.go"},{"func":"goexit","line":"1374","source":"asm_amd64.s"}],"error":"seems we have an error here","time":1609086683}`,
+			`{"level":"error","stack":[{"func":"inner","line":"20","source":"errors.go"},{"func":"middle","line":"24","source":"errors.go"},{"func":"outer","line":"32","source":"errors.go"},{"func":"main","line":"15","source":"errors.go"},{"func":"main","line":"204","source":"proc.go"},{"func":"goexit","line":"1374","source":"asm_amd64.s"}],"error":"seems we have an error here","time":1609086683}` + "\n",
 			"level",
 			newrelic.LogData{
-				Message:  `{"level":"error","stack":[{"func":"inner","line":"20","source":"errors.go"},{"func":"middle","line":"24","source":"errors.go"},{"func":"outer","line":"32","source":"errors.go"},{"func":"main","line":"15","source":"errors.go"},{"func":"main","line":"204","source":"proc.go"},{"func":"goexit","line":"1374","source":"asm_amd64.s"}],"error":"seems we have an error here","time":1609086683}`,
+				Message:  `{"level":"error","stack":[{"func":"inner","line":"20","source":"errors.go"},{"func":"middle","line":"24","source":"errors.go"},{"func":"outer","line":"32","source":"errors.go"},{"func":"main","line":"15","source":"errors.go"},{"func":"main","line":"204","source":"proc.go"},{"func":"goexit","line":"1374","source":"asm_amd64.s"}],"error":"seems we have an error here","time":1609086683}` + "\n",
 				Severity: "error",
 			},
 		},
 		{
 			// Tests that code can handle a stack trace, even if its at EOL
-			`{"level":"error","stack":[{"func":"inner","line":"20","source":"errors.go"},{"func":"middle","line":"24","source":"errors.go"},{"func":"outer","line":"32","source":"errors.go"},{"func":"main","line":"15","source":"errors.go"},{"func":"main","line":"204","source":"proc.go"},{"func":"goexit","line":"1374","source":"asm_amd64.s"}]}`,
+			`{"level":"error","stack":[{"func":"inner","line":"20","source":"errors.go"},{"func":"middle","line":"24","source":"errors.go"},{"func":"outer","line":"32","source":"errors.go"},{"func":"main","line":"15","source":"errors.go"},{"func":"main","line":"204","source":"proc.go"},{"func":"goexit","line":"1374","source":"asm_amd64.s"}]}` + "\n",
 			"level",
 			newrelic.LogData{
-				Message:  `{"level":"error","stack":[{"func":"inner","line":"20","source":"errors.go"},{"func":"middle","line":"24","source":"errors.go"},{"func":"outer","line":"32","source":"errors.go"},{"func":"main","line":"15","source":"errors.go"},{"func":"main","line":"204","source":"proc.go"},{"func":"goexit","line":"1374","source":"asm_amd64.s"}]}`,
+				Message:  `{"level":"error","stack":[{"func":"inner","line":"20","source":"errors.go"},{"func":"middle","line":"24","source":"errors.go"},{"func":"outer","line":"32","source":"errors.go"},{"func":"main","line":"15","source":"errors.go"},{"func":"main","line":"204","source":"proc.go"},{"func":"goexit","line":"1374","source":"asm_amd64.s"}]}` + "\n",
 				Severity: "error",
 			},
 		},
 		{
-			`{"level":"debug","Scale":"833 cents","Interval":833.09,"time":1562212768,"message":"Fibonacci is everywhere"}`,
+			`{"level":"debug","Scale":"833 cents","Interval":833.09,"time":1562212768,"message":"Fibonacci is everywhere"}` + "\n",
 			"level",
 			newrelic.LogData{
-				Message:  `{"level":"debug","Scale":"833 cents","Interval":833.09,"time":1562212768,"message":"Fibonacci is everywhere"}`,
+				Message:  `{"level":"debug","Scale":"833 cents","Interval":833.09,"time":1562212768,"message":"Fibonacci is everywhere"}` + "\n",
 				Severity: "debug",
 			},
 		},
 		{
-			`{"Scale":"833 cents","Interval":833.09,"time":1562212768,"message":"Fibonacci is everywhere","level":"debug"}`,
+			`{"Scale":"833 cents","Interval":833.09,"time":1562212768,"message":"Fibonacci is everywhere","level":"debug"}` + "\n",
 			"level",
 			newrelic.LogData{
-				Message:  `{"Scale":"833 cents","Interval":833.09,"time":1562212768,"message":"Fibonacci is everywhere","level":"debug"}`,
+				Message:  `{"Scale":"833 cents","Interval":833.09,"time":1562212768,"message":"Fibonacci is everywhere","level":"debug"}` + "\n",
 				Severity: "debug",
 			},
 		},
@@ -107,10 +131,10 @@ func TestParseLogData(t *testing.T) {
 		val := parseJSONLogData([]byte(test.log))
 
 		if val.Message != test.expect.Message {
-			parserTestError(t, "Message", val.Message, test.expect.Message)
+			parserTestError(t, "Message", val.Message, test.expect.Message, test.log)
 		}
 		if val.Severity != test.expect.Severity {
-			parserTestError(t, "Severity", val.Severity, test.expect.Severity)
+			parserTestError(t, "Severity", val.Severity, test.expect.Severity, test.log)
 		}
 
 		zerolog.LevelFieldName = "level"
@@ -139,6 +163,11 @@ func TestParseLogDataEscapes(t *testing.T) {
 			"info",
 			`{"level":"info","message":"escape quote,\",\" hi"}`,
 		},
+		{
+			"escape bracket,\"}\" hi",
+			"info",
+			`{"level":"info","message":"escape bracket,\"}\" hi"}`,
+		},
 	}
 
 	app := integrationsupport.NewTestApp(
@@ -164,8 +193,8 @@ func TestParseLogDataEscapes(t *testing.T) {
 
 }
 
-func parserTestError(t *testing.T, field, actual, expect string) {
-	t.Errorf("The parsed %s does not match the expected message: parsed \"%s\" expected \"%s\"", field, actual, expect)
+func parserTestError(t *testing.T, field, actual, expect, input string) {
+	t.Errorf("The parsed %s does not match the expected message: parsed \"%s\" expected \"%s\"\nFailed on input: %s", field, actual, expect, input)
 }
 
 func TestE2E(t *testing.T) {

--- a/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer_test.go
+++ b/v3/integrations/logcontext-v2/zerologWriter/zerolog-writer_test.go
@@ -55,6 +55,30 @@ func TestParseLogData(t *testing.T) {
 				Severity: "info",
 			},
 		},
+		{
+			`{"time":1516134303,"level":"debug","message":"hello, world"}`,
+			"level",
+			newrelic.LogData{
+				Message:  `{"time":1516134303,"level":"debug","message":"hello, world"}`,
+				Severity: "debug",
+			},
+		},
+		{
+			`{"level":"error","stack":[{"func":"inner","line":"20","source":"errors.go"},{"func":"middle","line":"24","source":"errors.go"},{"func":"outer","line":"32","source":"errors.go"},{"func":"main","line":"15","source":"errors.go"},{"func":"main","line":"204","source":"proc.go"},{"func":"goexit","line":"1374","source":"asm_amd64.s"}],"error":"seems we have an error here","time":1609086683}`,
+			"level",
+			newrelic.LogData{
+				Message:  `{"level":"error","stack":[{"func":"inner","line":"20","source":"errors.go"},{"func":"middle","line":"24","source":"errors.go"},{"func":"outer","line":"32","source":"errors.go"},{"func":"main","line":"15","source":"errors.go"},{"func":"main","line":"204","source":"proc.go"},{"func":"goexit","line":"1374","source":"asm_amd64.s"}],"error":"seems we have an error here","time":1609086683}`,
+				Severity: "error",
+			},
+		},
+		{
+			`{"level":"debug","Scale":"833 cents","Interval":833.09,"time":1562212768,"message":"Fibonacci is everywhere"}`,
+			"level",
+			newrelic.LogData{
+				Message:  `{"level":"debug","Scale":"833 cents","Interval":833.09,"time":1562212768,"message":"Fibonacci is everywhere"}`,
+				Severity: "debug",
+			},
+		},
 	}
 	for _, test := range tests {
 		if test.levelKey != "" {


### PR DESCRIPTION
In preparation for a more feature rich log data spec, this parser was built to be able to scan additional contextual vaule from a zerolog log message. This patch fixes a bug where it was unable to correctly parse the JSON value for strings with commas, numbers, or stack traces.