### PR TITLE
Run workflows on ubuntu-latest only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on: pull_request
 
 jobs:
   go-agent-v3:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       # Required when using older versions of Go that do not support gomod.
       GOPATH: ${{ github.workspace }}
@@ -168,7 +168,7 @@ jobs:
   go-agent-arm64:
     # Run all unit tests on aarch64 emulator to ensure compatibility with AWS
     # Graviton instances
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
     # if one test fails, do not abort the rest
       fail-fast: false


### PR DESCRIPTION
Avoid a mutual exclusion situation where the ubuntu latest and ubuntu 18.0.4 are expected as runtime versions, but can not be grouped. See https://github.com/orgs/community/discussions/26783 for details.
