### PR TITLE
Implement length limits for CLM attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased (working notes)
+
+### Changed
+
+* Changed the following `TraceOption` function to be consistent with their usage and other related identifier names. The old names remain for backward compatibility, but new code should use the new names. 
+   * `WithIgnoredPrefix` -> `WithIgnoredPrefixes`
+   * `WithPathPrefix` -> `WithPathPrefixes`
+* Implemented better handling of Code Level Metrics reporting when the data (e.g., function names) are excessively long, so that those attributes are suppressed rather than being reported with truncated names. Specifically:
+   * Attributes with values longer than 255 characters are dropped.
+   * No CLM attributes at all will be attached to a trace if the `code.function` attribute is empty or is longer than 255 characters.
+   * No CLM attributes at all will be attached to a trace if both `code.namespace` and `code.filepath` are longer than 255 characters.
+
 ## 3.20.0
 
 **PLEASE READ** these changes, and verify your config settings to ensure your application behaves how you intend it to. This release changes some default behaviors in the go agent.

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -6,3 +6,11 @@ require (
 	github.com/golang/protobuf v1.5.2
 	google.golang.org/grpc v1.49.0
 )
+
+require (
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
+	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+)

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -6,11 +6,3 @@ require (
 	github.com/golang/protobuf v1.5.2
 	google.golang.org/grpc v1.49.0
 )
-
-require (
-	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
-	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
-	golang.org/x/text v0.3.3 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
-)

--- a/v3/newrelic/code_level_metrics.go
+++ b/v3/newrelic/code_level_metrics.go
@@ -612,8 +612,18 @@ func reportCodeLevelMetrics(tOpts traceOptSet, run *appRun, setAttr func(string,
 		function = location.Function[ns+1:]
 	}
 
-	setAttr(AttributeCodeLineno, "", location.LineNo)
-	setAttr(AttributeCodeNamespace, namespace, nil)
-	setAttr(AttributeCodeFilepath, location.FilePath, nil)
-	setAttr(AttributeCodeFunction, function, nil)
+	// Impose data value size limits.
+	// Report no field over 255 characters in length.
+	// Report no CLM data at all if the function name is empty or >255 chars.
+	// Report no CLM data at all if both namespace and file path are >255 chars.
+	if function != "" && len(function) <= 255 && (len(namespace) <= 255 || len(location.FilePath) <= 255) {
+		setAttr(AttributeCodeLineno, "", location.LineNo)
+		setAttr(AttributeCodeFunction, function, nil)
+		if len(namespace) <= 255 {
+			setAttr(AttributeCodeNamespace, namespace, nil)
+		}
+		if len(location.FilePath) <= 255 {
+			setAttr(AttributeCodeFilepath, location.FilePath, nil)
+		}
+	}
 }


### PR DESCRIPTION
Updates to comply with new CLM agent specs relating to long fields.
No CLM field will be sent if it exceeds 255 characters.
All CLM fields will be suppressed if there isn't the minimum combination of useful fields that would fit in the 255 character limit.
This prevents truncated names from getting reported since they would be useless to code analysis.