### PR TITLE
Update CI jobs to run on ubuntu-latest 

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -6,7 +6,9 @@ addAssignees: false
 
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:
-  - newrelic/go-reviewers
+  - iamemilio
+  - mirackara
+  - nr-swilloughby
 
 # A number of reviewers added to the pull request
 # Set 0 to add all the reviewers (default: 0)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on: pull_request
 
 jobs:
   go-agent-v3:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       # Required when using older versions of Go that do not support gomod.
       GOPATH: ${{ github.workspace }}
@@ -168,7 +168,7 @@ jobs:
   go-agent-arm64:
     # Run all unit tests on aarch64 emulator to ensure compatibility with AWS
     # Graviton instances
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
     # if one test fails, do not abort the rest
       fail-fast: false


### PR DESCRIPTION
Jobs were unable to find hosts when using ubuntu-18.04. Updating to latest.