### PR TITLE
Error Group Callback and User Tracking

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -6,3 +6,11 @@ require (
 	github.com/golang/protobuf v1.5.2
 	google.golang.org/grpc v1.49.0
 )
+
+require (
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
+	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+)

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -6,11 +6,3 @@ require (
 	github.com/golang/protobuf v1.5.2
 	google.golang.org/grpc v1.49.0
 )
-
-require (
-	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
-	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
-	golang.org/x/text v0.3.3 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
-)

--- a/v3/newrelic/application.go
+++ b/v3/newrelic/application.go
@@ -114,7 +114,6 @@ func (app *Application) RecordLog(logEvent LogData) {
 // as needed in the background (and will continue attempting to connect
 // if it wasn't immediately successful, all while allowing your application
 // to proceed with its primary function).
-//
 func (app *Application) WaitForConnection(timeout time.Duration) error {
 	if nil == app {
 		return nil

--- a/v3/newrelic/attributes.go
+++ b/v3/newrelic/attributes.go
@@ -54,6 +54,8 @@ const (
 	AttributeCodeLineno = "code.lineno"
 	// AttributeErrorGroupName contains the error group name set by the user defined callback function.
 	AttributeErrorGroupName = "error.group.name"
+	// AttributeUserID tracks the user a transaction and its child events are impacting
+	AttributeUserID = "enduser.id"
 )
 
 // Attributes destined for Errors and Transaction Traces:

--- a/v3/newrelic/attributes.go
+++ b/v3/newrelic/attributes.go
@@ -52,6 +52,8 @@ const (
 	AttributeCodeFilepath = "code.filepath"
 	// AttributeCodeLineno contains the Code Level Metrics source file line number name.
 	AttributeCodeLineno = "code.lineno"
+	// AttributeErrorGroupName contains the error group name set by the user defined callback function.
+	AttributeErrorGroupName = "error.group.name"
 )
 
 // Attributes destined for Errors and Transaction Traces:

--- a/v3/newrelic/attributes_from_internal.go
+++ b/v3/newrelic/attributes_from_internal.go
@@ -5,7 +5,6 @@ package newrelic
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -57,6 +56,7 @@ var (
 		AttributeCodeNamespace:              usualDests,
 		AttributeCodeFilepath:               usualDests,
 		AttributeCodeLineno:                 usualDests,
+		AttributeUserID:                     usualDests,
 
 		// Span specific attributes
 		SpanAttributeDBStatement:             usualDests,
@@ -391,22 +391,6 @@ func validateFloat(v float64, key string) error {
 	return nil
 }
 
-// addAgentAttribute adds an agent attribute.
-func addAgentAttribute(a *attributes, key, value string) error {
-	val, err := validateUserAttribute(key, value)
-	if nil != err {
-		return err
-	}
-
-	strVal, ok := val.(string)
-	if !ok {
-		return errors.New("validated agent attribute was not returned as a string")
-	}
-
-	a.Agent.Add(key, strVal, nil)
-	return nil
-}
-
 // addUserAttribute adds a user attribute.
 func addUserAttribute(a *attributes, key string, val interface{}, d destinationSet) error {
 	val, err := validateUserAttribute(key, val)
@@ -479,6 +463,7 @@ func agentAttributesJSON(a *attributes, buf *bytes.Buffer, d destinationSet, add
 		buf.WriteString("{}")
 		return
 	}
+
 	w := jsonFieldsWriter{buf: buf}
 	buf.WriteByte('{')
 	for id, val := range a.Agent {
@@ -499,7 +484,6 @@ func agentAttributesJSON(a *attributes, buf *bytes.Buffer, d destinationSet, add
 	}
 
 	buf.WriteByte('}')
-
 }
 
 func userAttributesJSON(a *attributes, buf *bytes.Buffer, d destinationSet, extraAttributes map[string]interface{}) {

--- a/v3/newrelic/attributes_from_internal.go
+++ b/v3/newrelic/attributes_from_internal.go
@@ -5,6 +5,7 @@ package newrelic
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -387,6 +388,22 @@ func validateFloat(v float64, key string) error {
 			val: v,
 		}
 	}
+	return nil
+}
+
+// addAgentAttribute adds an agent attribute.
+func addAgentAttribute(a *attributes, key, value string) error {
+	val, err := validateUserAttribute(key, value)
+	if nil != err {
+		return err
+	}
+
+	strVal, ok := val.(string)
+	if !ok {
+		return errors.New("validated agent attribute was not returned as a string")
+	}
+
+	a.Agent.Add(key, strVal, nil)
 	return nil
 }
 

--- a/v3/newrelic/attributes_from_internal.go
+++ b/v3/newrelic/attributes_from_internal.go
@@ -457,7 +457,7 @@ func writeAttributeValueJSON(w *jsonFieldsWriter, key string, val interface{}) {
 	}
 }
 
-func agentAttributesJSON(a *attributes, buf *bytes.Buffer, d destinationSet) {
+func agentAttributesJSON(a *attributes, buf *bytes.Buffer, d destinationSet, additionalAttributes ...map[string]string) {
 	if a == nil {
 		buf.WriteString("{}")
 		return
@@ -473,6 +473,14 @@ func agentAttributesJSON(a *attributes, buf *bytes.Buffer, d destinationSet) {
 			}
 		}
 	}
+
+	// Add additional agent attributes to json
+	for _, additionalAttribute := range additionalAttributes {
+		for id, val := range additionalAttribute {
+			w.stringField(id, val)
+		}
+	}
+
 	buf.WriteByte('}')
 
 }

--- a/v3/newrelic/config.go
+++ b/v3/newrelic/config.go
@@ -113,6 +113,23 @@ type Config struct {
 		// as errors, and then re-panic them.  By default, this is
 		// set to false.
 		RecordPanics bool
+		// ErrorGroupCallback is a user defined callback function that takes an error as an input
+		// and returns a string that will be applied to an error to put it in an error group.
+		//
+		// If no error group is identified for a given error, this function should return an empty string.
+		// If an ErrorGroupCallbeck is defined, it will be executed against every error the go agent notices that
+		// is not ignored.
+		//
+		// example function:
+		//
+		// func ErrorGroupCallback(errorInfo newrelic.ErrorInfo) string {
+		// 		if errorInfo.IsWeb && errorInfo.Class == "403" {
+		//			return "client misconfigured example-group"
+		// 		}
+		//
+		//		return ""
+		// }
+		ErrorGroupCallback `json:"-"`
 	}
 
 	// TransactionTracer controls the capture of transaction traces.

--- a/v3/newrelic/config.go
+++ b/v3/newrelic/config.go
@@ -123,10 +123,11 @@ type Config struct {
 		// example function:
 		//
 		// func ErrorGroupCallback(errorInfo newrelic.ErrorInfo) string {
-		// 		if errorInfo.IsWeb && errorInfo.Class == "403" {
-		//			return "client misconfigured example-group"
+		//		if errorInfo.Class == "403" && errorInfo.GetUserId() == "example user" {
+		//			return "customer X payment issue"
 		// 		}
 		//
+		//		// returning empty string causes default error grouping behavior
 		//		return ""
 		// }
 		ErrorGroupCallback `json:"-"`

--- a/v3/newrelic/config_options.go
+++ b/v3/newrelic/config_options.go
@@ -199,14 +199,6 @@ func ConfigCodeLevelMetricsPathPrefixes(prefix ...string) ConfigOption {
 	}
 }
 
-// ConfigModuleDependencyMetricsIgnoredPrefixes sets the ErrorFingerprintingCallback function
-// to a function defined by the user.
-func ConfigErrorFingerprintingCallback(callbackFunction ErrorGroupCallback) ConfigOption {
-	return func(cfg *Config) {
-		cfg.ErrorCollector.ErrorGroupCallback = callbackFunction
-	}
-}
-
 // ConfigAppLogForwardingEnabled enables or disables the collection
 // of logs from a user's application by the agent
 // Defaults: enabled=false
@@ -293,6 +285,17 @@ func ConfigModuleDependencyMetricsEnabled(enabled bool) ConfigOption {
 func ConfigModuleDependencyMetricsIgnoredPrefixes(prefix ...string) ConfigOption {
 	return func(cfg *Config) {
 		cfg.ModuleDependencyMetrics.IgnoredPrefixes = prefix
+	}
+}
+
+// ConfigSetErrorGroupCallbackFunction set a callback function of type ErrorGroupCallback that will
+// be invoked against errors at harvest time. This function overrides the default grouping behavior
+// of errors into a custom, user defined group when set. Setting this may have performance implications
+// for your application depending on the contents of the callback function. Do not set this if you want
+// the default error grouping behavior to be executed.
+func ConfigSetErrorGroupCallbackFunction(callback ErrorGroupCallback) ConfigOption {
+	return func(cfg *Config) {
+		cfg.ErrorCollector.ErrorGroupCallback = callback
 	}
 }
 

--- a/v3/newrelic/config_options.go
+++ b/v3/newrelic/config_options.go
@@ -199,6 +199,14 @@ func ConfigCodeLevelMetricsPathPrefixes(prefix ...string) ConfigOption {
 	}
 }
 
+// ConfigModuleDependencyMetricsIgnoredPrefixes sets the ErrorFingerprintingCallback function
+// to a function defined by the user.
+func ConfigErrorFingerprintingCallback(callbackFunction ErrorGroupCallback) ConfigOption {
+	return func(cfg *Config) {
+		cfg.ErrorCollector.ErrorGroupCallback = callbackFunction
+	}
+}
+
 // ConfigAppLogForwardingEnabled enables or disables the collection
 // of logs from a user's application by the agent
 // Defaults: enabled=false

--- a/v3/newrelic/environment_test.go
+++ b/v3/newrelic/environment_test.go
@@ -73,9 +73,9 @@ func TestModuleDependency(t *testing.T) {
 	// of modules to at least check that the various options work.
 	expectedModules := make(map[string]*debug.Module)
 	mockedModuleList := []*debug.Module{
-		&debug.Module{Path: "example/path/to/module", Version: "v1.2.3"},
-		&debug.Module{Path: "github.com/another/module", Version: "v0.1.2"},
-		&debug.Module{Path: "some/development/module", Version: "(develop)"},
+		{Path: "example/path/to/module", Version: "v1.2.3"},
+		{Path: "github.com/another/module", Version: "v0.1.2"},
+		{Path: "some/development/module", Version: "(develop)"},
 	}
 	for _, module := range mockedModuleList {
 		expectedModules[module.Path] = module

--- a/v3/newrelic/error_events.go
+++ b/v3/newrelic/error_events.go
@@ -39,7 +39,13 @@ func (e *errorEvent) WriteJSON(buf *bytes.Buffer) {
 	buf.WriteByte(',')
 	userAttributesJSON(e.Attrs, buf, destError, e.errorData.ExtraAttributes)
 	buf.WriteByte(',')
-	agentAttributesJSON(e.Attrs, buf, destError)
+
+	if e.ErrorGroup != "" {
+		agentAttributesJSON(e.Attrs, buf, destError, map[string]string{AttributeErrorGroupName: e.ErrorGroup})
+	} else {
+		agentAttributesJSON(e.Attrs, buf, destError)
+	}
+
 	buf.WriteByte(']')
 }
 

--- a/v3/newrelic/error_group.go
+++ b/v3/newrelic/error_group.go
@@ -8,7 +8,7 @@ const (
 )
 
 // ErrorInfo contains info for user defined callbacks that are relevant to an error.
-// All fields are either safe to access coppies of internal agent data, or protected from direct
+// All fields are either safe to access copies of internal agent data, or protected from direct
 // access with methods and can not manipulate or distort any agent data.
 type ErrorInfo struct {
 	errAttributes map[string]interface{}

--- a/v3/newrelic/error_group.go
+++ b/v3/newrelic/error_group.go
@@ -117,9 +117,9 @@ func (e *ErrorInfo) GetHttpResponseCode() string {
 	return val.stringVal
 }
 
-// GetEnduserID will return the User ID set for the parent transaction of this error. It will return empty string
+// GetUserID will return the User ID set for the parent transaction of this error. It will return empty string
 // if none was set.
-func (e *ErrorInfo) GetEnduserID() string {
+func (e *ErrorInfo) GetUserID() string {
 	val, ok := e.txnAttributes.Agent[AttributeUserID]
 	if !ok {
 		return ""

--- a/v3/newrelic/error_group.go
+++ b/v3/newrelic/error_group.go
@@ -11,10 +11,9 @@ const (
 // All fields are either safe to access coppies of internal agent data, or protected from direct
 // access with methods and can not manipulate or distort any agent data.
 type ErrorInfo struct {
-	errAttributes    map[string]interface{}
-	txnAttributes    *attributes
-	stackTrace       stackTrace
-	isWebTransaction bool
+	errAttributes map[string]interface{}
+	txnAttributes *attributes
+	stackTrace    stackTrace
 
 	// TransactionName is the formatted name of a transaction that is equivilent to how it appears in
 	// the New Relic UI. For example, user defined transactions will be named `OtherTransaction/Go/yourTxnName`.
@@ -78,10 +77,6 @@ func (e *ErrorInfo) GetStackTraceFrames() []StacktraceFrame {
 // GetRequestURI returns the URI of the http request made during the parent transaction of this error. If no web request occured,
 // this will return an empty string.
 func (e *ErrorInfo) GetRequestURI() string {
-	if !e.isWebTransaction {
-		return ""
-	}
-
 	val, ok := e.txnAttributes.Agent[AttributeRequestURI]
 	if !ok {
 		return ""
@@ -93,10 +88,6 @@ func (e *ErrorInfo) GetRequestURI() string {
 // GetRequestMethod will return the HTTP method used to make a web request if one occured during the parent transaction
 // of this error. If no web request occured, then an empty string will be returned.
 func (e *ErrorInfo) GetRequestMethod() string {
-	if !e.isWebTransaction {
-		return ""
-	}
-
 	val, ok := e.txnAttributes.Agent[AttributeRequestMethod]
 	if !ok {
 		return ""
@@ -108,11 +99,17 @@ func (e *ErrorInfo) GetRequestMethod() string {
 // GetHttpResponseCode will return the HTTP response code that resulted from the web request made in the parent transaction of
 // this error. If no web request occured, then an empty string will be returned.
 func (e *ErrorInfo) GetHttpResponseCode() string {
-	if !e.isWebTransaction {
+	val, ok := e.txnAttributes.Agent[AttributeResponseCode]
+	if !ok {
 		return ""
 	}
 
-	val, ok := e.txnAttributes.Agent[AttributeResponseCode]
+	code := val.stringVal
+	if code != "" {
+		return code
+	}
+
+	val, ok = e.txnAttributes.Agent[AttributeResponseCodeDeprecated]
 	if !ok {
 		return ""
 	}

--- a/v3/newrelic/error_group.go
+++ b/v3/newrelic/error_group.go
@@ -117,6 +117,17 @@ func (e *ErrorInfo) GetHttpResponseCode() string {
 	return val.stringVal
 }
 
+// GetEnduserID will return the User ID set for the parent transaction of this error. It will return empty string
+// if none was set.
+func (e *ErrorInfo) GetEnduserID() string {
+	val, ok := e.txnAttributes.Agent[AttributeUserID]
+	if !ok {
+		return ""
+	}
+
+	return val.stringVal
+}
+
 // ErrorGroupCallback is a user defined callback function that takes an error as an input
 // and returns a string that will be applied to an error to put it in an error group.
 //

--- a/v3/newrelic/error_group.go
+++ b/v3/newrelic/error_group.go
@@ -1,0 +1,130 @@
+package newrelic
+
+import "time"
+
+const (
+	// The error class for panics
+	PanicErrorClass = panicErrorKlass
+)
+
+// ErrorInfo contains info for user defined callbacks that are relevant to an error.
+// All fields are either safe to access coppies of internal agent data, or protected from direct
+// access with methods and can not manipulate or distort any agent data.
+type ErrorInfo struct {
+	errAttributes    map[string]interface{}
+	txnAttributes    *attributes
+	stackTrace       stackTrace
+	isWebTransaction bool
+
+	// TransactionName is the formatted name of a transaction that is equivilent to how it appears in
+	// the New Relic UI. For example, user defined transactions will be named `OtherTransaction/Go/yourTxnName`.
+	TransactionName string
+
+	// Error contains the raw error object that the agent collected.
+	//
+	// Not all errors collected by the system are collected as
+	// error objects, like web/http errors and panics.
+	// In these cases, Error will be nil, but details will be captured in
+	// the Message and Class fields.
+	Error error
+
+	// Time Occured is the time.Time when the error was noticed by the go agent
+	TimeOccured time.Time
+
+	// Message will always be populated by a string message describing an error
+	Message string
+
+	// Class is a string containing the New Relic error class.
+	//
+	// If an error implements errorClasser, its value will be derived from that.
+	// Otherwise, it will be derived from the way the error was
+	// collected by the agent. For http errors, this will be the
+	// error number. Panics will be the constant value `newrelic.PanicErrorClass`.
+	// If no errorClass was defined, this will be reflect.TypeOf() the root
+	// error object, which is commonly `*errors.errorString`.
+	Class string
+
+	// Expected is true if the error was expected by the go agent
+	Expected bool
+}
+
+// GetTransactionUserAttribute safely looks up a user attribute by string key from the parent transaction
+// of an error. This function will return the attribute vaue as an interface{}, and a bool indicating whether the
+// key was found in the attribute map. If the key was not found, then the return will be (nil, false).
+func (e *ErrorInfo) GetTransactionUserAttribute(attribute string) (interface{}, bool) {
+	a, b := e.txnAttributes.user[attribute]
+	if b {
+		return a.value, b
+	}
+
+	return nil, b
+}
+
+// GetErrorAttribute safely looks up an error attribute by string key. The value of the attribute will be returned
+// as an interface{}, and a bool indicating whether the key was found in the attribute map. If no matching key was
+// found, the return will be (nil, false).
+func (e *ErrorInfo) GetErrorAttribute(attribute string) (interface{}, bool) {
+	a, b := e.errAttributes[attribute]
+	return a, b
+}
+
+// GetStackTraceFrames returns a slice of StacktraceFrame objects containing up to 100 lines of stack trace
+// data gathered from the Go runtime. Calling this function may be expensive since it allocates and
+// populates a new slice with stack trace data, and should be called only when needed.
+func (e *ErrorInfo) GetStackTraceFrames() []StacktraceFrame {
+	return e.stackTrace.frames()
+}
+
+// GetRequestURI returns the URI of the http request made during the parent transaction of this error. If no web request occured,
+// this will return an empty string.
+func (e *ErrorInfo) GetRequestURI() string {
+	if !e.isWebTransaction {
+		return ""
+	}
+
+	val, ok := e.txnAttributes.Agent[AttributeRequestURI]
+	if !ok {
+		return ""
+	}
+
+	return val.stringVal
+}
+
+// GetRequestMethod will return the HTTP method used to make a web request if one occured during the parent transaction
+// of this error. If no web request occured, then an empty string will be returned.
+func (e *ErrorInfo) GetRequestMethod() string {
+	if !e.isWebTransaction {
+		return ""
+	}
+
+	val, ok := e.txnAttributes.Agent[AttributeRequestMethod]
+	if !ok {
+		return ""
+	}
+
+	return val.stringVal
+}
+
+// GetHttpResponseCode will return the HTTP response code that resulted from the web request made in the parent transaction of
+// this error. If no web request occured, then an empty string will be returned.
+func (e *ErrorInfo) GetHttpResponseCode() string {
+	if !e.isWebTransaction {
+		return ""
+	}
+
+	val, ok := e.txnAttributes.Agent[AttributeResponseCode]
+	if !ok {
+		return ""
+	}
+
+	return val.stringVal
+}
+
+// ErrorGroupCallback is a user defined callback function that takes an error as an input
+// and returns a string that will be applied to an error to put it in an error group.
+//
+// If no error group is identified for a given error, this function should return an empty string.
+//
+// If an ErrorGroupCallbeck is defined, it will be executed against every error the go agent notices that
+// is not ignored.
+type ErrorGroupCallback func(ErrorInfo) string

--- a/v3/newrelic/errors_test.go
+++ b/v3/newrelic/errors_test.go
@@ -238,7 +238,7 @@ func TestErrorsLifecycle(t *testing.T) {
 			Priority: 0.5,
 		},
 		TotalTime: 2 * time.Second,
-	})
+	}, nil)
 	js, err := he.Data("agentRunID", time.Now())
 	if nil != err {
 		t.Error(err)
@@ -344,7 +344,7 @@ func BenchmarkErrorsJSON(b *testing.B) {
 	mergeTxnErrors(&he, ers, txnEvent{
 		FinalName: "WebTransaction/Go/hello",
 		Attrs:     attr,
-	})
+	}, nil)
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/v3/newrelic/harvest_test.go
+++ b/v3/newrelic/harvest_test.go
@@ -509,7 +509,7 @@ func TestHarvestMetricsTracesReady(t *testing.T) {
 
 	ers := newTxnErrors(10)
 	ers.Add(errorData{When: time.Now(), Msg: "msg", Klass: "klass", Stack: getStackTrace()})
-	mergeTxnErrors(&h.ErrorTraces, ers, txnEvent{FinalName: "finalName", Attrs: nil})
+	mergeTxnErrors(&h.ErrorTraces, ers, txnEvent{FinalName: "finalName", Attrs: nil}, nil)
 
 	h.TxnTraces.Witness(harvestTrace{
 		txnEvent: txnEvent{
@@ -612,7 +612,7 @@ func TestMergeFailedHarvest(t *testing.T) {
 	mergeTxnErrors(&h.ErrorTraces, ers, txnEvent{
 		FinalName: "finalName",
 		Attrs:     nil,
-	})
+	}, nil)
 	h.SpanEvents.addEventPopulated(&sampleSpanEvent)
 
 	if start1 != h.Metrics.metricPeriodStart {

--- a/v3/newrelic/internal_test.go
+++ b/v3/newrelic/internal_test.go
@@ -5,6 +5,7 @@ package newrelic
 
 import (
 	"encoding/json"
+	"errors"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -491,6 +492,88 @@ func TestSetName(t *testing.T) {
 	app.ExpectMetrics(t, backgroundMetrics)
 }
 
+type advancedError struct {
+	error
+}
+
+func (e *advancedError) Error() string {
+	return e.error.Error()
+}
+
+func (e *advancedError) ErrorClass() string {
+	return "test class"
+}
+
+func (e *advancedError) ErrorAttributes() map[string]interface{} {
+	return map[string]interface{}{
+		"testKey": "test val",
+	}
+}
+
+func TestErrorWithCallback(t *testing.T) {
+	errorGroupFunc := func(e ErrorInfo) string {
+		if e.Error == nil {
+			t.Error("expected ErrorInfo.Error not be nil")
+		}
+		if e.Expected {
+			t.Error("error should not be expected")
+		}
+
+		val, ok := e.GetErrorAttribute("testKey")
+		if !ok || val != "test val" {
+			t.Error("error should successfully look up user provided attribute: \"testKey\":\"test val\"")
+		}
+
+		val, ok = e.GetTransactionUserAttribute("txnAttribute")
+		if !ok || val != "test txn attr" {
+			t.Error("error should successfully look up user provided attribute: \"testKey\":\"test txn attr\"")
+		}
+
+		stackTrace := e.GetStackTraceFrames()
+		if len(stackTrace) == 0 {
+			t.Error("expected error stack trace to not be empty")
+		}
+
+		if e.isWebTransaction {
+			t.Error("expected error to not be part of a web txn")
+		}
+
+		AssertStringEqual(t, "ErrorInfo.TransactionName", `OtherTransaction/Go/hello`, e.TransactionName)
+		AssertStringEqual(t, "ErrorInfo.Message", "this is a test error", e.Message)
+		AssertStringEqual(t, "ErrorInfo.Class", "test class", e.Class)
+
+		return "testGroup"
+	}
+
+	app := testApp(
+		nil,
+		func(cfg *Config) {
+			cfg.DistributedTracer.Enabled = false
+			enableRecordPanics(cfg)
+			cfg.ErrorCollector.ErrorGroupCallback = errorGroupFunc
+		},
+		t,
+	)
+
+	txn := app.StartTransaction("hello")
+	txn.AddAttribute("txnAttribute", "test txn attr")
+	txn.NoticeError(&advancedError{errors.New("this is a test error")})
+	txn.End()
+
+	app.ExpectErrors(t, []internal.WantError{{
+		TxnName: "OtherTransaction/Go/hello",
+		Msg:     "this is a test error",
+		Klass:   "test class",
+	}})
+	app.ExpectErrorEvents(t, []internal.WantEvent{{
+		Intrinsics: map[string]interface{}{
+			"error.class":     "test class",
+			"error.message":   "this is a test error",
+			"transactionName": "OtherTransaction/Go/hello",
+		},
+	}})
+}
+
 func deferEndPanic(txn *Transaction, panicMe interface{}) (r interface{}) {
 	defer func() {
 		r = recover()
@@ -546,6 +629,51 @@ func TestPanicError(t *testing.T) {
 		},
 	}})
 	app.ExpectMetrics(t, backgroundErrorMetrics)
+}
+
+func TestPanicErrorWithCallback(t *testing.T) {
+	errorGroupFunc := func(e ErrorInfo) string {
+		if e.Error != nil {
+			t.Errorf("expected ErrorInfo.Error to be nil, but got %v", e.Error)
+		}
+		AssertStringEqual(t, "ErrorInfo.TransactionName", `OtherTransaction/Go/hello`, e.TransactionName)
+		AssertStringEqual(t, "ErrorInfo.Message", "my msg", e.Message)
+		AssertStringEqual(t, "ErrorInfo.Class", PanicErrorClass, e.Class)
+		return "testGroup"
+	}
+
+	app := testApp(
+		nil,
+		func(cfg *Config) {
+			cfg.DistributedTracer.Enabled = false
+			enableRecordPanics(cfg)
+			cfg.ErrorCollector.ErrorGroupCallback = errorGroupFunc
+		},
+		t,
+	)
+
+	txn := app.StartTransaction("hello")
+
+	e := myError{}
+	r := deferEndPanic(txn, e)
+	if r != e {
+		t.Error("panic not propagated", r)
+	}
+
+	app.ExpectErrors(t, []internal.WantError{{
+		TxnName: "OtherTransaction/Go/hello",
+		Msg:     "my msg",
+		Klass:   panicErrorKlass,
+	}})
+	app.ExpectErrorEvents(t, []internal.WantEvent{{
+		Intrinsics: map[string]interface{}{
+			"error.class":     panicErrorKlass,
+			"error.message":   "my msg",
+			"transactionName": "OtherTransaction/Go/hello",
+		},
+	}})
+	app.ExpectMetrics(t, backgroundErrorMetrics)
+
 }
 
 func TestPanicString(t *testing.T) {
@@ -651,6 +779,65 @@ func TestResponseCodeError(t *testing.T) {
 		AgentAttributes: mergeAttributes(helloRequestAttributes, map[string]interface{}{
 			"httpResponseCode": "400",
 			"http.statusCode":  "400",
+		}),
+	}})
+	app.ExpectMetrics(t, webErrorMetrics)
+}
+
+func AssertStringEqual(t *testing.T, field string, expect string, actual string) {
+	if expect != actual {
+		t.Errorf("incorrect value for %s; expected: %s got: %s", field, expect, actual)
+	}
+}
+
+func TestResponseCodeErrorWithErrorGroupCallback(t *testing.T) {
+	errorGroupFunc := func(e ErrorInfo) string {
+		if e.Error != nil {
+			t.Errorf("expected ErrorInfo.Error to be nil, but got %v", e.Error)
+		}
+		AssertStringEqual(t, "ErrorInfo.TransactionName", `WebTransaction/Go/hello`, e.TransactionName)
+		AssertStringEqual(t, "ErrorInfo.Message", "Bad Request", e.Message)
+		AssertStringEqual(t, "ErrorInfo.Class", "400", e.Class)
+		return "testGroup"
+	}
+
+	app := testApp(
+		nil,
+		func(cfg *Config) {
+			cfg.DistributedTracer.Enabled = false
+			cfg.ErrorCollector.ErrorGroupCallback = errorGroupFunc
+		},
+		t,
+	)
+	w := newCompatibleResponseRecorder()
+	txn := app.StartTransaction("hello")
+	rw := txn.SetWebResponse(w)
+	txn.SetWebRequestHTTP(helloRequest)
+
+	rw.WriteHeader(http.StatusBadRequest)   // 400
+	rw.WriteHeader(http.StatusUnauthorized) // 401
+
+	txn.End()
+
+	if http.StatusBadRequest != w.Code {
+		t.Error(w.Code)
+	}
+
+	app.ExpectErrors(t, []internal.WantError{{
+		TxnName: "WebTransaction/Go/hello",
+		Msg:     "Bad Request",
+		Klass:   "400",
+	}})
+	app.ExpectErrorEvents(t, []internal.WantEvent{{
+		Intrinsics: map[string]interface{}{
+			"error.class":     "400",
+			"error.message":   "Bad Request",
+			"transactionName": "WebTransaction/Go/hello",
+		},
+		AgentAttributes: mergeAttributes(helloRequestAttributes, map[string]interface{}{
+			"httpResponseCode":      "400",
+			"http.statusCode":       "400",
+			AttributeErrorGroupName: "testGroup",
 		}),
 	}})
 	app.ExpectMetrics(t, webErrorMetrics)

--- a/v3/newrelic/internal_txn.go
+++ b/v3/newrelic/internal_txn.go
@@ -545,6 +545,17 @@ func (thd *thread) End(recovered interface{}) error {
 	return nil
 }
 
+func (txn *txn) AddUserID(userID string) error {
+	txn.Lock()
+	defer txn.Unlock()
+
+	if txn.finished {
+		return errAlreadyEnded
+	}
+
+	return addAgentAttribute(txn.Attrs, AttributeUserID, userID)
+}
+
 func (txn *txn) AddAttribute(name string, value interface{}) error {
 	txn.Lock()
 	defer txn.Unlock()

--- a/v3/newrelic/internal_txn.go
+++ b/v3/newrelic/internal_txn.go
@@ -318,12 +318,10 @@ func (txn *txn) MergeIntoHarvest(h *harvest) {
 		h.TxnEvents.AddTxnEvent(alloc, priority)
 	}
 
-	// pass the callback func down the chain
-	txn.txnEvent.errGroupCallback = txn.Config.ErrorCollector.ErrorGroupCallback
-
 	hs := &highSecuritySettings{txn.Config.HighSecurity, txn.Reply.SecurityPolicies.AllowRawExceptionMessages.Enabled()}
 
 	if (txn.Reply.CollectErrors || txn.Config.ErrorCollector.CaptureEvents) && txn.Config.ErrorCollector.ErrorGroupCallback != nil {
+		txn.txnEvent.errGroupCallback = txn.Config.ErrorCollector.ErrorGroupCallback
 		for _, e := range txn.Errors {
 			e.applyErrorGroup(&txn.txnEvent)
 		}
@@ -548,12 +546,12 @@ func (thd *thread) End(recovered interface{}) error {
 func (txn *txn) AddUserID(userID string) error {
 	txn.Lock()
 	defer txn.Unlock()
-
 	if txn.finished {
 		return errAlreadyEnded
 	}
 
-	return addAgentAttribute(txn.Attrs, AttributeUserID, userID)
+	txn.Attrs.Agent.Add(AttributeUserID, userID, nil)
+	return nil
 }
 
 func (txn *txn) AddAttribute(name string, value interface{}) error {

--- a/v3/newrelic/stacktrace.go
+++ b/v3/newrelic/stacktrace.go
@@ -21,13 +21,13 @@ func getStackTrace() stackTrace {
 	return callers[:written]
 }
 
-type stacktraceFrame struct {
+type StacktraceFrame struct {
 	Name string
 	File string
 	Line int64
 }
 
-func (f stacktraceFrame) formattedName() string {
+func (f StacktraceFrame) formattedName() string {
 	if strings.HasPrefix(f.Name, "go.") {
 		// This indicates an anonymous struct. eg.
 		// "go.(*struct { github.com/newrelic/go-agent.threadWithExtras }).NoticeError"
@@ -36,7 +36,7 @@ func (f stacktraceFrame) formattedName() string {
 	return path.Base(f.Name)
 }
 
-func (f stacktraceFrame) isAgent() bool {
+func (f StacktraceFrame) isAgent() bool {
 	// Note this is not a contains conditional rather than a prefix
 	// conditional to handle anonymous functions like:
 	// "go.(*struct { github.com/newrelic/go-agent.threadWithExtras }).NoticeError"
@@ -44,7 +44,7 @@ func (f stacktraceFrame) isAgent() bool {
 		strings.Contains(f.Name, "github.com/newrelic/go-agent/v3/newrelic.")
 }
 
-func (f stacktraceFrame) WriteJSON(buf *bytes.Buffer) {
+func (f StacktraceFrame) WriteJSON(buf *bytes.Buffer) {
 	buf.WriteByte('{')
 	w := jsonFieldsWriter{buf: buf}
 	if f.Name != "" {
@@ -59,7 +59,7 @@ func (f stacktraceFrame) WriteJSON(buf *bytes.Buffer) {
 	buf.WriteByte('}')
 }
 
-func writeFrames(buf *bytes.Buffer, frames []stacktraceFrame) {
+func writeFrames(buf *bytes.Buffer, frames []StacktraceFrame) {
 	// Remove top agent frames.
 	for len(frames) > 0 && frames[0].isAgent() {
 		frames = frames[1:]
@@ -80,17 +80,17 @@ func writeFrames(buf *bytes.Buffer, frames []stacktraceFrame) {
 	buf.WriteByte(']')
 }
 
-func (st stackTrace) frames() []stacktraceFrame {
+func (st stackTrace) frames() []StacktraceFrame {
 	if len(st) == 0 {
 		return nil
 	}
 	frames := runtime.CallersFrames(st) // CallersFrames is only available in Go 1.7+
-	fs := make([]stacktraceFrame, 0, maxStackTraceFrames)
+	fs := make([]StacktraceFrame, 0, maxStackTraceFrames)
 	var frame runtime.Frame
 	more := true
 	for more {
 		frame, more = frames.Next()
-		fs = append(fs, stacktraceFrame{
+		fs = append(fs, StacktraceFrame{
 			Name: frame.Function,
 			File: frame.File,
 			Line: int64(frame.Line),

--- a/v3/newrelic/stacktrace_test.go
+++ b/v3/newrelic/stacktrace_test.go
@@ -37,7 +37,7 @@ func TestLongStackTraceLimitsFrames(t *testing.T) {
 }
 
 func TestManyStackTraceFramesLimitsOutput(t *testing.T) {
-	frames := make([]stacktraceFrame, maxStackTraceFrames+20)
+	frames := make([]StacktraceFrame, maxStackTraceFrames+20)
 	expect := `[
 	{},{},{},{},{},{},{},{},{},{},
 	{},{},{},{},{},{},{},{},{},{},
@@ -60,7 +60,7 @@ func TestManyStackTraceFramesLimitsOutput(t *testing.T) {
 
 func TestStacktraceFrames(t *testing.T) {
 	// This stacktrace taken from Go 1.13
-	inputFrames := []stacktraceFrame{
+	inputFrames := []StacktraceFrame{
 		{
 			File: "/Users/will/Desktop/gopath/src/github.com/newrelic/go-agent/v3/internal/stacktrace.go",
 			Name: "github.com/newrelic/go-agent/v3/internal.GetStackTrace",

--- a/v3/newrelic/tracing.go
+++ b/v3/newrelic/tracing.go
@@ -35,6 +35,7 @@ type txnEvent struct {
 	externalDuration   time.Duration
 	datastoreCallCount uint64
 	datastoreDuration  time.Duration
+	errGroupCallback   ErrorGroupCallback
 }
 
 // betterCAT stores the transaction's priority and all fields related

--- a/v3/newrelic/transaction.go
+++ b/v3/newrelic/transaction.go
@@ -169,6 +169,20 @@ func (txn *Transaction) AddAttribute(key string, value interface{}) {
 	txn.thread.logAPIError(txn.thread.AddAttribute(key, value), "add attribute", nil)
 }
 
+// SetUserID is used to track the user that a transaction, and all data that is recorded as a subset of that transaction,
+// belong to or interact with. This will propogate an attribute containing this information to all events that are
+// a child of this transaction, like errors and spans.
+func (txn *Transaction) SetUserID(userID string) {
+	if nil == txn {
+		return
+	}
+	if nil == txn.thread {
+		return
+	}
+
+	txn.thread.logAPIError(txn.thread.AddUserID(userID), "set user ID", nil)
+}
+
 // RecordLog records the data from a single log line.
 // This consumes a LogData object that should be configured
 // with data taken from a logging framework.


### PR DESCRIPTION
This adds functionality to the agent that enables users to define a custom callback function that will be applied to all noticed errors in the agent. It must return a string value which will be used to categorize this error into an error group in New Relic One.

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

<!--
Any relevant links that will help reviewers.
-->

## Details

<!--
In-depth description of changes, other technical notes, etc.
-->
