### PR TITLE
Dependabot Integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    # Disable version updates for gomod dependencies, security updates don't use this configuration
+    # See: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates
+    open-pull-requests-limit: 0
+    directory: "../v3"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "security"
+      prefix-development: "chore"
+      include: "scope"

--- a/v3/examples/server/main.go
+++ b/v3/examples/server/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 func index(w http.ResponseWriter, r *http.Request) {
-	io.WriteString(w, "hello")
+	io.WriteString(w, "hello world")
 }
 
 func versionHandler(w http.ResponseWriter, r *http.Request) {
@@ -321,5 +321,5 @@ func main() {
 		io.WriteString(w, "A background log message was recorded")
 	})
 
-	http.ListenAndServe(":6000", nil)
+	http.ListenAndServe(":8000", nil)
 }

--- a/v3/examples/server/main.go
+++ b/v3/examples/server/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 func index(w http.ResponseWriter, r *http.Request) {
-	io.WriteString(w, "hello world")
+	io.WriteString(w, "hello")
 }
 
 func versionHandler(w http.ResponseWriter, r *http.Request) {
@@ -321,5 +321,5 @@ func main() {
 		io.WriteString(w, "A background log message was recorded")
 	})
 
-	http.ListenAndServe(":8000", nil)
+	http.ListenAndServe(":6000", nil)
 }


### PR DESCRIPTION
Adding dependabot will allow us to automatically check for out of date dependencies and will automatically create PRs for us to merge with the new security updates.