### PR TITLE
Add Module Dependency Metrics to the Go Agent

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -6,3 +6,11 @@ require (
 	github.com/golang/protobuf v1.5.2
 	google.golang.org/grpc v1.49.0
 )
+
+require (
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
+	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+)

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -6,11 +6,3 @@ require (
 	github.com/golang/protobuf v1.5.2
 	google.golang.org/grpc v1.49.0
 )
-
-require (
-	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
-	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
-	golang.org/x/text v0.3.3 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
-)

--- a/v3/newrelic/config.go
+++ b/v3/newrelic/config.go
@@ -642,10 +642,13 @@ func defaultConfig() Config {
 
 	// Code Level Metrics
 	c.CodeLevelMetrics.Enabled = false
+	c.CodeLevelMetrics.RedactPathPrefixes = true
+	c.CodeLevelMetrics.RedactIgnoredPrefixes = true
 	c.CodeLevelMetrics.Scope = AllCLM
 
 	// Module Dependency Metrics
 	c.ModuleDependencyMetrics.Enabled = true
+	c.ModuleDependencyMetrics.RedactIgnoredPrefixes = true
 	return c
 }
 

--- a/v3/newrelic/config.go
+++ b/v3/newrelic/config.go
@@ -645,7 +645,7 @@ func defaultConfig() Config {
 	c.CodeLevelMetrics.Scope = AllCLM
 
 	// Module Dependency Metrics
-	c.ModuleDependencyMetrics.Enabled = false
+	c.ModuleDependencyMetrics.Enabled = true
 	return c
 }
 

--- a/v3/newrelic/config.go
+++ b/v3/newrelic/config.go
@@ -360,6 +360,12 @@ type Config struct {
 		// as attributes. If this is disabled, no such metrics will be collected
 		// or reported.
 		Enabled bool
+		// RedactPathPrefixes, if true, will redact a non-nil list of PathPrefixes
+		// from the configuration data transmitted by the agent.
+		RedactPathPrefixes bool
+		// RedactIgnoredPrefixes, if true, will redact a non-nil list of IgnoredPrefixes
+		// from the configuration data transmitted by the agent.
+		RedactIgnoredPrefixes bool
 		// Scope is a combination of CodeLevelMetricsScope values OR-ed together
 		// to indicate which specific kinds of events will carry CodeLevelMetrics
 		// data. This allows the agent to spend resources on discovering the source
@@ -401,21 +407,34 @@ type Config struct {
 		// names look like they are internal to the agent itself.
 		IgnoredPrefixes []string
 	}
+
+	// ModuleDependencyMetrics controls reporting of the packages used to build the instrumented
+	// application, to help manage project dependencies.
+	ModuleDependencyMetrics struct {
+		// Enabled controls whether the module dependencies are collected and reported.
+		Enabled bool
+		// RedactIgnoredPrefixes, if true, redacts a non-nil list of IgnoredPrefixes from
+		// the configuration data transmitted by the agent.
+		RedactIgnoredPrefixes bool
+		// IgnoredPrefixes is a list of module path prefixes. Any module whose import pathname
+		// begins with one of these prefixes is excluded from the dependency reporting.
+		// This list of ignored prefixes itself is not reported outside the agent.
+		IgnoredPrefixes []string
+	}
 }
 
-//
 // CodeLevelMetricsScope is a bit-encoded value. Each such value describes
 // a trace type for which code-level metrics are to be collected and
 // reported.
-//
 type CodeLevelMetricsScope uint32
 
 // These constants specify the types of telemetry data to which we will
 // attach code level metric data.
 //
 // Currently, this includes
-//    TransactionCLM            any kind of transaction
-//    AllCLM                    all kinds of telemetry data for which CLM is implemented (the default)
+//
+//	TransactionCLM            any kind of transaction
+//	AllCLM                    all kinds of telemetry data for which CLM is implemented (the default)
 //
 // The zero value of CodeLevelMetricsScope means "all types" as a convenience so that
 // new variables of this type provide the default expected behavior
@@ -429,7 +448,6 @@ const (
 	AllCLM         CodeLevelMetricsScope = 0
 )
 
-//
 // CodeLevelMetricsScopeLabelToValue accepts a number of string values representing
 // the possible scope restrictions available for the agent, returning the
 // CodeLevelMetricsScope value which represents the combination of all of the given
