### PR TITLE
release 3.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## 3.22.1
  * Corrects an error in the release process for 3.22.0.
 
+### Support statement
+
+ We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
+
+ See the [Go agent EOL Policy](https://docs.newrelic.com/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.
+
 ## 3.22.0
 
  ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.22.1
+ * Corrects an error in the release process for 3.22.0.
+
 ## 3.22.0
 
  ### Added

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -6,3 +6,13 @@ require (
 	github.com/golang/protobuf v1.5.3
 	google.golang.org/grpc v1.54.0
 )
+
+require (
+	golang.org/x/net v0.8.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/text v0.8.0 // indirect
+	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
+)
+
+retract v3.22.0 // release process error corrected in v3.22.1

--- a/v3/newrelic/version.go
+++ b/v3/newrelic/version.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Version is the full string version of this Go Agent.
-	Version = "3.22.0"
+	Version = "3.22.1"
 )
 
 var (


### PR DESCRIPTION
## 3.22.1
 * Corrects an error in the release process for 3.22.0.

 ### Support statement

 We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.

 See the [Go agent EOL Policy](https://docs.newrelic.com/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.
