### PR TITLE
feat: Added new config option for raw SQL Queries

### DIFF
--- a/v3/integrations/nrpq/example/main.go
+++ b/v3/integrations/nrpq/example/main.go
@@ -37,6 +37,7 @@ func main() {
 		newrelic.ConfigAppName("PostgreSQL App"),
 		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
 		newrelic.ConfigDebugLogger(os.Stdout),
+		newrelic.ConfigDatastoreRawQuery(true),
 	)
 	if nil != err {
 		panic(err)

--- a/v3/newrelic/config.go
+++ b/v3/newrelic/config.go
@@ -316,6 +316,10 @@ type Config struct {
 		QueryParameters struct {
 			Enabled bool
 		}
+		RawQuery struct {
+			Enabled bool
+		}
+
 		// SlowQuery controls the capture of slow query traces.  Slow
 		// query traces show you instances of your slowest datastore
 		// segments.
@@ -653,6 +657,7 @@ func defaultConfig() Config {
 	c.DatastoreTracer.QueryParameters.Enabled = true
 	c.DatastoreTracer.SlowQuery.Enabled = true
 	c.DatastoreTracer.SlowQuery.Threshold = 10 * time.Millisecond
+	c.DatastoreTracer.RawQuery.Enabled = false
 
 	c.ServerlessMode.ApdexThreshold = 500 * time.Millisecond
 	c.ServerlessMode.Enabled = false

--- a/v3/newrelic/config_options.go
+++ b/v3/newrelic/config_options.go
@@ -68,6 +68,14 @@ func ConfigCodeLevelMetricsEnabled(enabled bool) ConfigOption {
 	}
 }
 
+// ConfigDatastoreRawQuery replaces a parameterized query in datastores
+// with the full raw query
+func ConfigDatastoreRawQuery(enabled bool) ConfigOption {
+	return func(cfg *Config) {
+		cfg.DatastoreTracer.RawQuery.Enabled = enabled
+	}
+}
+
 // ConfigCodeLevelMetricsIgnoredPrefix alters the way the Code Level Metrics
 // collection code searches for the right function to report for a given
 // telemetry trace. It will find the innermost function whose name does NOT

--- a/v3/newrelic/config_test.go
+++ b/v3/newrelic/config_test.go
@@ -159,6 +159,7 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 				"DatabaseNameReporting":{"Enabled":true},
 				"InstanceReporting":{"Enabled":true},
 				"QueryParameters":{"Enabled":true},
+				"RawQuery":{"Enabled":false},
 				"SlowQuery":{
 					"Enabled":true,
 					"Threshold":10000000
@@ -358,6 +359,7 @@ func TestCopyConfigReferenceFieldsAbsent(t *testing.T) {
 				"DatabaseNameReporting":{"Enabled":true},
 				"InstanceReporting":{"Enabled":true},
 				"QueryParameters":{"Enabled":true},
+				"RawQuery":{"Enabled":false},
 				"SlowQuery":{
 					"Enabled":true,
 					"Threshold":10000000

--- a/v3/newrelic/internal_txn.go
+++ b/v3/newrelic/internal_txn.go
@@ -916,6 +916,9 @@ func endDatastore(s *DatastoreSegment) error {
 	if !txn.Config.DatastoreTracer.QueryParameters.Enabled {
 		s.QueryParameters = nil
 	}
+	if txn.Config.DatastoreTracer.RawQuery.Enabled {
+		s.ParameterizedQuery = s.RawQuery
+	}
 	if txn.Reply.SecurityPolicies.RecordSQL.IsSet() {
 		s.QueryParameters = nil
 		if !txn.Reply.SecurityPolicies.RecordSQL.Enabled() {

--- a/v3/newrelic/segments.go
+++ b/v3/newrelic/segments.go
@@ -52,6 +52,9 @@ type DatastoreSegment struct {
 	// ParameterizedQuery may be set to the query being performed.  It must
 	// not contain any raw parameters, only placeholders.
 	ParameterizedQuery string
+	// RawQuery stores the original raw query
+	RawQuery string
+
 	// QueryParameters may be used to provide query parameters.  Care should
 	// be taken to only provide parameters which are not sensitive.
 	// QueryParameters are ignored in high security mode. The keys must contain
@@ -278,7 +281,6 @@ func StartSegment(txn *Transaction, name string) *Segment {
 //
 // Using the same http.Client for all of your external requests?  Check out
 // NewRoundTripper: You may not need to use StartExternalSegment at all!
-//
 func StartExternalSegment(txn *Transaction, request *http.Request) *ExternalSegment {
 	if nil == txn {
 		txn = transactionFromRequestContext(request)

--- a/v3/newrelic/sqlparse/sqlparse.go
+++ b/v3/newrelic/sqlparse/sqlparse.go
@@ -61,6 +61,7 @@ func ParseQuery(segment *newrelic.DatastoreSegment, query string) {
 	op := strings.ToLower(firstWordRegex.FindString(s))
 	if rg, ok := sqlOperations[op]; ok {
 		segment.Operation = op
+		segment.RawQuery = query
 		if nil != rg {
 			if m := rg.FindStringSubmatch(s); len(m) > 1 {
 				segment.Collection = extractTable(m[1])


### PR DESCRIPTION
Using `newrelic.ConfigDatastoreRawQuery(true)`, it is now possible to see full queries on New Relic dashboards. The default configuration (Using parameterized queries) will remain unchanged.