@@ -441,9 +459,9 @@ const (
 // will represent any valid label strings passed, if any).
 //
 // Currently, this function recognizes the following labels:
-//   for AllCLM: "all" (if this value appears anywhere in the list of strings, AllCLM will be returned)
-//   for TransactionCLM: "transaction", "transactions", "txn"
 //
+//	for AllCLM: "all" (if this value appears anywhere in the list of strings, AllCLM will be returned)
+//	for TransactionCLM: "transaction", "transactions", "txn"
 func CodeLevelMetricsScopeLabelToValue(labels ...string) (CodeLevelMetricsScope, bool) {
 	var scope CodeLevelMetricsScope
 	ok := true
@@ -465,10 +483,8 @@ func CodeLevelMetricsScopeLabelToValue(labels ...string) (CodeLevelMetricsScope,
 	return scope, ok
 }
 
-//
 // UnmarshalText allows for a CodeLevelMetricsScope value to be read from a JSON
 // string (or other text encodings) whose value is a comma-separated list of scope labels.
-//
 func (s *CodeLevelMetricsScope) UnmarshalText(b []byte) error {
 	var ok bool
 
@@ -479,10 +495,8 @@ func (s *CodeLevelMetricsScope) UnmarshalText(b []byte) error {
 	return nil
 }
 
-//
 // MarshalText allows for a CodeLevelMetrics value to be encoded into JSON strings and other
 // text encodings.
-//
 func (s CodeLevelMetricsScope) MarshalText() ([]byte, error) {
 	if s == 0 || s == AllCLM {
 		return []byte("all"), nil
@@ -495,12 +509,10 @@ func (s CodeLevelMetricsScope) MarshalText() ([]byte, error) {
 	return nil, fmt.Errorf("unrecognized bit pattern in CodeLevelMetricsScope value")
 }
 
-//
 // CodeLevelMetricsScopeLabelListToValue is a convenience function which
 // is like CodeLevelMetricsScopeLabeltoValue except that it takes a single
 // string which contains comma-separated values instead of an already-broken-out
 // set of individual label strings.
-//
 func CodeLevelMetricsScopeLabelListToValue(labels string) (CodeLevelMetricsScope, bool) {
 	return CodeLevelMetricsScopeLabelToValue(strings.Split(labels, ",")...)
 }
@@ -631,6 +643,9 @@ func defaultConfig() Config {
 	// Code Level Metrics
 	c.CodeLevelMetrics.Enabled = false
 	c.CodeLevelMetrics.Scope = AllCLM
+
+	// Module Dependency Metrics
+	c.ModuleDependencyMetrics.Enabled = false
 	return c
 }
 
@@ -816,6 +831,28 @@ func (s settings) MarshalJSON() ([]byte, error) {
 		fields[`browser_monitoring.loader`] = "rum"
 	}
 
+	// Protect privacy for restricted fields
+	if clmConfig, ok := fields["CodeLevelMetrics"]; ok {
+		if clmMap, ok := clmConfig.(map[string]interface{}); ok {
+			if c.CodeLevelMetrics.RedactIgnoredPrefixes && c.CodeLevelMetrics.IgnoredPrefixes != nil {
+				delete(clmMap, "IgnoredPrefixes")
+				delete(clmMap, "IgnoredPrefix")
+			}
+			if c.CodeLevelMetrics.RedactPathPrefixes && c.CodeLevelMetrics.PathPrefixes != nil {
+				delete(clmMap, "PathPrefixes")
+				delete(clmMap, "PathPrefix")
+			}
+		}
+	}
+
+	if mdmConfig, ok := fields["ModuleDependencyMetrics"]; ok {
+		if mdmMap, ok := mdmConfig.(map[string]interface{}); ok {
+			if c.ModuleDependencyMetrics.RedactIgnoredPrefixes && c.ModuleDependencyMetrics.IgnoredPrefixes != nil {
+				delete(mdmMap, "IgnoredPrefixes")
+			}
+		}
+	}
+
 	return json.Marshal(fields)
 }
 
@@ -968,7 +1005,7 @@ func newInternalConfig(cfg Config, getenv func(string) string, environ []string)
 }
 
 func (c config) createConnectJSON(securityPolicies *internal.SecurityPolicies) ([]byte, error) {
-	env := newEnvironment()
+	env := newEnvironment(&c)
 	util := utilization.Gather(utilization.Config{
 		DetectAWS:         c.Utilization.DetectAWS,
 		DetectAzure:       c.Utilization.DetectAzure,

--- a/v3/newrelic/config.go
+++ b/v3/newrelic/config.go
@@ -812,12 +812,12 @@ func (s settings) MarshalJSON() ([]byte, error) {
 	c.Logger = nil
 
 	js, err := json.Marshal(c)
-	if nil != err {
+	if err != nil {
 		return nil, err
 	}
 	fields := make(map[string]interface{})
 	err = json.Unmarshal(js, &fields)
-	if nil != err {
+	if err != nil {
 		return nil, err
 	}
 	// The License field is not simply ignored by adding the `json:"-"` tag

--- a/v3/newrelic/config_options.go
+++ b/v3/newrelic/config_options.go
@@ -233,9 +233,9 @@ func ConfigInfoLogger(w io.Writer) ConfigOption {
 	return ConfigLogger(NewLogger(w))
 }
 
-// ConfigModuleDependencyMetricsEnable controls whether the agent collects and reports
+// ConfigModuleDependencyMetricsEnabled controls whether the agent collects and reports
 // the list of modules compiled into the instrumented application.
-func ConfigModuleDependencyMetricsEnable(enabled bool) ConfigOption {
+func ConfigModuleDependencyMetricsEnabled(enabled bool) ConfigOption {
 	return func(cfg *Config) {
 		cfg.ModuleDependencyMetrics.Enabled = enabled
 	}
@@ -245,7 +245,7 @@ func ConfigModuleDependencyMetricsEnable(enabled bool) ConfigOption {
 // indicating which modules should be excluded from the dependency report.
 func ConfigModuleDependencyMetricsIgnoredPrefixes(prefix ...string) ConfigOption {
 	return func(cfg *Config) {
-		cfg.ModuleDependencyMetrics.IgnoredPrefixes = prefixes
+		cfg.ModuleDependencyMetrics.IgnoredPrefixes = prefix
 	}
 }
 

--- a/v3/newrelic/config_options.go
+++ b/v3/newrelic/config_options.go
@@ -236,13 +236,17 @@ func ConfigInfoLogger(w io.Writer) ConfigOption {
 // ConfigModuleDependencyMetricsEnable controls whether the agent collects and reports
 // the list of modules compiled into the instrumented application.
 func ConfigModuleDependencyMetricsEnable(enabled bool) ConfigOption {
-	return func(cfg *Config) { cfg.ModuleDependencyMetrics.Enabled = enabled }
+	return func(cfg *Config) {
+		cfg.ModuleDependencyMetrics.Enabled = enabled
+	}
 }
 
 // ConfigModuleDependencyMetricsIgnoredPrefixes sets the list of module path prefix strings
 // indicating which modules should be excluded from the dependency report.
-func ConfigModuleDependencyMetricsIgnoredPrefixes(prefixes []string) ConfigOption {
-	return func(cfg *Config) { cfg.ModuleDependencyMetrics.IgnoredPrefixes = prefixes }
+func ConfigModuleDependencyMetricsIgnoredPrefixes(prefix ...string) ConfigOption {
+	return func(cfg *Config) {
+		cfg.ModuleDependencyMetrics.IgnoredPrefixes = prefixes
+	}
 }
 
 // ConfigModuleDependencyMetricsRedactIgnoredPrefixes controls whether the names

--- a/v3/newrelic/config_options.go
+++ b/v3/newrelic/config_options.go
@@ -85,6 +85,38 @@ func ConfigCodeLevelMetricsIgnoredPrefix(prefix ...string) ConfigOption {
 	}
 }
 
+// ConfigCodeLevelMetricsRedactIgnoredPrefixes controls whether the names
+// of ignored modules should be redacted from the agent configuration data
+// reported and visible in the New Relic UI. Since one of the reasons these
+// modules may be excluded is to preserve confidentiality of module or
+// directory names, the default behavior (if this option is set to true)
+// is to redact those names from the configuration data so that the only thing
+// reported is that some list of unnamed modules were excluded from reporting.
+// If this is set to false, then the names of the ignored modules will be
+// listed in the configuration data, although those modules will still be ignored
+// by Code Level Metrics.
+func ConfigCodeLevelMetricsRedactIgnoredPrefixes(enabled bool) ConfigOption {
+	return func(cfg *Config) {
+		cfg.CodeLevelMetrics.RedactIgnoredPrefixes = enabled
+	}
+}
+
+// ConfigCodeLevelMetricsRedactPathPrefixes controls whether the names
+// of source code parent directories should be redacted from the agent configuration data
+// reported and visible in the New Relic UI. Since one of the reasons these
+// path prefixes may be excluded is to preserve confidentiality of
+// directory names, the default behavior (if this option is set to true)
+// is to redact those names from the configuration data so that the only thing
+// reported is that some list of unnamed path prefixes were removed from reported pathnames.
+// If this is set to false, then the names of the removed path prefixes will be
+// listed in the configuration data, although those strings will still be removed from pathnames
+// reported by Code Level Metrics.
+func ConfigCodeLevelMetricsRedactPathPrefixes(enabled bool) ConfigOption {
+	return func(cfg *Config) {
+		cfg.CodeLevelMetrics.RedactPathPrefixes = enabled
+	}
+}
+
 // ConfigCodeLevelMetricsScope narrows the scope of where code level
 // metrics are to be used. By default, if CodeLevelMetrics are enabled,
 // they apply everywhere the agent currently supports them. To narrow
@@ -213,6 +245,22 @@ func ConfigModuleDependencyMetricsIgnoredPrefixes(prefixes []string) ConfigOptio
 	return func(cfg *Config) { cfg.ModuleDependencyMetrics.IgnoredPrefixes = prefixes }
 }
 
+// ConfigModuleDependencyMetricsRedactIgnoredPrefixes controls whether the names
+// of ignored module path prefixes should be redacted from the agent configuration data
+// reported and visible in the New Relic UI. Since one of the reasons these
+// modules may be excluded is to preserve confidentiality of module or
+// directory names, the default behavior (if this option is set to true)
+// is to redact those names from the configuration data so that the only thing
+// reported is that some list of unnamed modules were excluded from reporting.
+// If this is set to false, then the names of the ignored modules will be
+// listed in the configuration data, although those modules will still be ignored
+// by Module Dependency Metrics.
+func ConfigModuleDependencyMetricsRedactIgnoredPrefixes(enabled bool) ConfigOption {
+	return func(cfg *Config) {
+		cfg.ModuleDependencyMetrics.RedactIgnoredPrefixes = enabled
+	}
+}
+
 // ConfigDebugLogger populates the config with a Logger at debug level.
 func ConfigDebugLogger(w io.Writer) ConfigOption {
 	return ConfigLogger(NewDebugLogger(w))
@@ -225,10 +273,13 @@ func ConfigDebugLogger(w io.Writer) ConfigOption {
 //  NEW_RELIC_ATTRIBUTES_INCLUDE                         sets Attributes.Include using a comma-separated list
 //  NEW_RELIC_MODULE_DEPENDENCY_METRICS_ENABLED          sets ModuleDependencyMetrics.Enabled
 //  NEW_RELIC_MODULE_DEPENDENCY_METRICS_IGNORED_PREFIXES sets ModuleDependencyMetrics.IgnoredPrefixes
+//  NEW_RELIC_MODULE_DEPENDENCY_METRICS_REDACT_IGNORED_PREFIXES sets ModuleDependencyMetrics.RedactIgnoredPrefixes to a boolean value
 //  NEW_RELIC_CODE_LEVEL_METRICS_ENABLED                 sets CodeLevelMetrics.Enabled
 //  NEW_RELIC_CODE_LEVEL_METRICS_SCOPE                   sets CodeLevelMetrics.Scope using a comma-separated list, e.g. "transaction"
 //  NEW_RELIC_CODE_LEVEL_METRICS_PATH_PREFIX             sets CodeLevelMetrics.PathPrefixes using a comma-separated list
+//  NEW_RELIC_CODE_LEVEL_METRICS_REDACT_PATH_PREFIXES    sets CodeLevelMetrics.RedactPathPrefixes to a boolean value
 //  NEW_RELIC_CODE_LEVEL_METRICS_IGNORED_PREFIX          sets CodeLevelMetrics.IgnoredPrefixes using a comma-separated list
+//  NEW_RELIC_CODE_LEVEL_METRICS_REDACT_IGNORED_PREFIXES sets CodeLevelMetrics.RedactIgnoredPrefixes to a boolean value
 //  NEW_RELIC_DISTRIBUTED_TRACING_ENABLED                sets DistributedTracer.Enabled using strconv.ParseBool
 //  NEW_RELIC_ENABLED                                    sets Enabled using strconv.ParseBool
 //  NEW_RELIC_HIGH_SECURITY                              sets HighSecurity using strconv.ParseBool
@@ -285,7 +336,10 @@ func configFromEnvironment(getenv func(string) string) ConfigOption {
 		assignString(&cfg.AppName, "NEW_RELIC_APP_NAME")
 		assignString(&cfg.License, "NEW_RELIC_LICENSE_KEY")
 		assignBool(&cfg.ModuleDependencyMetrics.Enabled, "NEW_RELIC_MODULE_DEPENDENCY_METRICS_ENABLED")
+		assignBool(&cfg.ModuleDependencyMetrics.RedactIgnoredPrefixes, "NEW_RELIC_MODULE_DEPENDENCY_METRICS_REDACT_IGNORED_PREFIXES")
 		assignBool(&cfg.CodeLevelMetrics.Enabled, "NEW_RELIC_CODE_LEVEL_METRICS_ENABLED")
+		assignBool(&cfg.CodeLevelMetrics.RedactPathPrefixes, "NEW_RELIC_CODE_LEVEL_METRICS_REDACT_PATH_PREFIXES")
+		assignBool(&cfg.CodeLevelMetrics.RedactIgnoredPrefixes, "NEW_RELIC_CODE_LEVEL_METRICS_REDACT_IGNORED_PREFIXES")
 		assignBool(&cfg.DistributedTracer.Enabled, "NEW_RELIC_DISTRIBUTED_TRACING_ENABLED")
 		assignBool(&cfg.Enabled, "NEW_RELIC_ENABLED")
 		assignBool(&cfg.HighSecurity, "NEW_RELIC_HIGH_SECURITY")

--- a/v3/newrelic/config_test.go
+++ b/v3/newrelic/config_test.go
@@ -148,7 +148,7 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 				"Attributes":{"Enabled":false,"Exclude":["10"],"Include":["9"]},
 				"Enabled":true
 			},
-			"CodeLevelMetrics":{"Enabled":false,"IgnoredPrefix":"","IgnoredPrefixes":null,"PathPrefix":"","PathPrefixes":null,"RedactIgnoredPrefixes":false,"RedactPathPrefixes":false,"Scope":"all"},
+			"CodeLevelMetrics":{"Enabled":false,"IgnoredPrefix":"","IgnoredPrefixes":null,"PathPrefix":"","PathPrefixes":null,"RedactIgnoredPrefixes":true,"RedactPathPrefixes":true,"Scope":"all"},
 			"CrossApplicationTracer":{"Enabled":false},
 			"CustomInsightsEvents":{
 				"Enabled":true,
@@ -189,7 +189,7 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 			},
 			"Labels":{"zip":"zap"},
 			"Logger":"*logger.logFile",
-			"ModuleDependencyMetrics":{"Enabled":true,"IgnoredPrefixes":null,"RedactIgnoredPrefixes":false},
+			"ModuleDependencyMetrics":{"Enabled":true,"IgnoredPrefixes":null,"RedactIgnoredPrefixes":true},
 			"RuntimeSampler":{"Enabled":true},
 			"SecurityPoliciesToken":"",
 			"ServerlessMode":{
@@ -346,7 +346,7 @@ func TestCopyConfigReferenceFieldsAbsent(t *testing.T) {
 				},
 				"Enabled":true
 			},
-			"CodeLevelMetrics":{"Enabled":false,"IgnoredPrefix":"","IgnoredPrefixes":null,"PathPrefix":"","PathPrefixes":null,"RedactIgnoredPrefixes":false,"RedactPathPrefixes":false,"Scope":"all"},
+			"CodeLevelMetrics":{"Enabled":false,"IgnoredPrefix":"","IgnoredPrefixes":null,"PathPrefix":"","PathPrefixes":null,"RedactIgnoredPrefixes":true,"RedactPathPrefixes":true,"Scope":"all"},
 			"CrossApplicationTracer":{"Enabled":false},
 			"CustomInsightsEvents":{
 				"Enabled":true,
@@ -387,7 +387,7 @@ func TestCopyConfigReferenceFieldsAbsent(t *testing.T) {
 			},
 			"Labels":null,
 			"Logger":null,
-			"ModuleDependencyMetrics":{"Enabled":true,"IgnoredPrefixes":null,"RedactIgnoredPrefixes":false},
+			"ModuleDependencyMetrics":{"Enabled":true,"IgnoredPrefixes":null,"RedactIgnoredPrefixes":true},
 			"RuntimeSampler":{"Enabled":true},
 			"SecurityPoliciesToken":"",
 			"ServerlessMode":{

--- a/v3/newrelic/config_test.go
+++ b/v3/newrelic/config_test.go
@@ -189,7 +189,7 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 			},
 			"Labels":{"zip":"zap"},
 			"Logger":"*logger.logFile",
-			"ModuleDependencyMetrics":{"Enabled":false,"IgnoredPrefixes":null,"RedactIgnoredPrefixes":false},
+			"ModuleDependencyMetrics":{"Enabled":true,"IgnoredPrefixes":null,"RedactIgnoredPrefixes":false},
 			"RuntimeSampler":{"Enabled":true},
 			"SecurityPoliciesToken":"",
 			"ServerlessMode":{
@@ -387,7 +387,7 @@ func TestCopyConfigReferenceFieldsAbsent(t *testing.T) {
 			},
 			"Labels":null,
 			"Logger":null,
-			"ModuleDependencyMetrics":{"Enabled":false,"IgnoredPrefixes":null,"RedactIgnoredPrefixes":false},
+			"ModuleDependencyMetrics":{"Enabled":true,"IgnoredPrefixes":null,"RedactIgnoredPrefixes":false},
 			"RuntimeSampler":{"Enabled":true},
 			"SecurityPoliciesToken":"",
 			"ServerlessMode":{

--- a/v3/newrelic/config_test.go
+++ b/v3/newrelic/config_test.go
@@ -148,7 +148,7 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 				"Attributes":{"Enabled":false,"Exclude":["10"],"Include":["9"]},
 				"Enabled":true
 			},
-			"CodeLevelMetrics":{"Enabled":false,"IgnoredPrefix":"","IgnoredPrefixes":null,"PathPrefix":"","PathPrefixes":null,"Scope":"all"},
+			"CodeLevelMetrics":{"Enabled":false,"IgnoredPrefix":"","IgnoredPrefixes":null,"PathPrefix":"","PathPrefixes":null,"RedactIgnoredPrefixes":false,"RedactPathPrefixes":false,"Scope":"all"},
 			"CrossApplicationTracer":{"Enabled":false},
 			"CustomInsightsEvents":{
 				"Enabled":true,
@@ -189,6 +189,7 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 			},
 			"Labels":{"zip":"zap"},
 			"Logger":"*logger.logFile",
+			"ModuleDependencyMetrics":{"Enabled":false,"IgnoredPrefixes":null,"RedactIgnoredPrefixes":false},
 			"RuntimeSampler":{"Enabled":true},
 			"SecurityPoliciesToken":"",
 			"ServerlessMode":{
@@ -240,11 +241,12 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 		"high_security":false,
 		"labels":[{"label_type":"zip","label_value":"zap"}],
 		"environment":[
+			["runtime.NumCPU",8],
 			["runtime.Compiler","comp"],
 			["runtime.GOARCH","arch"],
 			["runtime.GOOS","goos"],
 			["runtime.Version","vers"],
-			["runtime.NumCPU",8]
+			["Modules", null]
 		],
 		"identifier":"my appname",
 		"utilization":{
@@ -300,6 +302,7 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 	}
 	out := standardizeNumbers(string(js))
 	if out != expect {
+		t.Error(expect)
 		t.Error(out)
 	}
 }
@@ -343,7 +346,7 @@ func TestCopyConfigReferenceFieldsAbsent(t *testing.T) {
 				},
 				"Enabled":true
 			},
-			"CodeLevelMetrics":{"Enabled":false,"IgnoredPrefix":"","IgnoredPrefixes":null,"PathPrefix":"","PathPrefixes":null,"Scope":"all"},
+			"CodeLevelMetrics":{"Enabled":false,"IgnoredPrefix":"","IgnoredPrefixes":null,"PathPrefix":"","PathPrefixes":null,"RedactIgnoredPrefixes":false,"RedactPathPrefixes":false,"Scope":"all"},
 			"CrossApplicationTracer":{"Enabled":false},
 			"CustomInsightsEvents":{
 				"Enabled":true,
@@ -384,6 +387,7 @@ func TestCopyConfigReferenceFieldsAbsent(t *testing.T) {
 			},
 			"Labels":null,
 			"Logger":null,
+			"ModuleDependencyMetrics":{"Enabled":false,"IgnoredPrefixes":null,"RedactIgnoredPrefixes":false},
 			"RuntimeSampler":{"Enabled":true},
 			"SecurityPoliciesToken":"",
 			"ServerlessMode":{
@@ -432,11 +436,12 @@ func TestCopyConfigReferenceFieldsAbsent(t *testing.T) {
 		"app_name":["my appname"],
 		"high_security":false,
 		"environment":[
+			["runtime.NumCPU",8],
 			["runtime.Compiler","comp"],
 			["runtime.GOARCH","arch"],
 			["runtime.GOOS","goos"],
 			["runtime.Version","vers"],
-			["runtime.NumCPU",8]
+			["Modules", null]
 		],
 		"identifier":"my appname",
 		"utilization":{

--- a/v3/newrelic/environment.go
+++ b/v3/newrelic/environment.go
@@ -45,6 +45,21 @@ func newEnvironment(c *config) environment {
 	}
 }
 
+// indended for testing purposes. This just returns the formatted
+// modules subject to the user's filtering rules.
+func injectDependencyModuleList(c *config, modules []*debug.Module) []string {
+	var modList []string
+
+	if c != nil && c.ModuleDependencyMetrics.Enabled {
+		for _, module := range modules {
+			if module != nil && includeModule(module.Path, c.ModuleDependencyMetrics.IgnoredPrefixes) {
+				modList = append(modList, fmt.Sprintf("%s(%s)", module.Path, module.Version))
+			}
+		}
+	}
+	return modList
+}
+
 func getDependencyModuleList(c *config) []string {
 	var modList []string
 

--- a/v3/newrelic/environment.go
+++ b/v3/newrelic/environment.go
@@ -5,6 +5,7 @@ package newrelic
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"runtime"
 	"runtime/debug"
@@ -13,12 +14,12 @@ import (
 
 // environment describes the application's environment.
 type environment struct {
-	NumCPU   int            `env:"runtime.NumCPU"`
-	Compiler string         `env:"runtime.Compiler"`
-	GOARCH   string         `env:"runtime.GOARCH"`
-	GOOS     string         `env:"runtime.GOOS"`
-	Version  string         `env:"runtime.Version"`
-	Modules  []debug.Module `env:"Modules"`
+	NumCPU   int      `env:"runtime.NumCPU"`
+	Compiler string   `env:"runtime.Compiler"`
+	GOARCH   string   `env:"runtime.GOARCH"`
+	GOOS     string   `env:"runtime.GOOS"`
+	Version  string   `env:"runtime.Version"`
+	Modules  []string `env:"Modules"`
 }
 
 var (
@@ -44,15 +45,15 @@ func newEnvironment(c *config) environment {
 	}
 }
 
-func getDependencyModuleList(c *config) []debug.Module {
-	var modList []debug.Module
+func getDependencyModuleList(c *config) []string {
+	var modList []string
 
 	if c != nil && c.ModuleDependencyMetrics.Enabled {
 		info, ok := debug.ReadBuildInfo()
 		if info != nil && ok {
 			for _, module := range info.Deps {
 				if module != nil && includeModule(module.Path, c.ModuleDependencyMetrics.IgnoredPrefixes) {
-					modList = append(modList, *module)
+					modList = append(modList, fmt.Sprintf("%s(%s)", module.Path, module.Version))
 				}
 			}
 		}

--- a/v3/newrelic/environment_test.go
+++ b/v3/newrelic/environment_test.go
@@ -17,18 +17,19 @@ func TestMarshalEnvironment(t *testing.T) {
 		t.Fatal(err)
 	}
 	expect := internal.CompactJSONString(`[
+		["runtime.NumCPU",8],
 		["runtime.Compiler","comp"],
 		["runtime.GOARCH","arch"],
 		["runtime.GOOS","goos"],
 		["runtime.Version","vers"],
-		["runtime.NumCPU",8]]`)
+		["Modules",null]]`)
 	if string(js) != expect {
 		t.Fatal(string(js))
 	}
 }
 
 func TestEnvironmentFields(t *testing.T) {
-	env := newEnvironment()
+	env := newEnvironment(nil)
 	if env.Compiler != runtime.Compiler {
 		t.Error(env.Compiler, runtime.Compiler)
 	}

--- a/v3/newrelic/environment_test.go
+++ b/v3/newrelic/environment_test.go
@@ -5,7 +5,9 @@ package newrelic
 
 import (
 	"encoding/json"
+	"regexp"
 	"runtime"
+	"runtime/debug"
 	"testing"
 
 	"github.com/newrelic/go-agent/v3/internal"
@@ -44,5 +46,110 @@ func TestEnvironmentFields(t *testing.T) {
 	}
 	if env.NumCPU != runtime.NumCPU() {
 		t.Error(env.NumCPU, runtime.NumCPU())
+	}
+	if env.Modules != nil {
+		t.Error(env.Modules, nil)
+	}
+}
+
+func TestModuleDependency(t *testing.T) {
+	cfg := config{Config: defaultConfig()}
+
+	// check that the default is to be enabled
+	if !cfg.ModuleDependencyMetrics.Enabled {
+		t.Error("MDM should be enabled, was", cfg.ModuleDependencyMetrics.Enabled)
+	}
+
+	// if disabled, we shouldn't get any data
+	cfg.ModuleDependencyMetrics.Enabled = false
+	env := newEnvironment(&cfg)
+	if env.Modules != nil && len(env.Modules) != 0 {
+		t.Error("MDM module list not empty:", env.Modules)
+	}
+
+	// enabled, and we should see our list of modules reported.
+	// first, get the list of modules we should expect to see.
+	// of course, we can't do that from a unit test, so we'll mock up a set
+	// of modules to at least check that the various options work.
+	expectedModules := make(map[string]*debug.Module)
+	mockedModuleList := []*debug.Module{
+		&debug.Module{Path: "example/path/to/module", Version: "v1.2.3"},
+		&debug.Module{Path: "github.com/another/module", Version: "v0.1.2"},
+		&debug.Module{Path: "some/development/module", Version: "(develop)"},
+	}
+	for _, module := range mockedModuleList {
+		expectedModules[module.Path] = module
+	}
+
+	cfg.ModuleDependencyMetrics.Enabled = true
+	env = newEnvironment(&cfg)
+	env.Modules = injectDependencyModuleList(&cfg, mockedModuleList)
+	checkModuleListsMatch(t, expectedModules, env.Modules, "full module list")
+
+	// try to elide some modules now
+	cfg.ModuleDependencyMetrics.IgnoredPrefixes = []string{"github.com"}
+	env = newEnvironment(&cfg)
+	env.Modules = injectDependencyModuleList(&cfg, mockedModuleList)
+	delete(expectedModules, "github.com/another/module")
+	checkModuleListsMatch(t, expectedModules, env.Modules, "reduced module list")
+
+	// more...
+	cfg.ModuleDependencyMetrics.IgnoredPrefixes = []string{"github.com", "exam"}
+	env = newEnvironment(&cfg)
+	env.Modules = injectDependencyModuleList(&cfg, mockedModuleList)
+	delete(expectedModules, "example/path/to/module")
+	checkModuleListsMatch(t, expectedModules, env.Modules, "reduced module list")
+}
+
+func checkModuleListsMatch(t *testing.T, expected map[string]*debug.Module, actual []string, message string) {
+	if expected == nil {
+		t.Error(message, "expected list is nil")
+	}
+	if len(expected) > 0 && actual == nil {
+		t.Error(message, "actual list is nil")
+	}
+	if len(expected) != len(actual) {
+		t.Error(message, "actual list has", len(actual), "module(s) but expected", len(expected))
+	}
+
+	modulePattern := regexp.MustCompile(`^(.+?)\((.+)\)$`)
+	checked := make(map[string]bool)
+	for path, _ := range expected {
+		checked[path] = false
+	}
+
+	for i, actualName := range actual {
+		matches := modulePattern.FindStringSubmatch(actualName)
+		if matches == nil || len(matches) != 3 {
+			t.Errorf("%s: actual module element #%d could not be parsed: \"%v\"", message, i, actualName)
+			continue
+		}
+
+		if module, present := expected[matches[1]]; present {
+			if matches[1] != module.Path {
+				t.Errorf("%s: actual module element #%d \"%v\" mismatch to path \"%v\" which really shouldn't be possible",
+					message, i, matches[1], module.Path)
+				continue
+			}
+			if matches[2] != module.Version {
+				t.Errorf("%s: actual module element #%d \"%v\" version \"%v\" mismatch to expected version \"%v\"",
+					message, i, matches[1], matches[2], module.Version)
+				continue
+			}
+			if checked[matches[1]] {
+				t.Errorf("%s: actual module element #%d \"%v\" was already seen earlier in the module list",
+					message, i, matches[1])
+				continue
+			}
+			checked[matches[1]] = true
+		} else {
+			t.Errorf("%s: actual module element #%d \"%v\" unexpected", message, i, matches[1])
+		}
+	}
+
+	for expectedName, wasChecked := range checked {
+		if !wasChecked {
+			t.Errorf("%s: did not see expected module \"%v\"", message, expectedName)
+		}
 	}
 }


### PR DESCRIPTION
This implements module dependency metrics in the Go Agent. This feature reports the application's dependencies when connecting to the New Relic service, allowing the customer to better manage dependencies and be aware of security vulnerabilities in libraries they use.

This version only collects the name and version number for each imported package.

Also introduces the ability to redact what modules were explicitly excluded by the user, and adds that capability to the Code Level Metrics capability as well.