### PR TITLE
corrections to recent securityagent updates

### DIFF
--- a/v3/integrations/nrgrpc/nrgrpc_server.go
+++ b/v3/integrations/nrgrpc/nrgrpc_server.go
@@ -377,7 +377,9 @@ func StreamServerInterceptor(app *newrelic.Application, options ...HandlerOption
 	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		txn := startTransaction(ss.Context(), app, info.FullMethod)
 		defer txn.End()
-		newrelic.GetSecurityAgentInterface().SendEvent("GRPC_INFO", info.IsClientStream, info.IsServerStream)
+		if newrelic.IsSecurityAgentPresent() {
+			newrelic.GetSecurityAgentInterface().SendEvent("GRPC_INFO", info.IsClientStream, info.IsServerStream)
+		}
 		err := handler(srv, newWrappedServerStream(ss, txn))
 		reportInterceptorStatus(ss.Context(), txn, localHandlerMap, err)
 		return err

--- a/v3/newrelic/secure_agent.go
+++ b/v3/newrelic/secure_agent.go
@@ -43,9 +43,9 @@ type securityAgent interface {
 func (app *Application) RegisterSecurityAgent(s securityAgent) {
 	if app != nil && app.app != nil && s != nil {
 		secureAgent = s
-	}
-	if app.app.run != nil {
-		secureAgent.RefreshState(getLinkedMetaData(app.app))
+		if app.app.run != nil {
+			secureAgent.RefreshState(getLinkedMetaData(app.app))
+		}
 	}
 }
 


### PR DESCRIPTION
This is a couple of small fixes, one puts securityagent access behind a check that the agent is present to avoid unnecessary work. The other prevents a null pointer reference.