### PR TITLE
Fix memory leak while compression

### DIFF
--- a/internal/collector.go
+++ b/internal/collector.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/newrelic/go-agent/internal/logger"
@@ -50,10 +51,11 @@ type RpmCmd struct {
 // RpmControls contains fields which will be the same for all calls made
 // by the same application.
 type RpmControls struct {
-	License      string
-	Client       *http.Client
-	Logger       logger.Logger
-	AgentVersion string
+	License        string
+	Client         *http.Client
+	Logger         logger.Logger
+	AgentVersion   string
+	GzipWriterPool *sync.Pool
 }
 
 // RPMResponse contains a NR endpoint response.
@@ -131,7 +133,7 @@ func rpmURL(cmd RpmCmd, cs RpmControls) string {
 }
 
 func collectorRequestInternal(url string, cmd RpmCmd, cs RpmControls) RPMResponse {
-	compressed, err := compress(cmd.Data)
+	compressed, err := compress(cmd.Data, cs.GzipWriterPool)
 	if nil != err {
 		return RPMResponse{Err: err}
 	}

--- a/internal/collector_test.go
+++ b/internal/collector_test.go
@@ -4,13 +4,16 @@
 package internal
 
 import (
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/newrelic/go-agent/internal/crossagent"
@@ -157,6 +160,11 @@ func TestUrl(t *testing.T) {
 		Client:       nil,
 		Logger:       nil,
 		AgentVersion: "1",
+		GzipWriterPool: &sync.Pool{
+			New: func() any {
+				return gzip.NewWriter(io.Discard)
+			},
+		},
 	}
 
 	out := rpmURL(cmd, cs)
@@ -515,6 +523,11 @@ func TestConnectReplyMaxPayloadSize(t *testing.T) {
 				}),
 			},
 			Logger: logger.ShimLogger{IsDebugEnabled: true},
+			GzipWriterPool: &sync.Pool{
+				New: func() any {
+					return gzip.NewWriter(io.Discard)
+				},
+			},
 		}
 	}
 

--- a/internal/collector_test.go
+++ b/internal/collector_test.go
@@ -114,6 +114,11 @@ func TestCollectorRequest(t *testing.T) {
 		},
 		Logger:       logger.ShimLogger{IsDebugEnabled: true},
 		AgentVersion: "agent_version",
+		GzipWriterPool: &sync.Pool{
+			New: func() interface{} {
+				return gzip.NewWriter(io.Discard)
+			},
+		},
 	}
 	resp := CollectorRequest(cmd, cs)
 	if nil != resp.Err {
@@ -141,6 +146,11 @@ func TestCollectorBadRequest(t *testing.T) {
 		},
 		Logger:       logger.ShimLogger{IsDebugEnabled: true},
 		AgentVersion: "agent_version",
+		GzipWriterPool: &sync.Pool{
+			New: func() interface{} {
+				return gzip.NewWriter(io.Discard)
+			},
+		},
 	}
 	u := ":" // bad url
 	resp := collectorRequestInternal(u, cmd, cs)
@@ -244,6 +254,11 @@ func testConnectHelper(cm connectMock) (*ConnectReply, RPMResponse) {
 		Client:       &http.Client{Transport: cm},
 		Logger:       logger.ShimLogger{IsDebugEnabled: true},
 		AgentVersion: "1",
+		GzipWriterPool: &sync.Pool{
+			New: func() interface{} {
+				return gzip.NewWriter(io.Discard)
+			},
+		},
 	}
 
 	return ConnectAttempt(config, "", false, cs)
@@ -487,6 +502,11 @@ func TestCollectorRequestRespectsMaxPayloadSize(t *testing.T) {
 			}),
 		},
 		Logger: logger.ShimLogger{IsDebugEnabled: true},
