### PR TITLE
added checks for the presence of the security agent before calling se…

### DIFF
--- a/v3/newrelic/transaction.go
+++ b/v3/newrelic/transaction.go
@@ -312,7 +312,7 @@ func (txn *Transaction) startSegmentAt(at time.Time) SegmentStartTime {
 //	// ... code you want to time here ...
 //	segment.End()
 func (txn *Transaction) StartSegment(name string) *Segment {
-	if txn != nil && txn.thread != nil && txn.thread.thread != nil && txn.thread.thread.threadID > 0 {
+	if IsSecurityAgentPresent() && txn != nil && txn.thread != nil && txn.thread.thread != nil && txn.thread.thread.threadID > 0 {
 		// async segment start
 		secureAgent.SendEvent("NEW_GOROUTINE_LINKER", txn.thread.getCsecData())
 	}
@@ -498,7 +498,7 @@ func (txn *Transaction) NewGoroutine() *Transaction {
 		return nil
 	}
 	newTxn := txn.thread.NewGoroutine()
-	if newTxn.thread != nil {
+	if IsSecurityAgentPresent() && newTxn.thread != nil {
 		newTxn.thread.setCsecData()
 	}
 	return newTxn


### PR DESCRIPTION
Since the fix to the race condition mentioned in [PR 754](https://github.com/newrelic/go-agent/pull/754) needs to lock and unlock a `Transaction` mutex each time a segment is created, this PR adds a check first so that if there is no security agent installed at all, we don't attempt the security call at all, removing the race condition and mutex overhead in that case. If a security agent is installed, then the mutex-protected code will be used to prevent the race condition.