### PR TITLE
feat: enhance serverless debug logging

### DIFF
--- a/v3/newrelic/serverless.go
+++ b/v3/newrelic/serverless.go
@@ -111,6 +111,7 @@ func (sh *serverlessHarvest) Write(arn string, writer io.Writer) {
 	if len(harvestPayloads) == 0 {
 		// The harvest may not contain any data if the serverless
 		// transaction was ignored.
+		sh.logger.Debug("go agent serverless harvest contained no payload data", nil)
 		return
 	}
 
@@ -156,5 +157,7 @@ func (sh *serverlessHarvest) Write(arn string, writer io.Writer) {
 		return
 	}
 
+	// log json data to stdout if the agent is in debug mode to help troubleshoot lambda issues
+	sh.logger.Debug(string(js), nil)
 	fmt.Fprintln(writer, string(js))
 }

--- a/v3/newrelic/serverless.go
+++ b/v3/newrelic/serverless.go
@@ -158,6 +158,6 @@ func (sh *serverlessHarvest) Write(arn string, writer io.Writer) {
 	}
 
 	// log json data to stdout if the agent is in debug mode to help troubleshoot lambda issues
-	sh.logger.Debug(string(js), nil)
+	sh.logger.Debug("harvest data: " + string(js), nil)
 	fmt.Fprintln(writer, string(js))
 }


### PR DESCRIPTION
Print the JSON payload that is generated when the go agent does a harvest in serverless mode. If the harvest contained no payload data, print a log line mentioning that.

This will help us troubleshoot serverless issues and bring us to parity with other language agents.