### PR TITLE
Update and Fixed Arbitrary File Write via Archive Extraction (Zip Slip)

### DIFF
--- a/v3/integrations/nrstan/test/go.mod
+++ b/v3/integrations/nrstan/test/go.mod
@@ -6,9 +6,9 @@ module github.com/newrelic/go-agent/v3/integrations/nrstan/test
 go 1.13
 
 require (
-	github.com/nats-io/nats-streaming-server v0.24.1
-	github.com/nats-io/stan.go v0.10.2
-	github.com/newrelic/go-agent/v3 v3.4.0
+	github.com/nats-io/nats-streaming-server v0.24.3
+	github.com/nats-io/stan.go v0.10.3
+	github.com/newrelic/go-agent/v3 v3.18.2
 	github.com/newrelic/go-agent/v3/integrations/nrstan v0.0.0
 )
 


### PR DESCRIPTION
### 👾 Describe The Sumarry:
Affected of this `newrelic/go-agent` are vulnerable to Arbitrary File Write via Archive Extraction (Zip Slip) in the stream restore. This due to inadequate checks on the filenames within the archive file which can lead to a path traversal. It is exploited using a specially crafted zip archive, that holds path traversal filenames. When exploited, a filename in a malicious archive is concatenated to the target extraction directory, which results in the final path ending up outside of the target folder. For instance, a zip may hold a file with a "../../file.exe" location and thus break out of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.

The following is an vulnerable of a zip archive with one benign file and one malicious file. Extracting the malicous file will result in traversing out of the target folder, ending up in /root/.ssh/ overwriting the authorized_keys file:
```
+2022-10-12 22:04:29 ..... 19 19 good.txt
```
```
+2022-10-12 22:04:42 ..... 20 20 ../../../../../../root/.ssh/authorized_keys
```
```js
	mdir := path.Join(fcfg.StoreDir, msgDir)
	odir := path.Join(fcfg.StoreDir, consumerDir)
	mdir := path.Join(fs.fcfg.StoreDir, msgDir)
	mb.mfn = path.Join(mdir, fi.Name())
	mb.ifn = path.Join(mdir, fmt.Sprintf(indexScan, index))
	mb.sfn = path.Join(mdir, fmt.Sprintf(fssScan, index))
		ekey, err := ioutil.ReadFile(path.Join(mdir, fmt.Sprintf(keyScan, mb.index)))
	         if fms, err := filepath.Glob(path.Join(mdir, fssScanAll)); err == nil && len(fms) > 0 {

```



**Remendation Workarounds**
 * Disable JetStream for untrusted users.
 * If only one NATS account uses JetStream, such that cross-user attacks are not an issue, and any user in that account with access to the JetStream API is fully trusted anyway, then appropriate sandboxing techniques will prevent exploit.
   * Eg, with systemd, the supplied util/nats-server-hardened.service example configuration demonstrates that NATS runs fine as an unprivileged user under ProtectSystem=strict and PrivateTmp=true restrictions; by only opening a ReadWritePaths hole for the JetStream storage area, the impact of this vulnerability is limited.


### 🥷 According CVeScores:
CVE-2022-26652
[CWE-22](https://cwe.mitre.org/data/definitions/22.html)