### PR TITLE
Disable IAST if HighSecurity is enabled

### DIFF
--- a/v3/integrations/nrsecurityagent/README.md
+++ b/v3/integrations/nrsecurityagent/README.md
@@ -10,7 +10,7 @@ This integration allows you to have the New Relic security agent analyze your ap
 This is not yet publicly released on github, so you will need to add a `replace` statement to your application's `go.mod` file to point the go toolchain to the location where you downloaded and unpacked the preview version of this integration and the agent. At minimum:
 ```
 replace (
-    github.com/newrelic/go-agent/v3/integrations/nrsecurityagent => {YOUR_PATH}/go-agent/v3/integrations/nrsecureagent
+    github.com/newrelic/go-agent/v3/integrations/nrsecurityagent => {YOUR_PATH}/go-agent/v3/integrations/nrsecurityagent
     github.com/newrelic/go-agent/v3 => {YOUR_PATH}/go-agent/v3
     github.com/newrelic/csec-go-agent => {YOUR_PATH}/csec-go-agent
 )

--- a/v3/integrations/nrsecurityagent/nrsecurityagent.go
+++ b/v3/integrations/nrsecurityagent/nrsecurityagent.go
@@ -54,8 +54,10 @@ func InitSecurityAgent(app *newrelic.Application, opts ...ConfigOption) error {
 		return fmt.Errorf("Newrelic application value cannot be read; did you call newrelic.NewApplication?")
 	}
 
-	secureAgent := securityAgent.InitSecurityAgent(c.Security, appConfig.AppName, appConfig.License, appConfig.Logger.DebugEnabled())
-	app.RegisterSecurityAgent(secureAgent)
+	if !appConfig.HighSecurity {
+		secureAgent := securityAgent.InitSecurityAgent(c.Security, appConfig.AppName, appConfig.License, appConfig.Logger.DebugEnabled())
+		app.RegisterSecurityAgent(secureAgent)
+	}
 	return nil
 }
 
@@ -91,12 +93,11 @@ func ConfigSecurityFromYaml() ConfigOption {
 // ConfigSecurityFromEnvironment directs the nrsecureagent integration to obtain all of its
 // configuration information from environment variables:
 //
-//		NEW_RELIC_SECURITY_ENABLED					(boolean)
-//		NEW_RELIC_SECURITY_VALIDATOR_SERVICE_URL    provides URL for the security validator service
-//		NEW_RELIC_SECURITY_MODE						scanning mode: "IAST" for now
-//		NEW_RELIC_SECURITY_AGENT_ENABLED			(boolean)
-//		NEW_RELIC_SECURITY_DETECTION_RXSS_ENABLED	(boolean)
-//
+//	NEW_RELIC_SECURITY_ENABLED					(boolean)
+//	NEW_RELIC_SECURITY_VALIDATOR_SERVICE_URL    provides URL for the security validator service
+//	NEW_RELIC_SECURITY_MODE						scanning mode: "IAST" for now
+//	NEW_RELIC_SECURITY_AGENT_ENABLED			(boolean)
+//	NEW_RELIC_SECURITY_DETECTION_RXSS_ENABLED	(boolean)
 func ConfigSecurityFromEnvironment() ConfigOption {
 	return func(cfg *SecurityConfig) {
 		assignBool := func(field *bool, name string) {

--- a/v3/integrations/nrsecurityagent/nrsecurityagent.go
+++ b/v3/integrations/nrsecurityagent/nrsecurityagent.go
@@ -33,7 +33,7 @@ func defaultSecurityConfig() SecurityConfig {
 	return cfg
 }
 
-// InitSecurityAgent initializes the nrsecureagent integration package from user-supplied
+// InitSecurityAgent initializes the nrsecurityagent integration package from user-supplied
 // configuration values.
 func InitSecurityAgent(app *newrelic.Application, opts ...ConfigOption) error {
 	if app == nil {
@@ -62,10 +62,10 @@ func InitSecurityAgent(app *newrelic.Application, opts ...ConfigOption) error {
 }
 
 // ConfigOption functions are used to programmatically provide configuration values to the
-// nrsecureagent integration package.
+// nrsecurityagent integration package.
 type ConfigOption func(*SecurityConfig)
 
-// ConfigSecurityFromYaml directs the nrsecureagent integration to read an external
+// ConfigSecurityFromYaml directs the nrsecurityagent integration to read an external
 // YAML-formatted file to obtain its configuration values.
 //
 // The path to this file must be provided by setting the environment variable NEW_RELIC_SECURITY_CONFIG_PATH.
@@ -90,7 +90,7 @@ func ConfigSecurityFromYaml() ConfigOption {
 	}
 }
 
-// ConfigSecurityFromEnvironment directs the nrsecureagent integration to obtain all of its
+// ConfigSecurityFromEnvironment directs the nrsecurityagent integration to obtain all of its
 // configuration information from environment variables:
 //
 //	NEW_RELIC_SECURITY_ENABLED					(boolean)

--- a/v3/newrelic/internal_app.go
+++ b/v3/newrelic/internal_app.go
@@ -290,6 +290,7 @@ func (app *app) process() {
 				app.Error("application disconnected", map[string]interface{}{
 					"app": app.config.AppName,
 				})
+				secureAgent.DeactivateSecurity()
 			} else if resp.IsRestartException() {
 				app.Info("application restarted", map[string]interface{}{
 					"app": app.config.AppName,


### PR DESCRIPTION
Disabling IAST if HighSecurity is enabled because in HighSecurity mode request parameters can't be collected and without request parameters, IAST won't be able to work properly.

reference: https://docs.newrelic.com/docs/apm/agents/go-agent/configuration/go-agent-configuration/#high_security

Disabling IAST if HighSecurity is enabled