### PR TITLE
feat: slog: automatically reference transaction from context

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,7 @@ jobs:
           - dirs: v3/integrations/logcontext-v2/nrlogrus
           - dirs: v3/integrations/logcontext-v2/nrzerolog
           - dirs: v3/integrations/logcontext-v2/nrzap
+          - dirs: v3/integrations/logcontext-v2/nrslog
           - dirs: v3/integrations/logcontext-v2/nrwriter
           - dirs: v3/integrations/logcontext-v2/zerologWriter
           - dirs: v3/integrations/logcontext-v2/logWriter

--- a/v3/integrations/logcontext-v2/nrslog/handler.go
+++ b/v3/integrations/logcontext-v2/nrslog/handler.go
@@ -215,18 +215,9 @@ func WithTransactionFromContext(handler NRHandler) TransactionFromContextHandler
 //   - If a group has no Attrs (even if it has a non-empty key),
 //     ignore it.
 func (h TransactionFromContextHandler) Handle(ctx context.Context, record slog.Record) error {
-	data := newrelic.LogData{
-		Severity:  record.Level.String(),
-		Timestamp: record.Time.UnixMilli(),
-		Message:   record.Message,
-	}
-
 	if txn := newrelic.FromContext(ctx); txn != nil {
-		txn.RecordLog(data)
 		return h.NRHandler.WithTransaction(txn).Handle(ctx, record)
 	}
 
-	h.app.RecordLog(data)
-
-	return h.handler.Handle(ctx, record)
+	return h.NRHandler.Handle(ctx, record)
 }


### PR DESCRIPTION
I would like to introduce a handler that takes new relic transaction data from context automatically.

It is quite a common pattern to inject the base slog logger instance to some piece of code only so to pass it to `nrslog.WithContext` to receive a handler that captures logs in context. I find this api to be a bit leaky and introducing noise. Especially that slog already has methods which make context available for handlers.

With introduction of this handler one now can set a slog instance relying on a NRHandler as default one and call it from anywhere, ensuring that log data with be passed to go-agent, as well as if the context contains transaction it will be linked. This is quite the case for http services which rely on `newrelic.WrapHandle`. This also decouples non infra/non instrumentation code from go-agent and allows to write code using stdlib.

an example:

on main.go
```go
app, _ := newrelic.NewApplication(
  newrelic.ConfigAppName("foo"),
  newrelic.ConfigLicense("bar"),
)

instrumentedHandler := nrslog.WithTransactionFromContext(nrslog.TextHandler(app, os.Stderr, &slog.HandlerOptions{}))
slog.SetDefault(slog.New(instrumentedHandler))
```

on service.go

```go
func DoSomeWork(ctx context.Context, app *newrelic.Application){
  txn := app.StartTransaction("baz")
  defer txn.End()

  ctx = newrelic.NewContext(ctx, txn)

  slog.InfoContext(ctx, "qux")  
}
```

All feedback is welcome. The implementation itself was hacked out pretty quick. I am open for suggestions for taking a different approach such as re-implementing the handler. At the moment this new feature is implemented using a decorator which disables setting the transactions externally and only allows passing transaction via context.

I hope this will serve as a good starting point for a discussion. Ideally the resulting implementation will not require to change the example above and the usage remains the same.

btw, not sure if the tests will pass as I found no way to run tests on local env.
also, slack link is broken on CONTRIBUTING.md