### PR TITLE
staged release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 3.23.0
- * Adds the nrsecurityagent integration for performing Interactive Application Security Testing (IAST) of your application.
+### Added
+ * Adds the `nrsecurityagent` integration for performing Interactive Application Security Testing (IAST) of your application.
+ * This action increments the version numbers of the following integrations:
+   * `nrgin` v1.2.0
+   * `nrgrpc` v1.4.0
+   * `nrmicro` v1.2.0
+   * `nrmongo` v1.2.0
+   * `nrsqlite3` v1.2.0
 
  To learn how to use IAST with the New Relic Go Agent, [check out our documentation](https://docs.newrelic.com/docs/iast/use-iast/).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 3.23.0
+ * Adds the nrsecurityagent integration for performing Interactive Application Security Testing (IAST) of your application.
+
+ To learn how to use IAST with the New Relic Go Agent, [check out our documentation](https://docs.newrelic.com/docs/iast/use-iast/).
+
+### Support statement
+
+ We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves (i.e., Go versions 1.19 and later are supported).
+
+ See the [Go agent EOL Policy](https://docs.newrelic.com/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.
+
+
 ## 3.22.1
  * Corrects an error in the release process for 3.22.0.
 

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -1,18 +1,7 @@
 module github.com/newrelic/go-agent/v3
-
 go 1.18
-
 require (
 	github.com/golang/protobuf v1.5.3
 	google.golang.org/grpc v1.54.0
 )
-
-require (
-	golang.org/x/net v0.8.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
-	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
-)
-
 retract v3.22.0 // release process error corrected in v3.22.1

--- a/v3/integrations/logcontext-v2/logWriter/go.mod
+++ b/v3/integrations/logcontext-v2/logWriter/go.mod
@@ -1,18 +1,6 @@
 module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/logWriter
-
 go 1.17
-
 require (
 	github.com/newrelic/go-agent/v3 v3.19.1
 	github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter v1.0.0
-)
-
-require (
-	github.com/golang/protobuf v1.4.3 // indirect
-	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
-	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
-	golang.org/x/text v0.3.0 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/grpc v1.39.0 // indirect
-	google.golang.org/protobuf v1.25.0 // indirect
 )

--- a/v3/integrations/logcontext-v2/logWriter/go.mod
+++ b/v3/integrations/logcontext-v2/logWriter/go.mod
@@ -6,3 +6,13 @@ require (
 	github.com/newrelic/go-agent/v3 v3.19.1
 	github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter v1.0.0
 )
+
+require (
+	github.com/golang/protobuf v1.4.3 // indirect
+	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
+	golang.org/x/text v0.3.0 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/grpc v1.39.0 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+)

--- a/v3/integrations/logcontext-v2/nrlogrus/go.mod
+++ b/v3/integrations/logcontext-v2/nrlogrus/go.mod
@@ -6,3 +6,13 @@ require (
 	github.com/newrelic/go-agent/v3 v3.18.0
 	github.com/sirupsen/logrus v1.8.1
 )
+
+require (
+	github.com/golang/protobuf v1.4.3 // indirect
+	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
+	golang.org/x/text v0.3.0 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/grpc v1.39.0 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+)

--- a/v3/integrations/logcontext-v2/nrlogrus/go.mod
+++ b/v3/integrations/logcontext-v2/nrlogrus/go.mod
@@ -1,18 +1,6 @@
 module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrlogrus
-
 go 1.17
-
 require (
 	github.com/newrelic/go-agent/v3 v3.18.0
 	github.com/sirupsen/logrus v1.8.1
-)
-
-require (
-	github.com/golang/protobuf v1.4.3 // indirect
-	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
-	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
-	golang.org/x/text v0.3.0 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/grpc v1.39.0 // indirect
-	google.golang.org/protobuf v1.25.0 // indirect
 )

--- a/v3/integrations/logcontext-v2/nrwriter/go.mod
+++ b/v3/integrations/logcontext-v2/nrwriter/go.mod
@@ -3,3 +3,13 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter
 go 1.17
 
 require github.com/newrelic/go-agent/v3 v3.19.1
+
+require (
+	github.com/golang/protobuf v1.4.3 // indirect
+	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
+	golang.org/x/text v0.3.0 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/grpc v1.39.0 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+)

--- a/v3/integrations/logcontext-v2/nrwriter/go.mod
+++ b/v3/integrations/logcontext-v2/nrwriter/go.mod
@@ -1,15 +1,3 @@
 module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter
-
 go 1.17
-
 require github.com/newrelic/go-agent/v3 v3.19.1
-
-require (
-	github.com/golang/protobuf v1.4.3 // indirect
-	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
-	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
-	golang.org/x/text v0.3.0 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/grpc v1.39.0 // indirect
-	google.golang.org/protobuf v1.25.0 // indirect
-)

--- a/v3/integrations/logcontext-v2/nrzap/go.mod
+++ b/v3/integrations/logcontext-v2/nrzap/go.mod
@@ -1,20 +1,6 @@
 module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrzap
-
 go 1.18
-
 require (
 	github.com/newrelic/go-agent/v3 v3.21.1
 	go.uber.org/zap v1.24.0
-)
-
-require (
-	github.com/golang/protobuf v1.5.3 // indirect
-	go.uber.org/atomic v1.7.0 // indirect
-	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/net v0.8.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
-	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
-	google.golang.org/grpc v1.54.0 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
 )

--- a/v3/integrations/logcontext-v2/nrzap/go.mod
+++ b/v3/integrations/logcontext-v2/nrzap/go.mod
@@ -6,3 +6,15 @@ require (
 	github.com/newrelic/go-agent/v3 v3.21.1
 	go.uber.org/zap v1.24.0
 )
+
+require (
+	github.com/golang/protobuf v1.5.3 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	golang.org/x/net v0.8.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/text v0.8.0 // indirect
+	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
+	google.golang.org/grpc v1.54.0 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
+)

--- a/v3/integrations/logcontext-v2/nrzerolog/go.mod
+++ b/v3/integrations/logcontext-v2/nrzerolog/go.mod
@@ -1,18 +1,6 @@
 module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrzerolog
-
 go 1.17
-
 require (
 	github.com/newrelic/go-agent/v3 v3.18.0
 	github.com/rs/zerolog v1.26.1
-)
-
-require (
-	github.com/golang/protobuf v1.4.3 // indirect
-	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
-	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
-	golang.org/x/text v0.3.6 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/grpc v1.39.0 // indirect
-	google.golang.org/protobuf v1.25.0 // indirect
 )

--- a/v3/integrations/logcontext-v2/nrzerolog/go.mod
+++ b/v3/integrations/logcontext-v2/nrzerolog/go.mod
@@ -6,3 +6,13 @@ require (
 	github.com/newrelic/go-agent/v3 v3.18.0
 	github.com/rs/zerolog v1.26.1
 )
+
+require (
+	github.com/golang/protobuf v1.4.3 // indirect
+	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
+	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/grpc v1.39.0 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+)

--- a/v3/integrations/logcontext-v2/zerologWriter/go.mod
+++ b/v3/integrations/logcontext-v2/zerologWriter/go.mod
@@ -7,3 +7,15 @@ require (
 	github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter v1.0.0
 	github.com/rs/zerolog v1.27.0
 )
+
+require (
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
+	golang.org/x/text v0.3.0 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/grpc v1.39.0 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+)

--- a/v3/integrations/logcontext-v2/zerologWriter/go.mod
+++ b/v3/integrations/logcontext-v2/zerologWriter/go.mod
@@ -1,21 +1,7 @@
 module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/zerologWriter
-
 go 1.17
-
 require (
 	github.com/newrelic/go-agent/v3 v3.19.1
 	github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter v1.0.0
 	github.com/rs/zerolog v1.27.0
-)
-
-require (
-	github.com/golang/protobuf v1.4.3 // indirect
-	github.com/mattn/go-colorable v0.1.12 // indirect
-	github.com/mattn/go-isatty v0.0.14 // indirect
-	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
-	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
-	golang.org/x/text v0.3.0 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/grpc v1.39.0 // indirect
-	google.golang.org/protobuf v1.25.0 // indirect
 )

--- a/v3/integrations/logcontext/nrlogrusplugin/go.mod
+++ b/v3/integrations/logcontext/nrlogrusplugin/go.mod
@@ -1,12 +1,9 @@
 module github.com/newrelic/go-agent/v3/integrations/logcontext/nrlogrusplugin
-
 // As of Dec 2019, the logrus go.mod file uses 1.13:
 // https://github.com/sirupsen/logrus/blob/master/go.mod
 go 1.13
-
 require (
 	github.com/newrelic/go-agent/v3 v3.17.0
 	// v1.4.0 is required for for the log.WithContext.
 	github.com/sirupsen/logrus v1.4.0
-	golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e // indirect
 )

--- a/v3/integrations/nrawssdk-v1/go.mod
+++ b/v3/integrations/nrawssdk-v1/go.mod
@@ -1,10 +1,8 @@
 module github.com/newrelic/go-agent/v3/integrations/nrawssdk-v1
-
 // As of Dec 2019, aws-sdk-go's go.mod does not specify a Go version.  1.6 is
 // the earliest version of Go tested by aws-sdk-go's CI:
 // https://github.com/aws/aws-sdk-go/blob/master/.travis.yml
 go 1.7
-
 require (
 	// v1.15.0 is the first aws-sdk-go version with module support.
 	github.com/aws/aws-sdk-go v1.34.0

--- a/v3/integrations/nrawssdk-v2/go.mod
+++ b/v3/integrations/nrawssdk-v2/go.mod
@@ -13,3 +13,29 @@ require (
 	github.com/aws/smithy-go v1.13.3
 	github.com/newrelic/go-agent/v3 v3.18.2
 )
+
+require (
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.8 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.12.19 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.16 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.22 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.16 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.13 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.17 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.16 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.16 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.16 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.11.22 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.4 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.16.18 // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
+	golang.org/x/text v0.3.0 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/grpc v1.39.0 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+)

--- a/v3/integrations/nrawssdk-v2/go.mod
+++ b/v3/integrations/nrawssdk-v2/go.mod
@@ -1,9 +1,7 @@
 module github.com/newrelic/go-agent/v3/integrations/nrawssdk-v2
-
 // As of May 2021, the aws-sdk-go-v2 go.mod file uses 1.15:
 // https://github.com/aws/aws-sdk-go-v2/blob/master/go.mod
 go 1.17
-
 require (
 	github.com/aws/aws-sdk-go-v2 v1.16.15
 	github.com/aws/aws-sdk-go-v2/config v1.17.6
@@ -12,30 +10,4 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.10
 	github.com/aws/smithy-go v1.13.3
 	github.com/newrelic/go-agent/v3 v3.18.2
-)
-
-require (
-	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.8 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.12.19 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.16 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.22 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.16 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.23 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.13 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.9 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.17 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.16 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.16 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.16 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sso v1.11.22 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.4 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.16.18 // indirect
-	github.com/golang/protobuf v1.4.3 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
-	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
-	golang.org/x/text v0.3.0 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/grpc v1.39.0 // indirect
-	google.golang.org/protobuf v1.25.0 // indirect
 )

--- a/v3/integrations/nrb3/go.mod
+++ b/v3/integrations/nrb3/go.mod
@@ -1,15 +1,3 @@
 module github.com/newrelic/go-agent/v3/integrations/nrb3
-
 go 1.19
-
 require github.com/newrelic/go-agent/v3 v3.21.1
-
-require (
-	github.com/golang/protobuf v1.5.3 // indirect
-	golang.org/x/net v0.8.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
-	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
-	google.golang.org/grpc v1.54.0 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
-)

--- a/v3/integrations/nrb3/go.mod
+++ b/v3/integrations/nrb3/go.mod
@@ -3,3 +3,13 @@ module github.com/newrelic/go-agent/v3/integrations/nrb3
 go 1.19
 
 require github.com/newrelic/go-agent/v3 v3.21.1
+
+require (
+	github.com/golang/protobuf v1.5.3 // indirect
+	golang.org/x/net v0.8.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/text v0.8.0 // indirect
+	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
+	google.golang.org/grpc v1.54.0 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
+)

--- a/v3/integrations/nrecho-v3/go.mod
+++ b/v3/integrations/nrecho-v3/go.mod
@@ -1,13 +1,10 @@
 module github.com/newrelic/go-agent/v3/integrations/nrecho-v3
-
 // 1.7 is the earliest version of Go tested by v3.1.0:
 // https://github.com/labstack/echo/blob/v3.1.0/.travis.yml
 go 1.7
-
 require (
 	// v3.1.0 is the earliest v3 version of Echo that works with modules due
 	// to the github.com/rsc/letsencrypt import of v3.0.0.
 	github.com/labstack/echo v3.1.0+incompatible
-	github.com/labstack/gommon v0.3.0 // indirect
 	github.com/newrelic/go-agent/v3 v3.17.0
 )

--- a/v3/integrations/nrecho-v4/go.mod
+++ b/v3/integrations/nrecho-v4/go.mod
@@ -8,3 +8,19 @@ require (
 	github.com/labstack/echo/v4 v4.9.0
 	github.com/newrelic/go-agent/v3 v3.18.2
 )
+
+require (
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/labstack/gommon v0.3.1 // indirect
+	github.com/mattn/go-colorable v0.1.11 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasttemplate v1.2.1 // indirect
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
+	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect
+	golang.org/x/sys v0.0.0-20211103235746-7861aae1554b // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/grpc v1.39.0 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+)

--- a/v3/integrations/nrecho-v4/go.mod
+++ b/v3/integrations/nrecho-v4/go.mod
@@ -1,26 +1,8 @@
 module github.com/newrelic/go-agent/v3/integrations/nrecho-v4
-
 // As of Jun 2022, the echo go.mod file uses 1.17:
 // https://github.com/labstack/echo/blob/master/go.mod
 go 1.17
-
 require (
 	github.com/labstack/echo/v4 v4.9.0
 	github.com/newrelic/go-agent/v3 v3.18.2
-)
-
-require (
-	github.com/golang/protobuf v1.4.3 // indirect
-	github.com/labstack/gommon v0.3.1 // indirect
-	github.com/mattn/go-colorable v0.1.11 // indirect
-	github.com/mattn/go-isatty v0.0.14 // indirect
-	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasttemplate v1.2.1 // indirect
-	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
-	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect
-	golang.org/x/sys v0.0.0-20211103235746-7861aae1554b // indirect
-	golang.org/x/text v0.3.7 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/grpc v1.39.0 // indirect
-	google.golang.org/protobuf v1.25.0 // indirect
 )

--- a/v3/integrations/nrelasticsearch-v7/go.mod
+++ b/v3/integrations/nrelasticsearch-v7/go.mod
@@ -1,9 +1,7 @@
 module github.com/newrelic/go-agent/v3/integrations/nrelasticsearch-v7
-
 // As of Jan 2020, the v7 elasticsearch go.mod uses 1.11:
 // https://github.com/elastic/go-elasticsearch/blob/7.x/go.mod
 go 1.11
-
 require (
 	github.com/elastic/go-elasticsearch/v7 v7.17.0
 	github.com/newrelic/go-agent/v3 v3.17.0

--- a/v3/integrations/nrgin/go.mod
+++ b/v3/integrations/nrgin/go.mod
@@ -1,41 +1,9 @@
 module github.com/newrelic/go-agent/v3/integrations/nrgin
-
 // As of Dec 2019, the gin go.mod file uses 1.12:
 // https://github.com/gin-gonic/gin/blob/master/go.mod
 go 1.19
-
 require (
 	github.com/gin-gonic/gin v1.9.0
 	github.com/newrelic/go-agent/v3 v3.23.0
 )
-
 replace github.com/newrelic/go-agent/v3 => ../..
-
-require (
-	github.com/bytedance/sonic v1.8.0 // indirect
-	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
-	github.com/gin-contrib/sse v0.1.0 // indirect
-	github.com/go-playground/locales v0.14.1 // indirect
-	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.11.2 // indirect
-	github.com/goccy/go-json v0.10.0 // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
-	github.com/leodido/go-urn v1.2.1 // indirect
-	github.com/mattn/go-isatty v0.0.17 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
-	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
-	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
-	github.com/ugorji/go/codec v1.2.9 // indirect
-	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
-	golang.org/x/crypto v0.5.0 // indirect
-	golang.org/x/net v0.8.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
-	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
-	google.golang.org/grpc v1.54.0 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-)

--- a/v3/integrations/nrgin/go.mod
+++ b/v3/integrations/nrgin/go.mod
@@ -2,9 +2,40 @@ module github.com/newrelic/go-agent/v3/integrations/nrgin
 
 // As of Dec 2019, the gin go.mod file uses 1.12:
 // https://github.com/gin-gonic/gin/blob/master/go.mod
-go 1.18
+go 1.19
 
 require (
 	github.com/gin-gonic/gin v1.9.0
-	github.com/newrelic/go-agent/v3 v3.22.1
+	github.com/newrelic/go-agent/v3 v3.23.0
+)
+
+replace github.com/newrelic/go-agent/v3 => ../..
+
+require (
+	github.com/bytedance/sonic v1.8.0 // indirect
+	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
+	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-playground/validator/v10 v10.11.2 // indirect
+	github.com/goccy/go-json v0.10.0 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
+	github.com/leodido/go-urn v1.2.1 // indirect
+	github.com/mattn/go-isatty v0.0.17 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
+	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+	github.com/ugorji/go/codec v1.2.9 // indirect
+	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
+	golang.org/x/crypto v0.5.0 // indirect
+	golang.org/x/net v0.8.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/text v0.8.0 // indirect
+	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
+	google.golang.org/grpc v1.54.0 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/v3/integrations/nrgorilla/go.mod
+++ b/v3/integrations/nrgorilla/go.mod
@@ -1,9 +1,7 @@
 module github.com/newrelic/go-agent/v3/integrations/nrgorilla
-
 // As of Dec 2019, the gorilla/mux go.mod file uses 1.12:
 // https://github.com/gorilla/mux/blob/master/go.mod
 go 1.12
-
 require (
 	// v1.7.0 is the earliest version of Gorilla using modules.
 	github.com/gorilla/mux v1.7.0

--- a/v3/integrations/nrgraphgophers/go.mod
+++ b/v3/integrations/nrgraphgophers/go.mod
@@ -1,9 +1,7 @@
 module github.com/newrelic/go-agent/v3/integrations/nrgraphgophers
-
 // As of Jan 2020, the graphql-go go.mod file uses 1.13:
 // https://github.com/graph-gophers/graphql-go/blob/master/go.mod
 go 1.13
-
 require (
 	// graphql-go has no tagged releases as of Jan 2020.
 	github.com/graph-gophers/graphql-go v0.0.0-20200207002730-8334863f2c8b

--- a/v3/integrations/nrgraphqlgo/example/go.mod
+++ b/v3/integrations/nrgraphqlgo/example/go.mod
@@ -1,14 +1,10 @@
 module github.com/newrelic/go-agent/v3/integrations/nrgraphqlgo/example
-
 go 1.13
-
 require (
 	github.com/graphql-go/graphql v0.7.9
 	github.com/graphql-go/graphql-go-handler v0.2.3
 	github.com/newrelic/go-agent/v3 v3.3.0
 	github.com/newrelic/go-agent/v3/integrations/nrgraphqlgo v1.0.0
 )
-
 replace github.com/newrelic/go-agent/v3 => ../../../
-
 replace github.com/newrelic/go-agent/v3/integrations/nrgraphqlgo => ../

--- a/v3/integrations/nrgraphqlgo/go.mod
+++ b/v3/integrations/nrgraphqlgo/go.mod
@@ -1,7 +1,5 @@
 module github.com/newrelic/go-agent/v3/integrations/nrgraphqlgo
-
 go 1.13
-
 require (
 	github.com/graphql-go/graphql v0.7.9
 	github.com/newrelic/go-agent/v3 v3.17.0

--- a/v3/integrations/nrgrpc/go.mod
+++ b/v3/integrations/nrgrpc/go.mod
@@ -1,12 +1,22 @@
 module github.com/newrelic/go-agent/v3/integrations/nrgrpc
 
-go 1.18
+go 1.19
 
 require (
 	// protobuf v1.3.0 is the earliest version using modules, we use v1.3.1
 	// because all dependencies were removed in this version.
 	github.com/golang/protobuf v1.5.3
-	github.com/newrelic/go-agent/v3 v3.22.1
+	github.com/newrelic/go-agent/v3 v3.23.0
 	// v1.15.0 is the earliest version of grpc using modules.
 	google.golang.org/grpc v1.54.0
+)
+
+replace github.com/newrelic/go-agent/v3 => ../..
+
+require (
+	golang.org/x/net v0.8.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/text v0.8.0 // indirect
+	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
 )

--- a/v3/integrations/nrgrpc/go.mod
+++ b/v3/integrations/nrgrpc/go.mod
@@ -1,7 +1,5 @@
 module github.com/newrelic/go-agent/v3/integrations/nrgrpc
-
 go 1.19
-
 require (
 	// protobuf v1.3.0 is the earliest version using modules, we use v1.3.1
 	// because all dependencies were removed in this version.
@@ -10,13 +8,4 @@ require (
 	// v1.15.0 is the earliest version of grpc using modules.
 	google.golang.org/grpc v1.54.0
 )
-
 replace github.com/newrelic/go-agent/v3 => ../..
-
-require (
-	golang.org/x/net v0.8.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
-	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
-)

--- a/v3/integrations/nrhttprouter/go.mod
+++ b/v3/integrations/nrhttprouter/go.mod
@@ -1,9 +1,7 @@
 module github.com/newrelic/go-agent/v3/integrations/nrhttprouter
-
 // As of Dec 2019, the httprouter go.mod file uses 1.7:
 // https://github.com/julienschmidt/httprouter/blob/master/go.mod
 go 1.7
-
 require (
 	// v1.3.0 is the earliest version of httprouter using modules.
 	github.com/julienschmidt/httprouter v1.3.0

--- a/v3/integrations/nrlambda/go.mod
+++ b/v3/integrations/nrlambda/go.mod
@@ -1,18 +1,6 @@
 module github.com/newrelic/go-agent/v3/integrations/nrlambda
-
 go 1.18
-
 require (
 	github.com/aws/aws-lambda-go v1.41.0
 	github.com/newrelic/go-agent/v3 v3.21.1
-)
-
-require (
-	github.com/golang/protobuf v1.5.3 // indirect
-	golang.org/x/net v0.8.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
-	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
-	google.golang.org/grpc v1.54.0 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
 )

--- a/v3/integrations/nrlambda/go.mod
+++ b/v3/integrations/nrlambda/go.mod
@@ -6,3 +6,13 @@ require (
 	github.com/aws/aws-lambda-go v1.41.0
 	github.com/newrelic/go-agent/v3 v3.21.1
 )
+
+require (
+	github.com/golang/protobuf v1.5.3 // indirect
+	golang.org/x/net v0.8.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/text v0.8.0 // indirect
+	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
+	google.golang.org/grpc v1.54.0 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
+)

--- a/v3/integrations/nrlogrus/go.mod
+++ b/v3/integrations/nrlogrus/go.mod
@@ -1,24 +1,10 @@
 module github.com/newrelic/go-agent/v3/integrations/nrlogrus
-
 // As of Dec 2019, the logrus go.mod file uses 1.13:
 // https://github.com/sirupsen/logrus/blob/master/go.mod
 go 1.18
-
 require (
 	github.com/newrelic/go-agent/v3 v3.21.0
 	// v1.1.0 is required for the Logger.GetLevel method, and is the earliest
 	// version of logrus using modules.
 	github.com/sirupsen/logrus v1.1.0
-)
-
-require (
-	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe // indirect
-	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
-	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
-	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
-	golang.org/x/text v0.3.3 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/grpc v1.49.0 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
 )

--- a/v3/integrations/nrlogrus/go.mod
+++ b/v3/integrations/nrlogrus/go.mod
@@ -10,3 +10,15 @@ require (
 	// version of logrus using modules.
 	github.com/sirupsen/logrus v1.1.0
 )
+
+require (
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
+	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/grpc v1.49.0 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+)

--- a/v3/integrations/nrlogxi/go.mod
+++ b/v3/integrations/nrlogxi/go.mod
@@ -9,3 +9,17 @@ require (
 	github.com/mgutz/logxi v0.0.0-20161027140823-aebf8a7d67ab
 	github.com/newrelic/go-agent/v3 v3.21.1
 )
+
+require (
+	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
+	golang.org/x/net v0.8.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/text v0.8.0 // indirect
+	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
+	google.golang.org/grpc v1.54.0 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
+)

--- a/v3/integrations/nrlogxi/go.mod
+++ b/v3/integrations/nrlogxi/go.mod
@@ -1,25 +1,9 @@
 module github.com/newrelic/go-agent/v3/integrations/nrlogxi
-
 // As of Dec 2019, logxi requires 1.3+:
 // https://github.com/mgutz/logxi#requirements
 go 1.18
-
 require (
 	// 'v1', at commit aebf8a7d67ab, is the only logxi release.
 	github.com/mgutz/logxi v0.0.0-20161027140823-aebf8a7d67ab
 	github.com/newrelic/go-agent/v3 v3.21.1
-)
-
-require (
-	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.19 // indirect
-	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
-	github.com/stretchr/testify v1.8.4 // indirect
-	golang.org/x/net v0.8.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
-	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
-	google.golang.org/grpc v1.54.0 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
 )

--- a/v3/integrations/nrmicro/go.mod
+++ b/v3/integrations/nrmicro/go.mod
@@ -1,56 +1,10 @@
 module github.com/newrelic/go-agent/v3/integrations/nrmicro
-
 // As of Dec 2019, the go-micro go.mod file uses 1.13:
 // https://github.com/micro/go-micro/blob/master/go.mod
 go 1.19
-
 require (
 	github.com/golang/protobuf v1.5.3
 	github.com/micro/go-micro v1.8.0
 	github.com/newrelic/go-agent/v3 v3.23.0
 )
-
 replace github.com/newrelic/go-agent/v3 => ../..
-
-require (
-	github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878 // indirect
-	github.com/go-log/log v0.1.0 // indirect
-	github.com/google/btree v1.0.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
-	github.com/hashicorp/consul/api v1.1.0 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
-	github.com/hashicorp/go-immutable-radix v1.1.0 // indirect
-	github.com/hashicorp/go-msgpack v0.5.5 // indirect
-	github.com/hashicorp/go-multierror v1.0.0 // indirect
-	github.com/hashicorp/go-rootcerts v1.0.1 // indirect
-	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
-	github.com/hashicorp/golang-lru v0.5.1 // indirect
-	github.com/hashicorp/memberlist v0.1.4 // indirect
-	github.com/hashicorp/serf v0.8.3 // indirect
-	github.com/json-iterator/go v1.1.6 // indirect
-	github.com/klauspost/compress v1.16.5 // indirect
-	github.com/micro/cli v0.2.0 // indirect
-	github.com/micro/mdns v0.1.1-0.20190729112526-ef68c9635478 // indirect
-	github.com/miekg/dns v1.1.15 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mitchellh/hashstructure v1.0.0 // indirect
-	github.com/mitchellh/mapstructure v1.1.2 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/nats-io/nats-server/v2 v2.9.18 // indirect
-	github.com/nats-io/nats.go v1.27.0 // indirect
-	github.com/nats-io/nkeys v0.4.4 // indirect
-	github.com/nats-io/nuid v1.0.1 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
-	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
-	golang.org/x/crypto v0.9.0 // indirect
-	golang.org/x/net v0.10.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.8.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19 // indirect
-	google.golang.org/grpc v1.54.0 // indirect
-	google.golang.org/grpc/examples v0.0.0-20230612212144-642dd63a8527 // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
-)

--- a/v3/integrations/nrmicro/go.mod
+++ b/v3/integrations/nrmicro/go.mod
@@ -2,11 +2,55 @@ module github.com/newrelic/go-agent/v3/integrations/nrmicro
 
 // As of Dec 2019, the go-micro go.mod file uses 1.13:
 // https://github.com/micro/go-micro/blob/master/go.mod
-go 1.18
+go 1.19
 
 require (
 	github.com/golang/protobuf v1.5.3
 	github.com/micro/go-micro v1.8.0
-	github.com/newrelic/go-agent/v3 v3.22.0
+	github.com/newrelic/go-agent/v3 v3.23.0
 )
 
+replace github.com/newrelic/go-agent/v3 => ../..
+
+require (
+	github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878 // indirect
+	github.com/go-log/log v0.1.0 // indirect
+	github.com/google/btree v1.0.0 // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/hashicorp/consul/api v1.1.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
+	github.com/hashicorp/go-immutable-radix v1.1.0 // indirect
+	github.com/hashicorp/go-msgpack v0.5.5 // indirect
+	github.com/hashicorp/go-multierror v1.0.0 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.1 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
+	github.com/hashicorp/memberlist v0.1.4 // indirect
+	github.com/hashicorp/serf v0.8.3 // indirect
+	github.com/json-iterator/go v1.1.6 // indirect
+	github.com/klauspost/compress v1.16.5 // indirect
+	github.com/micro/cli v0.2.0 // indirect
+	github.com/micro/mdns v0.1.1-0.20190729112526-ef68c9635478 // indirect
+	github.com/miekg/dns v1.1.15 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/hashstructure v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/nats-io/nats-server/v2 v2.9.18 // indirect
+	github.com/nats-io/nats.go v1.27.0 // indirect
+	github.com/nats-io/nkeys v0.4.4 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
+	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
+	golang.org/x/crypto v0.9.0 // indirect
+	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19 // indirect
+	google.golang.org/grpc v1.54.0 // indirect
+	google.golang.org/grpc/examples v0.0.0-20230612212144-642dd63a8527 // indirect
+	google.golang.org/protobuf v1.30.0 // indirect
+)

--- a/v3/integrations/nrmongo/go.mod
+++ b/v3/integrations/nrmongo/go.mod
@@ -1,33 +1,10 @@
 module github.com/newrelic/go-agent/v3/integrations/nrmongo
-
 // As of Dec 2019, 1.10 is the mongo-driver requirement:
 // https://github.com/mongodb/mongo-go-driver#requirements
 go 1.19
-
 require (
 	github.com/newrelic/go-agent/v3 v3.23.0
 	// mongo-driver does not support modules as of Nov 2019.
 	go.mongodb.org/mongo-driver v1.10.2
 )
-
 replace github.com/newrelic/go-agent/v3 => ../..
-
-require (
-	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/golang/snappy v0.0.1 // indirect
-	github.com/klauspost/compress v1.13.6 // indirect
-	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
-	github.com/xdg-go/scram v1.1.1 // indirect
-	github.com/xdg-go/stringprep v1.0.3 // indirect
-	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
-	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
-	golang.org/x/net v0.8.0 // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
-	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
-	google.golang.org/grpc v1.54.0 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
-)

--- a/v3/integrations/nrmongo/go.mod
+++ b/v3/integrations/nrmongo/go.mod
@@ -2,11 +2,32 @@ module github.com/newrelic/go-agent/v3/integrations/nrmongo
 
 // As of Dec 2019, 1.10 is the mongo-driver requirement:
 // https://github.com/mongodb/mongo-go-driver#requirements
-go 1.18
+go 1.19
 
 require (
-	github.com/newrelic/go-agent/v3 v3.22.1
+	github.com/newrelic/go-agent/v3 v3.23.0
 	// mongo-driver does not support modules as of Nov 2019.
 	go.mongodb.org/mongo-driver v1.10.2
 )
 
+replace github.com/newrelic/go-agent/v3 => ../..
+
+require (
+	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/klauspost/compress v1.13.6 // indirect
+	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.1.1 // indirect
+	github.com/xdg-go/stringprep v1.0.3 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
+	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
+	golang.org/x/net v0.8.0 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/text v0.8.0 // indirect
+	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
+	google.golang.org/grpc v1.54.0 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
+)

--- a/v3/integrations/nrmssql/go.mod
+++ b/v3/integrations/nrmssql/go.mod
@@ -6,3 +6,16 @@ require (
 	github.com/microsoft/go-mssqldb v0.19.0
 	github.com/newrelic/go-agent/v3 v3.16.1
 )
+
+require (
+	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
+	github.com/golang-sql/sqlexp v0.1.0 // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
+	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
+	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
+	golang.org/x/sys v0.0.0-20220224120231-95c6836cb0e7 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/grpc v1.39.0 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+)

--- a/v3/integrations/nrmssql/go.mod
+++ b/v3/integrations/nrmssql/go.mod
@@ -1,21 +1,6 @@
 module github.com/newrelic/go-agent/v3/integrations/nrmssql
-
 go 1.17
-
 require (
 	github.com/microsoft/go-mssqldb v0.19.0
 	github.com/newrelic/go-agent/v3 v3.16.1
-)
-
-require (
-	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
-	github.com/golang-sql/sqlexp v0.1.0 // indirect
-	github.com/golang/protobuf v1.4.3 // indirect
-	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
-	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
-	golang.org/x/sys v0.0.0-20220224120231-95c6836cb0e7 // indirect
-	golang.org/x/text v0.3.7 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/grpc v1.39.0 // indirect
-	google.golang.org/protobuf v1.25.0 // indirect
 )

--- a/v3/integrations/nrmysql/go.mod
+++ b/v3/integrations/nrmysql/go.mod
@@ -9,3 +9,13 @@ require (
 	// v3.3.0 includes the new location of ParseQuery
 	github.com/newrelic/go-agent/v3 v3.18.2
 )
+
+require (
+	github.com/golang/protobuf v1.4.3 // indirect
+	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
+	golang.org/x/text v0.3.0 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/grpc v1.39.0 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+)

--- a/v3/integrations/nrmysql/go.mod
+++ b/v3/integrations/nrmysql/go.mod
@@ -1,21 +1,9 @@
 module github.com/newrelic/go-agent/v3/integrations/nrmysql
-
 // 1.10 is the Go version in mysql's go.mod
 go 1.17
-
 require (
 	// v1.5.0 is the first mysql version to support gomod
 	github.com/go-sql-driver/mysql v1.6.0
 	// v3.3.0 includes the new location of ParseQuery
 	github.com/newrelic/go-agent/v3 v3.18.2
-)
-
-require (
-	github.com/golang/protobuf v1.4.3 // indirect
-	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
-	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
-	golang.org/x/text v0.3.0 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/grpc v1.39.0 // indirect
-	google.golang.org/protobuf v1.25.0 // indirect
 )

--- a/v3/integrations/nrnats/go.mod
+++ b/v3/integrations/nrnats/go.mod
@@ -1,27 +1,9 @@
 module github.com/newrelic/go-agent/v3/integrations/nrnats
-
 // As of Dec 2019, 1.11 is the earliest version of Go tested by nats:
 // https://github.com/nats-io/nats.go/blob/master/.travis.yml
 go 1.18
-
 require (
 	github.com/nats-io/nats-server v1.4.1
 	github.com/nats-io/nats.go v1.25.0
 	github.com/newrelic/go-agent/v3 v3.21.0
-)
-
-require (
-	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/nats-io/gnatsd v1.4.1 // indirect
-	github.com/nats-io/go-nats v1.7.2 // indirect
-	github.com/nats-io/nats-server/v2 v2.9.17 // indirect
-	github.com/nats-io/nkeys v0.4.4 // indirect
-	github.com/nats-io/nuid v1.0.1 // indirect
-	golang.org/x/crypto v0.8.0 // indirect
-	golang.org/x/net v0.9.0 // indirect
-	golang.org/x/sys v0.7.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/grpc v1.49.0 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
 )

--- a/v3/integrations/nrnats/test/go.mod
+++ b/v3/integrations/nrnats/test/go.mod
@@ -1,13 +1,8 @@
 module github.com/newrelic/go-agent/v3/integrations/test
-
 // This module exists to avoid having extra nrnats module dependencies.
-
 go 1.17
-
 replace github.com/newrelic/go-agent/v3/integrations/nrnats v1.0.0 => ../
-
 replace github.com/newrelic/go-agent/v3 v3.18.2 => ../../../
-
 require (
 	github.com/nats-io/nats-server v1.4.1
 	github.com/nats-io/nats.go v1.17.0

--- a/v3/integrations/nrpgx/example/sqlx/go.mod
+++ b/v3/integrations/nrpgx/example/sqlx/go.mod
@@ -1,17 +1,11 @@
 // This sqlx example is a separate module to avoid adding sqlx dependency to the
 // nrpgx go.mod file.
-
 module github.com/newrelic/go-agent/v3/integrations/nrpgx/example/sqlx
-
 go 1.13
-
 require (
-	github.com/jackc/fake v0.0.0-20150926172116-812a484cc733 // indirect
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/newrelic/go-agent/v3 v3.3.0
 	github.com/newrelic/go-agent/v3/integrations/nrpgx v0.0.0
 )
-
 replace github.com/newrelic/go-agent/v3 => ../../../../
-
 replace github.com/newrelic/go-agent/v3/integrations/nrpgx => ../../

--- a/v3/integrations/nrpgx/go.mod
+++ b/v3/integrations/nrpgx/go.mod
@@ -9,3 +9,17 @@ require (
 	github.com/jackc/pgx/v4 v4.13.0
 	github.com/newrelic/go-agent/v3 v3.3.0
 )
+
+require (
+	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
+	github.com/jackc/fake v0.0.0-20150926172116-812a484cc733 // indirect
+	github.com/jackc/pgconn v1.10.0 // indirect
+	github.com/jackc/pgio v1.0.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgproto3/v2 v2.1.1 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
+	github.com/jackc/pgtype v1.8.1 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
+	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
+	golang.org/x/text v0.3.6 // indirect
+)

--- a/v3/integrations/nrpgx/go.mod
+++ b/v3/integrations/nrpgx/go.mod
@@ -1,25 +1,9 @@
 module github.com/newrelic/go-agent/v3/integrations/nrpgx
-
 // As of Dec 2019, go 1.11 is the earliest version of Go tested by lib/pq:
 // https://github.com/lib/pq/blob/master/.travis.yml
 go 1.18
-
 require (
 	github.com/jackc/pgx v3.6.2+incompatible
 	github.com/jackc/pgx/v4 v4.13.0
 	github.com/newrelic/go-agent/v3 v3.3.0
-)
-
-require (
-	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/fake v0.0.0-20150926172116-812a484cc733 // indirect
-	github.com/jackc/pgconn v1.10.0 // indirect
-	github.com/jackc/pgio v1.0.0 // indirect
-	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.1.1 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
-	github.com/jackc/pgtype v1.8.1 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
-	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
-	golang.org/x/text v0.3.6 // indirect
 )

--- a/v3/integrations/nrpgx5/go.mod
+++ b/v3/integrations/nrpgx5/go.mod
@@ -1,35 +1,8 @@
 module github.com/newrelic/go-agent/v3/integrations/nrpgx5
-
 go 1.18
-
 require (
 	github.com/egon12/pgsnap v0.0.0-20221022154027-2847f0124ed8
 	github.com/jackc/pgx/v5 v5.0.3
 	github.com/newrelic/go-agent/v3 v3.20.0
 	github.com/stretchr/testify v1.8.0
-)
-
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgconn v1.10.0 // indirect
-	github.com/jackc/pgio v1.0.0 // indirect
-	github.com/jackc/pgmock v0.0.0-20210724152146-4ad1a8207f65 // indirect
-	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.1.1 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
-	github.com/jackc/pgtype v1.8.1 // indirect
-	github.com/jackc/pgx/v4 v4.13.0 // indirect
-	github.com/jackc/puddle/v2 v2.0.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rogpeppe/go-internal v1.10.0 // indirect
-	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
-	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
-	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
-	golang.org/x/text v0.3.7 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/grpc v1.49.0 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/v3/integrations/nrpgx5/go.mod
+++ b/v3/integrations/nrpgx5/go.mod
@@ -8,3 +8,28 @@ require (
 	github.com/newrelic/go-agent/v3 v3.20.0
 	github.com/stretchr/testify v1.8.0
 )
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
+	github.com/jackc/pgconn v1.10.0 // indirect
+	github.com/jackc/pgio v1.0.0 // indirect
+	github.com/jackc/pgmock v0.0.0-20210724152146-4ad1a8207f65 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgproto3/v2 v2.1.1 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
+	github.com/jackc/pgtype v1.8.1 // indirect
+	github.com/jackc/pgx/v4 v4.13.0 // indirect
+	github.com/jackc/puddle/v2 v2.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rogpeppe/go-internal v1.10.0 // indirect
+	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/grpc v1.49.0 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/v3/integrations/nrpkgerrors/go.mod
+++ b/v3/integrations/nrpkgerrors/go.mod
@@ -1,9 +1,7 @@
 module github.com/newrelic/go-agent/v3/integrations/nrpkgerrors
-
 // As of Dec 2019, 1.11 is the earliest version of Go tested by pkg/errors:
 // https://github.com/pkg/errors/blob/master/.travis.yml
 go 1.11
-
 require (
 	github.com/newrelic/go-agent/v3 v3.0.0
 	// v0.8.0 was the last release in 2016, and when

--- a/v3/integrations/nrpq/example/sqlx/go.mod
+++ b/v3/integrations/nrpq/example/sqlx/go.mod
@@ -1,17 +1,12 @@
 // This sqlx example is a separate module to avoid adding sqlx dependency to the
 // nrpq go.mod file.
-
 module github.com/newrelic/go-agent/v3/integrations/nrpq/example/sqlx
-
 go 1.13
-
 require (
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.1.0
 	github.com/newrelic/go-agent/v3 v3.3.0
 	github.com/newrelic/go-agent/v3/integrations/nrpq v0.0.0
 )
-
 replace github.com/newrelic/go-agent/v3 => ../../../../
-
 replace github.com/newrelic/go-agent/v3/integrations/nrpq => ../../

--- a/v3/integrations/nrpq/go.mod
+++ b/v3/integrations/nrpq/go.mod
@@ -1,9 +1,7 @@
 module github.com/newrelic/go-agent/v3/integrations/nrpq
-
 // As of Dec 2019, go 1.11 is the earliest version of Go tested by lib/pq:
 // https://github.com/lib/pq/blob/master/.travis.yml
 go 1.11
-
 require (
 	// NewConnector dsn parsing tests expect v1.1.0 error return behavior.
 	github.com/lib/pq v1.1.0

--- a/v3/integrations/nrredis-v7/go.mod
+++ b/v3/integrations/nrredis-v7/go.mod
@@ -1,9 +1,7 @@
 module github.com/newrelic/go-agent/v3/integrations/nrredis-v7
-
 // As of Jan 2020, go 1.11 is in the go-redis go.mod file:
 // https://github.com/go-redis/redis/blob/master/go.mod
 go 1.11
-
 require (
 	github.com/go-redis/redis/v7 v7.0.0-beta.5
 	github.com/newrelic/go-agent/v3 v3.17.0

--- a/v3/integrations/nrredis-v8/go.mod
+++ b/v3/integrations/nrredis-v8/go.mod
@@ -1,9 +1,7 @@
 module github.com/newrelic/go-agent/v3/integrations/nrredis-v8
-
 // As of Jan 2020, go 1.11 is in the go-redis go.mod file:
 // https://github.com/go-redis/redis/blob/master/go.mod
 go 1.11
-
 require (
 	github.com/go-redis/redis/v8 v8.4.0
 	github.com/newrelic/go-agent/v3 v3.0.0

--- a/v3/integrations/nrredis-v9/go.mod
+++ b/v3/integrations/nrredis-v9/go.mod
@@ -8,3 +8,15 @@ require (
 	github.com/newrelic/go-agent/v3 v3.20.4
 	github.com/redis/go-redis/v9 v9.0.2
 )
+
+require (
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
+	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/grpc v1.49.0 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+)

--- a/v3/integrations/nrredis-v9/go.mod
+++ b/v3/integrations/nrredis-v9/go.mod
@@ -1,22 +1,8 @@
 module github.com/newrelic/go-agent/v3/integrations/nrredis-v9
-
 // As of Mar 2023, go 1.17 is in the go-redis go.mod file:
 // https://github.com/redis/go-redis/blob/a38f75b640398bd709ee46c778a23e80e09d48b5/go.mod#L3
 go 1.17
-
 require (
 	github.com/newrelic/go-agent/v3 v3.20.4
 	github.com/redis/go-redis/v9 v9.0.2
-)
-
-require (
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
-	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
-	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
-	golang.org/x/text v0.3.3 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/grpc v1.49.0 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
 )

--- a/v3/integrations/nrsarama/go.mod
+++ b/v3/integrations/nrsarama/go.mod
@@ -1,41 +1,7 @@
 module github.com/newrelic/go-agent/v3/integrations/nrsarama
-
 go 1.19
-
 require (
 	github.com/Shopify/sarama v1.38.1
 	github.com/newrelic/go-agent/v3 v3.21.1
 	github.com/stretchr/testify v1.8.1
-)
-
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/eapache/go-resiliency v1.3.0 // indirect
-	github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6 // indirect
-	github.com/eapache/queue v1.1.0 // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/golang/snappy v0.0.4 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/go-uuid v1.0.3 // indirect
-	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
-	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
-	github.com/jcmturner/gofork v1.7.6 // indirect
-	github.com/jcmturner/gokrb5/v8 v8.4.3 // indirect
-	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
-	github.com/klauspost/compress v1.15.14 // indirect
-	github.com/kr/text v0.2.0 // indirect
-	github.com/pierrec/lz4/v4 v4.1.17 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
-	github.com/rogpeppe/go-internal v1.10.0 // indirect
-	github.com/stretchr/objx v0.5.0 // indirect
-	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
-	golang.org/x/net v0.8.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
-	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
-	google.golang.org/grpc v1.54.0 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/v3/integrations/nrsecurityagent/README.md
+++ b/v3/integrations/nrsecurityagent/README.md
@@ -4,18 +4,10 @@ The New Relic security agent analyzes your application for potentially exploitab
 
 **DO NOT** use this integration in your production environment. It is intended only for use in your development and testing phases. Since it will attempt to actually find and exploit vulnerabilities in your code, it may cause data loss or crash the application. Therefore it should only be used with test data in a non-production environment that does not connect to any production services.
 
-# Special Note for this Preview Version
-**Please read the following carefully before proceeding.**
 
-This is not yet publicly released on github, so you will need to add a `replace` statement to your application's `go.mod` file to point the go toolchain to the location where you downloaded and unpacked the preview version of this integration and the agent. At minimum:
-```
-replace (
-    github.com/newrelic/go-agent/v3/integrations/nrsecurityagent => {YOUR_PATH}/go-agent/v3/integrations/nrsecurityagent
-    github.com/newrelic/go-agent/v3 => {YOUR_PATH}/go-agent/v3
-    github.com/newrelic/csec-go-agent => {YOUR_PATH}/csec-go-agent
-)
-```
-Additionally, add `replace` lines for each integration you are using so they are taken from the preview version of the agent and not downloaded from the latest public release.
+## Learn More About IAST
+
+ To learn how to use IAST with the New Relic Go Agent, [check out our documentation](https://docs.newrelic.com/docs/iast/use-iast/).
 
 ## Setup Instructions
 
@@ -55,7 +47,7 @@ enabled: true
 mode: IAST
 
  # New Relic’s SaaS connection URLs
-validator_service_url: wss://csec-staging.nr-data.net
+validator_service_url: wss://csec.nr-data.net
 
  # Following category of security events
  # can be disabled from generating.
@@ -67,7 +59,7 @@ detection:
 * Based on additional packages imported by the user application, add suitable instrumentation package imports. 
   For more information, see https://github.com/newrelic/csec-go-agent#instrumentation-packages
 
-**Note**: To completely disable security, set `NEW_RELIC_SECURITY_AGENT_ENABLED` env to false.
+**Note**: To completely disable security, set `NEW_RELIC_SECURITY_AGENT_ENABLED` env to false. (Otherwise, there are some security hooks will already be in place before any of the other configuration settings can be taken into account. This environment variable setting will prevent that from happening.)
 
 ## Instrument security-sensitive areas in your application
 If you are using the `nrgin`, `nrgrpc`, `nrmicro`, and/or `nrmongo` integrations, they now contain code to support security analysis of the data they handle.
@@ -84,4 +76,3 @@ Generate traffic against your application for the IAST agent to detect vulnerabi
 
 For more information, see
 [godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrsecurityagent).
-**(note that link will only be live once this feature is fully released to the public)**

--- a/v3/integrations/nrsecurityagent/README.md
+++ b/v3/integrations/nrsecurityagent/README.md
@@ -59,7 +59,7 @@ detection:
 * Based on additional packages imported by the user application, add suitable instrumentation package imports. 
   For more information, see https://github.com/newrelic/csec-go-agent#instrumentation-packages
 
-**Note**: To completely disable security, set `NEW_RELIC_SECURITY_AGENT_ENABLED` env to false. (Otherwise, there are some security hooks will already be in place before any of the other configuration settings can be taken into account. This environment variable setting will prevent that from happening.)
+**Note**: To completely disable security, set `NEW_RELIC_SECURITY_AGENT_ENABLED` env to false. (Otherwise, there are some security hooks that will already be in place before any of the other configuration settings can be taken into account. This environment variable setting will prevent that from happening.)
 
 ## Instrument security-sensitive areas in your application
 If you are using the `nrgin`, `nrgrpc`, `nrmicro`, and/or `nrmongo` integrations, they now contain code to support security analysis of the data they handle.

--- a/v3/integrations/nrsecurityagent/example/example.go
+++ b/v3/integrations/nrsecurityagent/example/example.go
@@ -80,10 +80,6 @@ func main() {
 		newrelic.ConfigAppLogForwardingEnabled(true),
 		newrelic.ConfigCodeLevelMetricsEnabled(true),
 		newrelic.ConfigCodeLevelMetricsPathPrefix("go-agent/v3"),
-		func(config *newrelic.Config) {
-			config.Host = "staging-collector.newrelic.com"
-
-		},
 	)
 	if err != nil {
 		fmt.Println(err)

--- a/v3/integrations/nrsecurityagent/go.mod
+++ b/v3/integrations/nrsecurityagent/go.mod
@@ -1,11 +1,33 @@
 module github.com/newrelic/go-agent/v3/integrations/nrsecurityagent
 
-go 1.18
+go 1.19
 
 require (
 	github.com/newrelic/csec-go-agent v0.2.1
-	github.com/newrelic/go-agent/v3 v3.22.0
+	github.com/newrelic/go-agent/v3 v3.23.0
 	github.com/newrelic/go-agent/v3/integrations/nrsqlite3 v1.1.1
 	gopkg.in/yaml.v2 v2.4.0
 )
 
+replace github.com/newrelic/go-agent/v3 => ../..
+
+require (
+	github.com/dlclark/regexp2 v1.9.0 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b // indirect
+	github.com/k2io/hookingo v1.0.3 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
+	github.com/mackerelio/go-osstat v0.2.4 // indirect
+	github.com/mattn/go-sqlite3 v1.0.0 // indirect
+	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
+	github.com/sirupsen/logrus v1.9.0 // indirect
+	github.com/struCoder/pidusage v0.2.1 // indirect
+	golang.org/x/arch v0.3.0 // indirect
+	golang.org/x/net v0.8.0 // indirect
+	golang.org/x/sys v0.7.0 // indirect
+	golang.org/x/text v0.8.0 // indirect
+	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
+	google.golang.org/grpc v1.54.0 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
+)

--- a/v3/integrations/nrsecurityagent/go.mod
+++ b/v3/integrations/nrsecurityagent/go.mod
@@ -1,9 +1,12 @@
 module github.com/newrelic/go-agent/v3/integrations/nrsecurityagent
+
 go 1.19
+
 require (
 	github.com/newrelic/csec-go-agent v0.2.1
 	github.com/newrelic/go-agent/v3 v3.23.0
-	github.com/newrelic/go-agent/v3/integrations/nrsqlite3 v1.1.1
+	github.com/newrelic/go-agent/v3/integrations/nrsqlite3 v1.2.0
 	gopkg.in/yaml.v2 v2.4.0
 )
+
 replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nrsecurityagent/go.mod
+++ b/v3/integrations/nrsecurityagent/go.mod
@@ -1,33 +1,9 @@
 module github.com/newrelic/go-agent/v3/integrations/nrsecurityagent
-
 go 1.19
-
 require (
 	github.com/newrelic/csec-go-agent v0.2.1
 	github.com/newrelic/go-agent/v3 v3.23.0
 	github.com/newrelic/go-agent/v3/integrations/nrsqlite3 v1.1.1
 	gopkg.in/yaml.v2 v2.4.0
 )
-
 replace github.com/newrelic/go-agent/v3 => ../..
-
-require (
-	github.com/dlclark/regexp2 v1.9.0 // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/gorilla/websocket v1.5.0 // indirect
-	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b // indirect
-	github.com/k2io/hookingo v1.0.3 // indirect
-	github.com/kr/pretty v0.3.1 // indirect
-	github.com/mackerelio/go-osstat v0.2.4 // indirect
-	github.com/mattn/go-sqlite3 v1.0.0 // indirect
-	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
-	github.com/sirupsen/logrus v1.9.0 // indirect
-	github.com/struCoder/pidusage v0.2.1 // indirect
-	golang.org/x/arch v0.3.0 // indirect
-	golang.org/x/net v0.8.0 // indirect
-	golang.org/x/sys v0.7.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
-	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
-	google.golang.org/grpc v1.54.0 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
-)

--- a/v3/integrations/nrsnowflake/go.mod
+++ b/v3/integrations/nrsnowflake/go.mod
@@ -6,3 +6,49 @@ require (
 	github.com/newrelic/go-agent/v3 v3.20.2
 	github.com/snowflakedb/gosnowflake v1.6.16
 )
+
+require (
+	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
+	github.com/99designs/keyring v1.2.1 // indirect
+	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
+	github.com/Azure/azure-storage-blob-go v0.15.0 // indirect
+	github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.16.16 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.8 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.12.20 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.33 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.17 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.14 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.18 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.17 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.17 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.11 // indirect
+	github.com/aws/smithy-go v1.13.3 // indirect
+	github.com/danieljoos/wincred v1.1.2 // indirect
+	github.com/dvsekhvalnov/jose2go v1.5.0 // indirect
+	github.com/form3tech-oss/jwt-go v3.2.5+incompatible // indirect
+	github.com/gabriel-vasile/mimetype v1.4.1 // indirect
+	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/flatbuffers v2.0.8+incompatible // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/klauspost/compress v1.15.11 // indirect
+	github.com/mattn/go-ieproxy v0.0.1 // indirect
+	github.com/mtibben/percent v0.2.1 // indirect
+	github.com/pierrec/lz4/v4 v4.1.16 // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
+	github.com/sirupsen/logrus v1.9.0 // indirect
+	golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be // indirect
+	golang.org/x/net v0.0.0-20221002022538-bcab6841153b // indirect
+	golang.org/x/sys v0.0.0-20220926163933-8cfa568d3c25 // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
+	google.golang.org/genproto v0.0.0-20210630183607-d20f26d13c79 // indirect
+	google.golang.org/grpc v1.49.0 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+)

--- a/v3/integrations/nrsnowflake/go.mod
+++ b/v3/integrations/nrsnowflake/go.mod
@@ -1,54 +1,6 @@
 module github.com/newrelic/go-agent/v3/integrations/nrsnowflake
-
 go 1.17
-
 require (
 	github.com/newrelic/go-agent/v3 v3.20.2
 	github.com/snowflakedb/gosnowflake v1.6.16
-)
-
-require (
-	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
-	github.com/99designs/keyring v1.2.1 // indirect
-	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
-	github.com/Azure/azure-storage-blob-go v0.15.0 // indirect
-	github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.16.16 // indirect
-	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.8 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.12.20 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.33 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.23 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.17 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.14 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.9 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.18 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.17 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.17 // indirect
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.11 // indirect
-	github.com/aws/smithy-go v1.13.3 // indirect
-	github.com/danieljoos/wincred v1.1.2 // indirect
-	github.com/dvsekhvalnov/jose2go v1.5.0 // indirect
-	github.com/form3tech-oss/jwt-go v3.2.5+incompatible // indirect
-	github.com/gabriel-vasile/mimetype v1.4.1 // indirect
-	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/flatbuffers v2.0.8+incompatible // indirect
-	github.com/google/uuid v1.3.0 // indirect
-	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/klauspost/compress v1.15.11 // indirect
-	github.com/mattn/go-ieproxy v0.0.1 // indirect
-	github.com/mtibben/percent v0.2.1 // indirect
-	github.com/pierrec/lz4/v4 v4.1.16 // indirect
-	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
-	github.com/sirupsen/logrus v1.9.0 // indirect
-	golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be // indirect
-	golang.org/x/net v0.0.0-20221002022538-bcab6841153b // indirect
-	golang.org/x/sys v0.0.0-20220926163933-8cfa568d3c25 // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
-	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
-	google.golang.org/genproto v0.0.0-20210630183607-d20f26d13c79 // indirect
-	google.golang.org/grpc v1.49.0 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
 )

--- a/v3/integrations/nrsqlite3/go.mod
+++ b/v3/integrations/nrsqlite3/go.mod
@@ -1,9 +1,7 @@
 module github.com/newrelic/go-agent/v3/integrations/nrsqlite3
-
 // As of Dec 2019, 1.9 is the oldest version of Go tested by go-sqlite3:
 // https://github.com/mattn/go-sqlite3/blob/master/.travis.yml
 go 1.9
-
 require (
 	github.com/mattn/go-sqlite3 v1.0.0
 	// v3.3.0 includes the new location of ParseQuery

--- a/v3/integrations/nrstan/examples/go.mod
+++ b/v3/integrations/nrstan/examples/go.mod
@@ -1,18 +1,12 @@
 module github.com/newrelic/go-agent/v3/integrations/nrstan/examples
-
 // This module exists to avoid a dependency on nrnrats.
-
 go 1.13
-
 require (
 	github.com/nats-io/stan.go v0.5.0
 	github.com/newrelic/go-agent/v3 v3.4.0
 	github.com/newrelic/go-agent/v3/integrations/nrnats v0.0.0
 	github.com/newrelic/go-agent/v3/integrations/nrstan v0.0.0
 )
-
 replace github.com/newrelic/go-agent/v3 => ../../../
-
 replace github.com/newrelic/go-agent/v3/integrations/nrstan => ../
-
 replace github.com/newrelic/go-agent/v3/integrations/nrnats => ../../nrnats/

--- a/v3/integrations/nrstan/go.mod
+++ b/v3/integrations/nrstan/go.mod
@@ -1,28 +1,8 @@
 module github.com/newrelic/go-agent/v3/integrations/nrstan
-
 // As of Dec 2019, 1.11 is the earliest Go version tested by Stan:
 // https://github.com/nats-io/stan.go/blob/master/.travis.yml
 go 1.18
-
 require (
 	github.com/nats-io/stan.go v0.10.4
 	github.com/newrelic/go-agent/v3 v3.21.1
-)
-
-require (
-	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/klauspost/compress v1.16.5 // indirect
-	github.com/nats-io/nats-server/v2 v2.9.18 // indirect
-	github.com/nats-io/nats-streaming-server v0.25.4 // indirect
-	github.com/nats-io/nats.go v1.27.0 // indirect
-	github.com/nats-io/nkeys v0.4.4 // indirect
-	github.com/nats-io/nuid v1.0.1 // indirect
-	golang.org/x/crypto v0.9.0 // indirect
-	golang.org/x/net v0.10.0 // indirect
-	golang.org/x/sys v0.8.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
-	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
-	google.golang.org/grpc v1.54.0 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
 )

--- a/v3/integrations/nrstan/go.mod
+++ b/v3/integrations/nrstan/go.mod
@@ -8,3 +8,21 @@ require (
 	github.com/nats-io/stan.go v0.10.4
 	github.com/newrelic/go-agent/v3 v3.21.1
 )
+
+require (
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/klauspost/compress v1.16.5 // indirect
+	github.com/nats-io/nats-server/v2 v2.9.18 // indirect
+	github.com/nats-io/nats-streaming-server v0.25.4 // indirect
+	github.com/nats-io/nats.go v1.27.0 // indirect
+	github.com/nats-io/nkeys v0.4.4 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
+	golang.org/x/crypto v0.9.0 // indirect
+	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
+	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
+	google.golang.org/grpc v1.54.0 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
+)

--- a/v3/integrations/nrstan/test/go.mod
+++ b/v3/integrations/nrstan/test/go.mod
@@ -1,17 +1,12 @@
 module github.com/newrelic/go-agent/v3/integrations/nrstan/test
-
 // This module exists to avoid a dependency on
 // github.com/nats-io/nats-streaming-server in nrstan.
-
 go 1.13
-
 require (
 	github.com/nats-io/nats-streaming-server v0.24.3
 	github.com/nats-io/stan.go v0.10.3
 	github.com/newrelic/go-agent/v3 v3.18.2
 	github.com/newrelic/go-agent/v3/integrations/nrstan v0.0.0
 )
-
 replace github.com/newrelic/go-agent/v3 => ../../../
-
 replace github.com/newrelic/go-agent/v3/integrations/nrstan => ../

--- a/v3/integrations/nrzap/go.mod
+++ b/v3/integrations/nrzap/go.mod
@@ -1,9 +1,7 @@
 module github.com/newrelic/go-agent/v3/integrations/nrzap
-
 // As of Dec 2019, zap has 1.13 in their go.mod file:
 // https://github.com/uber-go/zap/blob/master/go.mod
 go 1.13
-
 require (
 	github.com/newrelic/go-agent/v3 v3.0.0
 	// v1.12.0 is the earliest version of zap using modules.

--- a/v3/newrelic/version.go
+++ b/v3/newrelic/version.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Version is the full string version of this Go Agent.
-	Version = "3.22.1"
+	Version = "3.23.0"
 )
 
 var (


### PR DESCRIPTION
## 3.23.0
 * Adds the nrsecurityagent integration for performing Interactive Application Security Testing (IAST) of your application.

 To learn how to use IAST with the New Relic Go Agent, [check out our documentation](https://docs.newrelic.com/docs/iast/use-iast/).

### Support statement

 We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves (i.e., Go versions 1.19 and later are supported).

 See the [Go agent EOL Policy](https://docs.newrelic.com/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.