### PR TITLE
 Issue fixes and few new Implementations for nrsecurityagent

### DIFF
--- a/v3/integrations/nrgrpc/go.mod
+++ b/v3/integrations/nrgrpc/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/newrelic/go-agent/v3 v3.23.0
 	// v1.15.0 is the earliest version of grpc using modules.
 	google.golang.org/grpc v1.54.0
+	google.golang.org/protobuf v1.28.1
 )
 replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/newrelic/secure_agent.go
+++ b/v3/newrelic/secure_agent.go
@@ -44,6 +44,9 @@ func (app *Application) RegisterSecurityAgent(s securityAgent) {
 	if app != nil && app.app != nil && s != nil {
 		secureAgent = s
 	}
+	if app.app.run != nil {
+		secureAgent.RefreshState(getLinkedMetaData(app.app))
+	}
 }
 
 func getLinkedMetaData(app *app) map[string]string {


### PR DESCRIPTION
- Added required for NR-142166 (If go-agent is connected before the initialization of nrsecurityagent, then it doesn't send initialization signal to the nrsecurityagent)

- Added new Implementation for gRPC event generation.
   - Added Implementation to detect RPC message type and version that use for fire fuzz requests.
   - Populate stream server Info via "GRPC_INFO" API call to determine which grpc client needs to replay the request in IAST mode
 
 