### PR TITLE
release 3.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 3.33.1
+### Added
+   - Increased max span events default limit to 2,000 to align with agent specifications
+   - Added support for gRPC API endpoints and HTTP status codes in the nrsecurity integration
+   - Added feature to detect route of an incoming request for all supported frameworks in the nrsecurity integration.
+   - Updated support for latest New Relic Security Agent release.
+### Fixed
+   - Fixed an issue with nrzap attributes not properly being forwarded
+   - Improved comments on nropenai
+   - Fixed a minor bug relating to ExpectStatusCodes in `app_run.go`
+### Support statement
+We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
+See the [Go agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy) for details about supported versions of the Go agent and third-party components.
+
+
 ## 3.33.0
 ### Added
 - Support for Zap Field Attributes

--- a/v3/newrelic/version.go
+++ b/v3/newrelic/version.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Version is the full string version of this Go Agent.
-	Version = "3.33.0"
+	Version = "3.33.1"
 )
 
 var (


### PR DESCRIPTION
## 3.33.1
### Added
   - Increased max span events default limit to 2,000 to align with agent specifications
   - Added support for gRPC API endpoints and HTTP status codes in the nrsecurity integration
   - Added feature to detect route of an incoming request for all supported frameworks in the nrsecurity integration.
   - Updated support for latest New Relic Security Agent release.
### Fixed
   - Fixed an issue with nrzap attributes not properly being forwarded
   - Improved comments on nropenai
   - Fixed a minor bug relating to ExpectStatusCodes in `app_run.go`
### Support statement
We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
See the [Go agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy) for details about supported versions of the Go agent and third-party components.

