### PR TITLE
Error Expected Bug

### DIFF
--- a/v3/newrelic/error_events.go
+++ b/v3/newrelic/error_events.go
@@ -32,7 +32,7 @@ func (e *errorEvent) WriteJSON(buf *bytes.Buffer) {
 		w.stringField("spanId", e.SpanID)
 	}
 	if e.Expect {
-		w.stringField("error.expected", "true")
+		w.boolField(expectErrorAttr, true)
 	}
 
 	sharedTransactionIntrinsics(&e.txnEvent, &w)


### PR DESCRIPTION
The attribute error.expected should be a boolean, not a string. It is also good practice to use a constant value for the key.

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

<!--
Any relevant links that will help reviewers.
-->

## Details

<!--
In-depth description of changes, other technical notes, etc.
-->
