### PR TITLE
added Name() transaction name getter function

### DIFF
--- a/v3/newrelic/internal_txn.go
+++ b/v3/newrelic/internal_txn.go
@@ -771,6 +771,12 @@ func (txn *txn) SetName(name string) error {
 	return nil
 }
 
+func (txn *txn) GetName() string {
+	txn.Lock()
+	defer txn.Unlock()
+	return txn.Name
+}
+
 func (txn *txn) Ignore() error {
 	txn.Lock()
 	defer txn.Unlock()

--- a/v3/newrelic/internal_txn_test.go
+++ b/v3/newrelic/internal_txn_test.go
@@ -567,6 +567,26 @@ func TestNilTransaction(t *testing.T) {
 	}
 }
 
+func TestGetName(t *testing.T) {
+	replyfn := func(reply *internal.ConnectReply) {
+		reply.SetSampleEverything()
+		reply.EntityGUID = "entities-are-guid"
+		reply.TraceIDGenerator = internal.NewTraceIDGenerator(12345)
+	}
+	cfgfn := func(cfg *Config) {
+		cfg.AppName = "app-name"
+		cfg.DistributedTracer.Enabled = true
+	}
+	app := testApp(replyfn, cfgfn, t)
+	txn := app.StartTransaction("hello")
+	defer txn.End()
+	txn.Ignore()
+	txn.SetName("hello世界")
+	if theName := txn.Name(); theName != "hello世界" {
+		t.Error(theName)
+	}
+}
+
 func TestEmptyTransaction(t *testing.T) {
 	txn := &Transaction{}
 

--- a/v3/newrelic/transaction.go
+++ b/v3/newrelic/transaction.go
@@ -75,6 +75,19 @@ func (txn *Transaction) SetName(name string) {
 	txn.thread.logAPIError(txn.thread.SetName(name), "set transaction name", nil)
 }
 
+// Name returns the name currently set for the transaction, as, e.g. by a call to SetName.
+// If unable to do so (such as due to a nil transaction pointer), the empty string is returned.
+func (txn *Transaction) Name() string {
+	// This is called Name rather than GetName to be consistent with the prevailing naming
+	// conventions for the Go language, even though the underlying internal call must be called
+	// something else (like GetName) because there's already a Name struct member.
+
+	if txn == nil || txn.thread == nil {
+		return ""
+	}
+	return txn.thread.GetName()
+}
+
 // NoticeError records an error.  The Transaction saves the first five
 // errors.  For more control over the recorded error fields, see the
 // newrelic.Error type.


### PR DESCRIPTION
Partially satisfies [Issue 714](https://github.com/newrelic/go-agent/issues/714) by providing a `Name` getter method on `Transaction` to get the current transaction name.

Needs review to ensure adding this won't be a problem anywhere but looks to work reliably so far.
Adding this much toward the customer issue because it's simple enough to do now with minimal effort for the upcoming release until looking at the rest of the enhancement request in that issue at a later time.