### PR TITLE
Fixed AWS S3 Crypto SDK sends an unencrypted hash of the plaintext alongside the ciphertext as a metadata field

### DIFF
--- a/v3/integrations/nrawssdk-v1/go.mod
+++ b/v3/integrations/nrawssdk-v1/go.mod
@@ -7,6 +7,6 @@ go 1.7
 
 require (
 	// v1.15.0 is the first aws-sdk-go version with module support.
-	github.com/aws/aws-sdk-go v1.15.0
+	github.com/aws/aws-sdk-go v1.33.0
 	github.com/newrelic/go-agent/v3 v3.16.0
 )


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Details
Affected of this project are vulnerable to Cryptographic Issues when it sends an unencrypted hash of the plaintext alongside the ciphertext as a metadata field, this hash can be used to brute force the plaintext if the hash is readable to the attacker.

**PoC:**
```js
func HashExploit(bucket string, key string, input *OfflineAttackInput) (string, error) { _, header, err := input.S3Mock.GetObjectDirect(bucket, key) length, err := strconv.Atoi(header.Get("X-Amz-Meta-X-Amz-Unencrypted-Content-Length")) plaintextMd5 := header.Get("X-Amz-Meta-X-Amz-Unencrypted-Content-Md5") blocks := length / 16 possiblePlaintextNum := 1 segNum := len(input.PossiblePlaintextSegments) for i := 0; i < blocks; i++ { possiblePlaintextNum *= segNum } for i := 0; i < possiblePlaintextNum; i++ { w := i guess := "" for j := 0; j < blocks; j++ { guess += input.PossiblePlaintextSegments[w%segNum] w /= segNum } guessMd5 := md5.Sum([]byte(guess)) if plaintextMd5 == base64.StdEncoding.EncodeToString(guessMd5[:]) { return guess, nil } } return "", fmt.Errorf("No plaintext found!") }
```
```js
func AESGCMContentCipherBuilder(generator CipherDataGenerator) ContentCipherBuilder {
@@ -29,9 +36,14 @@ func (builder gcmContentCipherBuilder) ContentCipherWithContext(ctx aws.Context)
	var cd CipherData
	var err error

	if v, ok := builder.generator.(CipherDataGeneratorWithContext); ok {
	switch v := builder.generator.(type) {
	case CipherDataGeneratorWithCEKAlgWithContext:
		cd, err = v.GenerateCipherDataWithCEKAlgWithContext(ctx, gcmKeySize, gcmNonceSize, AESGCMNoPadding)
	case CipherDataGeneratorWithCEKAlg:
		cd, err = v.GenerateCipherDataWithCEKAlg(gcmKeySize, gcmNonceSize, AESGCMNoPadding)
	case CipherDataGeneratorWithContext:
		cd, err = v.GenerateCipherDataWithContext(ctx, gcmKeySize, gcmNonceSize)
	} else {
	default:
		cd, err = builder.generator.GenerateCipherData(gcmKeySize, gcmNonceSize)
	}
	if err != nil {
```
The AWS S3 Crypto SDK sends an unencrypted hash of the plaintext alongside the ciphertext as a metadata field. This hash can be used to brute force the plaintext, if the hash is readable to the attacker. AWS now blocks this metadata field, but older SDK versions still send it.



CVE-2022-2582
[CWE-326](https://cwe.mitre.org/data/definitions/326.html)
`CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N`



