### PR TITLE
Notice Expected Errors

### DIFF
--- a/v3/examples/server/main.go
+++ b/v3/examples/server/main.go
@@ -31,6 +31,13 @@ func noticeError(w http.ResponseWriter, r *http.Request) {
 	txn.NoticeError(errors.New("my error message"))
 }
 
+func noticeExpectedError(w http.ResponseWriter, r *http.Request) {
+	io.WriteString(w, "noticing an error")
+
+	txn := newrelic.FromContext(r.Context())
+	txn.NoticeExpectedError(errors.New("my expected error message"))
+}
+
 func noticeErrorWithAttributes(w http.ResponseWriter, r *http.Request) {
 	io.WriteString(w, "noticing an error")
 
@@ -273,6 +280,7 @@ func main() {
 	http.HandleFunc(newrelic.WrapHandleFunc(app, "/", index))
 	http.HandleFunc(newrelic.WrapHandleFunc(app, "/version", versionHandler))
 	http.HandleFunc(newrelic.WrapHandleFunc(app, "/notice_error", noticeError))
+	http.HandleFunc(newrelic.WrapHandleFunc(app, "/notice_expected_error", noticeExpectedError))
 	http.HandleFunc(newrelic.WrapHandleFunc(app, "/notice_error_with_attributes", noticeErrorWithAttributes))
 	http.HandleFunc(newrelic.WrapHandleFunc(app, "/custom_event", customEvent))
 	http.HandleFunc(newrelic.WrapHandleFunc(app, "/set_name", setName))

--- a/v3/newrelic/errors_from_internal.go
+++ b/v3/newrelic/errors_from_internal.go
@@ -61,6 +61,7 @@ type errorData struct {
 	Msg             string
 	Klass           string
 	SpanID          string
+	Expect          bool
 }
 
 // txnError combines error data with information about a transaction.  txnError is used for
@@ -113,7 +114,7 @@ func (h *tracedError) WriteJSON(buf *bytes.Buffer) {
 	buf.WriteByte(',')
 	buf.WriteString(`"intrinsics"`)
 	buf.WriteByte(':')
-	intrinsicsJSON(&h.txnEvent, buf)
+	intrinsicsJSON(&h.txnEvent, buf, h.errorData.Expect)
 	if nil != h.Stack {
 		buf.WriteByte(',')
 		buf.WriteString(`"stack_trace"`)
@@ -152,7 +153,7 @@ func mergeTxnErrors(errors *harvestErrors, errs txnErrors, txnEvent txnEvent) {
 }
 
 func (errors harvestErrors) Data(agentRunID string, harvestStart time.Time) ([]byte, error) {
-	if 0 == len(errors) {
+	if len(errors) == 0 {
 		return nil, nil
 	}
 	estimate := 1024 * len(errors)

--- a/v3/newrelic/harvest.go
+++ b/v3/newrelic/harvest.go
@@ -327,10 +327,14 @@ func createTxnMetrics(args *txnData, metrics *metricTable) {
 	}
 
 	// Error Metrics
-	if args.HasErrors() {
+	if args.NoticeErrors() {
 		metrics.addSingleCount(errorsRollupMetric.all, forced)
 		metrics.addSingleCount(errorsRollupMetric.webOrOther(args.IsWeb), forced)
 		metrics.addSingleCount(errorsPrefix+args.FinalName, forced)
+	}
+
+	if args.HasExpectedErrors() {
+		metrics.addSingleCount(expectedErrorsRollupMetric.all, forced)
 	}
 
 	// Queueing Metrics

--- a/v3/newrelic/harvest_test.go
+++ b/v3/newrelic/harvest_test.go
@@ -771,6 +771,7 @@ func TestCreateTxnMetrics(t *testing.T) {
 	webName := "WebTransaction/zip/zap"
 	backgroundName := "OtherTransaction/zip/zap"
 	args := &txnData{}
+	args.noticeErrors = true
 	args.Duration = 123 * time.Second
 	args.TotalTime = 150 * time.Second
 	args.ApdexThreshold = 2 * time.Second
@@ -803,6 +804,7 @@ func TestCreateTxnMetrics(t *testing.T) {
 	args.FinalName = webName
 	args.IsWeb = true
 	args.Errors = nil
+	args.noticeErrors = false
 	args.Zone = apdexTolerating
 	metrics = newMetricTable(100, time.Now())
 	createTxnMetrics(args, metrics)
@@ -821,6 +823,7 @@ func TestCreateTxnMetrics(t *testing.T) {
 	args.FinalName = backgroundName
 	args.IsWeb = false
 	args.Errors = txnErrors
+	args.noticeErrors = true
 	args.Zone = apdexNone
 	metrics = newMetricTable(100, time.Now())
 	createTxnMetrics(args, metrics)
@@ -838,9 +841,32 @@ func TestCreateTxnMetrics(t *testing.T) {
 		{Name: "ErrorsByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: []float64{1, 0, 0, 0, 0, 0}},
 	})
 
+	// Verify expected errors metrics
+	args.FinalName = backgroundName
+	args.IsWeb = false
+	args.Errors = txnErrors
+	args.noticeErrors = false
+	args.expectedErrors = true
+	args.Zone = apdexNone
+	metrics = newMetricTable(100, time.Now())
+	createTxnMetrics(args, metrics)
+	expectMetrics(t, metrics, []internal.WantMetric{
+		{Name: backgroundName, Scope: "", Forced: true, Data: []float64{1, 123, 0, 123, 123, 123 * 123}},
+		{Name: backgroundRollup, Scope: "", Forced: true, Data: []float64{1, 123, 0, 123, 123, 123 * 123}},
+		{Name: "OtherTransactionTotalTime", Scope: "", Forced: true, Data: []float64{1, 150, 150, 150, 150, 150 * 150}},
+		{Name: "OtherTransactionTotalTime/zip/zap", Scope: "", Forced: false, Data: []float64{1, 150, 150, 150, 150, 150 * 150}},
+		{Name: "ErrorsExpected/all", Scope: "", Forced: true, Data: []float64{1, 0, 0, 0, 0, 0}},
+		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: []float64{1, 123, 123, 123, 123, 123 * 123}},
+		{Name: "ErrorsByCaller/Unknown/Unknown/Unknown/Unknown/all", Scope: "", Forced: false, Data: []float64{1, 0, 0, 0, 0, 0}},
+		{Name: "ErrorsByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Scope: "", Forced: false, Data: []float64{1, 0, 0, 0, 0, 0}},
+	})
+
 	args.FinalName = backgroundName
 	args.IsWeb = false
 	args.Errors = nil
+	args.noticeErrors = false
+	args.expectedErrors = false
 	args.Zone = apdexNone
 	metrics = newMetricTable(100, time.Now())
 	createTxnMetrics(args, metrics)
@@ -889,6 +915,7 @@ func TestCreateTxnMetricsOldCAT(t *testing.T) {
 	args.FinalName = webName
 	args.IsWeb = true
 	args.Errors = txnErrors
+	args.noticeErrors = true
 	args.Zone = apdexTolerating
 	metrics := newMetricTable(100, time.Now())
 	createTxnMetrics(args, metrics)
@@ -908,6 +935,7 @@ func TestCreateTxnMetricsOldCAT(t *testing.T) {
 	args.FinalName = webName
 	args.IsWeb = true
 	args.Errors = nil
+	args.noticeErrors = false
 	args.Zone = apdexTolerating
 	metrics = newMetricTable(100, time.Now())
 	createTxnMetrics(args, metrics)
@@ -924,6 +952,7 @@ func TestCreateTxnMetricsOldCAT(t *testing.T) {
 	args.FinalName = backgroundName
 	args.IsWeb = false
 	args.Errors = txnErrors
+	args.noticeErrors = true
 	args.Zone = apdexNone
 	metrics = newMetricTable(100, time.Now())
 	createTxnMetrics(args, metrics)
@@ -940,6 +969,7 @@ func TestCreateTxnMetricsOldCAT(t *testing.T) {
 	args.FinalName = backgroundName
 	args.IsWeb = false
 	args.Errors = nil
+	args.noticeErrors = false
 	args.Zone = apdexNone
 	metrics = newMetricTable(100, time.Now())
 	createTxnMetrics(args, metrics)

--- a/v3/newrelic/internal_errors_stacktrace_test.go
+++ b/v3/newrelic/internal_errors_stacktrace_test.go
@@ -64,7 +64,7 @@ func TestStackTrace(t *testing.T) {
 	}
 
 	for idx, tc := range testcases {
-		data, err := errDataFromError(tc.Error)
+		data, err := errDataFromError(tc.Error, false)
 		if err != nil {
 			t.Errorf("testcase %d: got error: %v", idx, err)
 			continue

--- a/v3/newrelic/internal_errors_test.go
+++ b/v3/newrelic/internal_errors_test.go
@@ -636,7 +636,7 @@ func TestErrorClass(t *testing.T) {
 	}
 
 	for idx, tc := range testcases {
-		data, err := errDataFromError(tc.Error)
+		data, err := errDataFromError(tc.Error, false)
 		if err != nil {
 			t.Errorf("testcase %d: got error: %v", idx, err)
 			continue

--- a/v3/newrelic/intrinsics.go
+++ b/v3/newrelic/intrinsics.go
@@ -7,13 +7,17 @@ import (
 	"bytes"
 )
 
+const (
+	expectErrorAttr = "error.expected"
+)
+
 func addOptionalStringField(w *jsonFieldsWriter, key, value string) {
 	if value != "" {
 		w.stringField(key, value)
 	}
 }
 
-func intrinsicsJSON(e *txnEvent, buf *bytes.Buffer) {
+func intrinsicsJSON(e *txnEvent, buf *bytes.Buffer, expect bool) {
 	w := jsonFieldsWriter{buf: buf}
 
 	buf.WriteByte('{')
@@ -25,6 +29,10 @@ func intrinsicsJSON(e *txnEvent, buf *bytes.Buffer) {
 		w.stringField("traceId", e.BetterCAT.TraceID)
 		w.writerField("priority", e.BetterCAT.Priority)
 		w.boolField("sampled", e.BetterCAT.Sampled)
+	}
+
+	if expect {
+		w.stringField(expectErrorAttr, "true")
 	}
 
 	if e.CrossProcess.Used() {

--- a/v3/newrelic/metric_names.go
+++ b/v3/newrelic/metric_names.go
@@ -187,8 +187,8 @@ func (r rollupMetric) webOrOther(isWeb bool) string {
 }
 
 var (
-	errorsRollupMetric = newRollupMetric("Errors/")
-
+	errorsRollupMetric         = newRollupMetric("Errors/")
+	expectedErrorsRollupMetric = newRollupMetric("ErrorsExpected/")
 	// source.datanerd.us/agents/agent-specs/blob/master/APIs/external_segment.md
 	// source.datanerd.us/agents/agent-specs/blob/master/APIs/external_cat.md
 	// source.datanerd.us/agents/agent-specs/blob/master/Cross-Application-Tracing-PORTED.md

--- a/v3/newrelic/txn_trace.go
+++ b/v3/newrelic/txn_trace.go
@@ -281,7 +281,7 @@ func (trace *harvestTrace) writeJSON(buf *bytes.Buffer) {
 	userAttributesJSON(trace.Attrs, buf, destTxnTrace, nil)
 	buf.WriteByte(',')
 	buf.WriteString(`"intrinsics":`)
-	intrinsicsJSON(&trace.txnEvent, buf)
+	intrinsicsJSON(&trace.txnEvent, buf, false)
 	buf.WriteByte('}')
 
 	// If the trace string pool is used, end another array here.


### PR DESCRIPTION
A new API has been added that will allow users to notice errors without triggering their error alerts or metrics: NoticeExpectedError() 

Fixes #161 