### PR TITLE
Azure Utilization Detecting Bug

### DIFF
--- a/v3/internal/utilization/azure.go
+++ b/v3/internal/utilization/azure.go
@@ -28,7 +28,7 @@ func gatherAzure(util *Data, client *http.Client) error {
 	if err != nil {
 		// Only return the error here if it is unexpected to prevent
 		// warning customers who aren't running Azure about a timeout.
-		// If any of the other vendors have been detected, and we have an unauthorized error, we should not return the error
+		// If any of the other vendors have already been detected and set, and we have an error, we should not return the error
 		// If no vendors have been detected, we should return the error.
 		if _, ok := err.(unexpectedAzureErr); ok && !util.Vendors.AnySet() {
 			return err
@@ -61,12 +61,8 @@ func getAzure(client *http.Client) (*azure, error) {
 	}
 	defer response.Body.Close()
 
-	if response.StatusCode != 200 && response.StatusCode != 401 {
+	if response.StatusCode != 200 {
 		return nil, unexpectedAzureErr{e: fmt.Errorf("response code %d", response.StatusCode)}
-	}
-
-	if response.StatusCode == 401 {
-		return nil, unexpectedAzureErr{e: err}
 	}
 
 	data, err := ioutil.ReadAll(response.Body)

--- a/v3/internal/utilization/azure.go
+++ b/v3/internal/utilization/azure.go
@@ -28,7 +28,9 @@ func gatherAzure(util *Data, client *http.Client) error {
 	if err != nil {
 		// Only return the error here if it is unexpected to prevent
 		// warning customers who aren't running Azure about a timeout.
-		if _, ok := err.(unexpectedAzureErr); ok {
+		// If any of the other vendors have been detected, and we have an unauthorized error, we should not return the error
+		// If no vendors have been detected, we should return the error.
+		if _, ok := err.(unexpectedAzureErr); ok && !util.Vendors.AnySet() {
 			return err
 		}
 		return nil
@@ -59,8 +61,12 @@ func getAzure(client *http.Client) (*azure, error) {
 	}
 	defer response.Body.Close()
 
-	if response.StatusCode != 200 {
+	if response.StatusCode != 200 && response.StatusCode != 401 {
 		return nil, unexpectedAzureErr{e: fmt.Errorf("response code %d", response.StatusCode)}
+	}
+
+	if response.StatusCode == 401 {
+		return nil, unexpectedAzureErr{e: err}
 	}
 
 	data, err := ioutil.ReadAll(response.Body)

--- a/v3/internal/utilization/utilization.go
+++ b/v3/internal/utilization/utilization.go
@@ -3,7 +3,6 @@
 
 // Package utilization implements the Utilization spec, available at
 // https://source.datanerd.us/agents/agent-specs/blob/master/Utilization.md
-//
 package utilization
 
 import (
@@ -84,6 +83,9 @@ type vendors struct {
 	Kubernetes *kubernetes `json:"kubernetes,omitempty"`
 }
 
+func (v *vendors) AnySet() bool {
+	return v.AWS != nil || v.Azure != nil || v.GCP != nil || v.PCF != nil || v.Docker != nil || v.Kubernetes != nil
+}
 func (v *vendors) isEmpty() bool {
 	return nil == v || *v == vendors{}
 }


### PR DESCRIPTION
Previously, when any Containerized Environments that aren't running on Azure get detected the go agent would output a Azure unauthorized utilization error. Now, if any containerized environments are detected, the error should not incorrectly be logged