### PR TITLE
Update handling for complete disabling of security agent.

### DIFF
--- a/v3/integrations/nrsecurityagent/README.md
+++ b/v3/integrations/nrsecurityagent/README.md
@@ -49,18 +49,22 @@ NEW_RELIC_SECURITY_CONFIG_PATH={YOUR_PATH}/myappsecurity.yaml
 The YAML file should have these contents (adjust as needed for your application):
 ```
 enabled: true
-    mode: IAST
-  validator_service_url: wss://csec.nr-data.net
-  agent:
+
+ # NR security provides two modes IAST and RASP
+ # Default is IAST
+mode: IAST
+
+ # New Relic’s SaaS connection URLs
+validator_service_url: wss://csec-staging.nr-data.net
+
+ # Following category of security events
+ # can be disabled from generating.
+detection:
+  rxss:
     enabled: true
-  detection:
-    rci:
-      enabled: true
-    rxss:
-      enabled: true
-    deserialization:
-      enabled: true
 ```
+
+**Note**: To completely disable security, set `NEW_RELIC_SECURITY_AGENT_ENABLED` env to false.
 
 ## Instrument security-sensitive areas in your application
 If you are using the `nrgin`, `nrgrpc`, `nrmicro`, and/or `nrmongo` integrations, they now contain code to support security analysis of the data they handle.

--- a/v3/integrations/nrsecurityagent/go.mod
+++ b/v3/integrations/nrsecurityagent/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrsecurityagent
 go 1.18
 
 require (
-	github.com/newrelic/csec-go-agent v0.0.0-20230524143909-1aa8077d39af
+	github.com/newrelic/csec-go-agent v0.2.0
 	github.com/newrelic/go-agent/v3 v3.22.0
 	github.com/newrelic/go-agent/v3/integrations/nrsqlite3 v1.1.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/v3/integrations/nrsecurityagent/go.mod
+++ b/v3/integrations/nrsecurityagent/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrsecurityagent
 go 1.18
 
 require (
-	github.com/newrelic/csec-go-agent v0.2.0
+	github.com/newrelic/csec-go-agent v0.2.1
 	github.com/newrelic/go-agent/v3 v3.22.0
 	github.com/newrelic/go-agent/v3/integrations/nrsqlite3 v1.1.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/v3/integrations/nrsecurityagent/nrsecurityagent.go
+++ b/v3/integrations/nrsecurityagent/nrsecurityagent.go
@@ -33,6 +33,17 @@ func defaultSecurityConfig() SecurityConfig {
 	return cfg
 }
 
+// To completely disable security set NEW_RELIC_SECURITY_AGENT_ENABLED env to false.
+// If env is set to false,the security module is not loaded
+func isSecurityAgentEnabled() bool {
+	if env := os.Getenv("NEW_RELIC_SECURITY_AGENT_ENABLED"); env != "" {
+		if b, err := strconv.ParseBool("false"); nil == err {
+			return b
+		}
+	}
+	return true
+}
+
 // InitSecurityAgent initializes the nrsecurityagent integration package from user-supplied
 // configuration values.
 func InitSecurityAgent(app *newrelic.Application, opts ...ConfigOption) error {
@@ -53,8 +64,7 @@ func InitSecurityAgent(app *newrelic.Application, opts ...ConfigOption) error {
 	if !isValid {
 		return fmt.Errorf("Newrelic application value cannot be read; did you call newrelic.NewApplication?")
 	}
-
-	if !appConfig.HighSecurity {
+	if !appConfig.HighSecurity && isSecurityAgentEnabled() {
 		secureAgent := securityAgent.InitSecurityAgent(c.Security, appConfig.AppName, appConfig.License, appConfig.Logger.DebugEnabled())
 		app.RegisterSecurityAgent(secureAgent)
 	}

--- a/v3/integrations/nrsecurityagent/nrsecurityagent.go
+++ b/v3/integrations/nrsecurityagent/nrsecurityagent.go
@@ -12,7 +12,6 @@ import (
 	securityAgent "github.com/newrelic/csec-go-agent"
 	"github.com/newrelic/go-agent/v3/internal"
 	"github.com/newrelic/go-agent/v3/newrelic"
-	"gopkg.in/yaml.v2"
 )
 
 func init() { internal.TrackUsage("integration", "securityagent") }
@@ -37,7 +36,7 @@ func defaultSecurityConfig() SecurityConfig {
 // If env is set to false,the security module is not loaded
 func isSecurityAgentEnabled() bool {
 	if env := os.Getenv("NEW_RELIC_SECURITY_AGENT_ENABLED"); env != "" {
-		if b, err := strconv.ParseBool("false"); nil == err {
+		if b, err := strconv.ParseBool("false"); err == nil {
 			return b
 		}
 	}


### PR DESCRIPTION
- To completely disable security set NEW_RELIC_SECURITY_AGENT_ENABLED env to false. If the env is set to false, the security module and hooks are not loaded.
- Update default config YAML in README.md
- Updated go.mod in nrsecurityagent to point to the latest csec-go-agent version (v0.2.1)