+		GzipWriterPool: &sync.Pool{
+			New: func() interface{} {
+				return gzip.NewWriter(io.Discard)
+			},
+		},
 	}
 	resp := CollectorRequest(cmd, cs)
 	if nil == resp.Err {

--- a/internal/collector_test.go
+++ b/internal/collector_test.go
@@ -161,7 +161,7 @@ func TestUrl(t *testing.T) {
 		Logger:       nil,
 		AgentVersion: "1",
 		GzipWriterPool: &sync.Pool{
-			New: func() any {
+			New: func() interface{} {
 				return gzip.NewWriter(io.Discard)
 			},
 		},
@@ -524,7 +524,7 @@ func TestConnectReplyMaxPayloadSize(t *testing.T) {
 			},
 			Logger: logger.ShimLogger{IsDebugEnabled: true},
 			GzipWriterPool: &sync.Pool{
-				New: func() any {
+				New: func() interface{} {
 					return gzip.NewWriter(io.Discard)
 				},
 			},

--- a/internal/compress.go
+++ b/internal/compress.go
@@ -6,11 +6,15 @@ package internal
 import (
 	"bytes"
 	"compress/gzip"
+	"sync"
 )
 
-func compress(b []byte) (*bytes.Buffer, error) {
+func compress(b []byte, gzipWriterPool *sync.Pool) (*bytes.Buffer, error) {
+	w := gzipWriterPool.Get().(*gzip.Writer)
+	defer gzipWriterPool.Put(w)
+
 	var buf bytes.Buffer
-	w := gzip.NewWriter(&buf)
+	w.Reset(&buf)
 	_, err := w.Write(b)
 	w.Close()
 

--- a/v3/newrelic/collector.go
+++ b/v3/newrelic/collector.go
@@ -55,6 +55,7 @@ type rpmControls struct {
 	License string
 	Client  *http.Client
 	Logger  logger.Logger
+	Writer  *gzip.Writer
 }
 
 // rpmResponse contains a NR endpoint response.
@@ -136,11 +137,10 @@ func rpmURL(cmd rpmCmd, cs rpmControls) string {
 	return u.String()
 }
 
-func compress(b []byte) (*bytes.Buffer, error) {
+func compress(b []byte, w *gzip.Writer) (*bytes.Buffer, error) {
 	var buf bytes.Buffer
-	w := gzip.NewWriter(&buf)
+	w.Reset(&buf)
 	_, err := w.Write(b)
-	w.Close()
 
 	if nil != err {
 		return nil, err
@@ -150,7 +150,7 @@ func compress(b []byte) (*bytes.Buffer, error) {
 }
 
 func collectorRequestInternal(url string, cmd rpmCmd, cs rpmControls) rpmResponse {
-	compressed, err := compress(cmd.Data)
+	compressed, err := compress(cmd.Data, cs.Writer)
 	if nil != err {
 		return rpmResponse{Err: err}
 	}

--- a/v3/newrelic/collector_test.go
+++ b/v3/newrelic/collector_test.go
@@ -4,13 +4,16 @@
 package newrelic
 
 import (
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -105,6 +108,11 @@ func TestCollectorRequest(t *testing.T) {
 			}),
 		},
 		Logger: logger.ShimLogger{IsDebugEnabled: true},
+		GzipWriterPool: &sync.Pool{
+			New: func() interface{} {
+				return gzip.NewWriter(io.Discard)
+			},
+		},
 	}
 	resp := collectorRequest(cmd, cs)
 	if nil != resp.Err {
@@ -131,6 +139,11 @@ func TestCollectorBadRequest(t *testing.T) {
 			}),
 		},
 		Logger: logger.ShimLogger{IsDebugEnabled: true},
+		GzipWriterPool: &sync.Pool{
+			New: func() interface{} {
+				return gzip.NewWriter(io.Discard)
+			},
+		},
 	}
 	u := ":" // bad url
 	resp := collectorRequestInternal(u, cmd, cs)
@@ -154,6 +167,11 @@ func TestCollectorTimeout(t *testing.T) {
 			Timeout: time.Nanosecond, // force a timeout
 		},
 		Logger: logger.ShimLogger{IsDebugEnabled: true},
+		GzipWriterPool: &sync.Pool{
+			New: func() interface{} {
+				return gzip.NewWriter(io.Discard)
+			},
+		},
 	}
 	u := "https://example.com"
 	resp := collectorRequestInternal(u, cmd, cs)
@@ -174,6 +192,11 @@ func TestUrl(t *testing.T) {
 		License: "123abc",
 		Client:  nil,
 		Logger:  nil,
+		GzipWriterPool: &sync.Pool{
+			New: func() interface{} {
+				return gzip.NewWriter(io.Discard)
+			},
+		},
 	}
 
 	out := rpmURL(cmd, cs)
@@ -235,6 +258,11 @@ func testConnectHelper(cm connectMock) (*internal.ConnectReply, rpmResponse) {
 		License: "12345",
 		Client:  &http.Client{Transport: cm},
 		Logger:  logger.ShimLogger{IsDebugEnabled: true},
+		GzipWriterPool: &sync.Pool{
+			New: func() interface{} {
+				return gzip.NewWriter(io.Discard)
+			},
+		},
 	}
 
 	return connectAttempt(cm.config, cs)
@@ -403,6 +431,11 @@ func TestCollectorRequestRespectsMaxPayloadSize(t *testing.T) {
 			}),
 		},
 		Logger: logger.ShimLogger{IsDebugEnabled: true},
+		GzipWriterPool: &sync.Pool{
+			New: func() interface{} {
+				return gzip.NewWriter(io.Discard)
+			},
+		},
 	}
 	resp := collectorRequest(cmd, cs)
 	if nil == resp.Err {
@@ -439,6 +472,11 @@ func TestConnectReplyMaxPayloadSize(t *testing.T) {
 				}),
 			},
 			Logger: logger.ShimLogger{IsDebugEnabled: true},
+			GzipWriterPool: &sync.Pool{
+				New: func() interface{} {
+					return gzip.NewWriter(io.Discard)
+				},
+			},
 		}
 	}
 

