### PR TITLE
Patched unencrypted hash of the plaintext alongside the ciphertext as a metadata field

### DIFF
--- a/v3/integrations/nrawssdk-v1/go.mod
+++ b/v3/integrations/nrawssdk-v1/go.mod
@@ -7,6 +7,6 @@ go 1.7
 
 require (
 	// v1.15.0 is the first aws-sdk-go version with module support.
-	github.com/aws/aws-sdk-go v1.15.0
+	github.com/aws/aws-sdk-go v1.33.0
 	github.com/newrelic/go-agent/v3 v3.16.0
 )


### PR DESCRIPTION
sends an unencrypted hash of the plaintext alongside the ciphertext as a metadata field. This hash can be used to brute force the plaintext, if the hash is readable to the attacker. AWS now blocks this metadata field, but older SDK versions still send it.