### PR TITLE
Release 3.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 3.25.1
+ * Corrects an error in the release process for 3.25.0.
+### Support statement
+
+ We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
+
+ See the [Go agent EOL Policy](https://docs.newrelic.com/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.
+
+
 ## 3.25.0
 ### Added
    * Added Support for FastHTTP package

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -9,3 +9,4 @@ require (
 )
 
 retract v3.22.0 // release process error corrected in v3.22.1
+retract v3.25.0 // release process error corrected in v3.25.1

--- a/v3/newrelic/version.go
+++ b/v3/newrelic/version.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Version is the full string version of this Go Agent.
-	Version = "3.25.0"
+	Version = "3.25.1"
 )
 
 var (


### PR DESCRIPTION
## 3.25.1
 * Corrects an error in the release process for 3.25.0.
### Support statement

 We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.

 See the [Go agent EOL Policy](https://docs.newrelic.com/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.