--- a/v3/newrelic/internal_app.go
+++ b/v3/newrelic/internal_app.go
@@ -435,7 +435,7 @@ func newApp(c config) *app {
 			},
 			Logger: c.Logger,
 			GzipWriterPool: &sync.Pool{
-				New: func() any {
+				New: func() interface{} {
 					return gzip.NewWriter(io.Discard)
 				},
 			},

--- a/v3/newrelic/internal_app.go
+++ b/v3/newrelic/internal_app.go
@@ -434,7 +434,11 @@ func newApp(c config) *app {
 				Timeout:   collectorTimeout,
 			},
 			Logger: c.Logger,
-			Writer: gzip.NewWriter(nil),
+			GzipWriterPool: &sync.Pool{
+				New: func() any {
+					return gzip.NewWriter(io.Discard)
+				},
+			},
 		},
 	}
 

--- a/v3/newrelic/internal_app.go
+++ b/v3/newrelic/internal_app.go
@@ -4,6 +4,7 @@
 package newrelic
 
 import (
+	"compress/gzip"
 	"errors"
 	"fmt"
 	"io"
@@ -433,6 +434,7 @@ func newApp(c config) *app {
 				Timeout:   collectorTimeout,
 			},
 			Logger: c.Logger,
+			Writer: gzip.NewWriter(nil),
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links
We have been observing the memory increase in our Go applications for a long time. When We look at the cumulative increase of the memories used by the application with the memory dump method, We observed that the New Relic agent uses a lot of memory while doing gzip compression.

As a result, too much GC is running. You can visualize it by closing GOGC=off and defining GOMEMLIMIT this will avoid unnecessary GC, and will trigger the GC only if it's closed to the GOMEMLIMIT.

Issue: https://github.com/newrelic/go-agent/issues/619

## Details
Instead of creating a new gzip writer for every collect request, use common ones by using gzip writer sync pool.
