### PR TITLE
update dependency on csec

### DIFF
--- a/v3/integrations/nrsecurityagent/go.mod
+++ b/v3/integrations/nrsecurityagent/go.mod
@@ -3,11 +3,10 @@ module github.com/newrelic/go-agent/v3/integrations/nrsecurityagent
 go 1.19
 
 require (
-	github.com/newrelic/csec-go-agent v0.7.0
+	github.com/newrelic/csec-go-agent v1.0.0
 	github.com/newrelic/go-agent/v3 v3.29.1
 	github.com/newrelic/go-agent/v3/integrations/nrsqlite3 v1.2.0
 	gopkg.in/yaml.v2 v2.4.0
 )
-
 
 replace github.com/newrelic/go-agent/v3 => ../..


### PR DESCRIPTION
The security agent is now at v1.0.0. This PR updates our dependency on it to that version.