### PR TITLE
CLM user code location callback alternative to LocationOverride option

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -7,6 +7,13 @@ require (
 	google.golang.org/grpc v1.56.3
 )
 
+require (
+	golang.org/x/net v0.9.0 // indirect
+	golang.org/x/sys v0.7.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
+	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
+	google.golang.org/protobuf v1.30.0 // indirect
+)
 
 retract v3.22.0 // release process error corrected in v3.22.1
 

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -7,14 +7,6 @@ require (
 	google.golang.org/grpc v1.56.3
 )
 
-require (
-	golang.org/x/net v0.9.0 // indirect
-	golang.org/x/sys v0.7.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
-	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
-)
-
 retract v3.22.0 // release process error corrected in v3.22.1
 
 retract v3.25.0 // release process error corrected in v3.25.1

--- a/v3/newrelic/code_level_metrics.go
+++ b/v3/newrelic/code_level_metrics.go
@@ -125,6 +125,13 @@ func WithCodeLocation(loc *CodeLocation) TraceOption {
 // level metrics is enabled, saving unnecessary work if those metrics
 // are not enabled.
 //
+// If the callback function value passed here is nil, then no callback
+// function will be used (same as if this function were never called).
+// If the callback function itself returns nil instead of a pointer to
+// a CodeLocation, then it is assumed the callback function was not able
+// to determine the code location, and the CLM reporting code's normal
+// method for determining the code location is used instead.
+//
 func WithCodeLocationCallback(locf func() *CodeLocation) TraceOption {
 	return func(o *traceOptSet) {
 		o.LocationCallback = locf


### PR DESCRIPTION
Fixes [Issue #640](https://github.com/newrelic/go-agent/issues/640).
Deprecates the CLM option to set `LocationOverride`, which forces the caller to do the work to determine the code location up-front even if CLM is disabled. Replaces this with a new function which registers a callback function, which the CLM code will call to get the function location from the user's code only if actually needed. The user's callback may use the existing caching code location functions to further optimize this.