### PR TITLE
release candidate

### DIFF
--- a/v3/integrations/logcontext-v2/logWriter/go.mod
+++ b/v3/integrations/logcontext-v2/logWriter/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/logWriter
 go 1.20
 
 require (
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter v1.0.0
 )
 

--- a/v3/integrations/logcontext-v2/nrlogrus/go.mod
+++ b/v3/integrations/logcontext-v2/nrlogrus/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrlogrus
 go 1.20
 
 require (
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/sirupsen/logrus v1.8.1
 )
 

--- a/v3/integrations/logcontext-v2/nrslog/go.mod
+++ b/v3/integrations/logcontext-v2/nrslog/go.mod
@@ -2,7 +2,7 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrslog
 
 go 1.20
 
-require github.com/newrelic/go-agent/v3 v3.32.0
+require github.com/newrelic/go-agent/v3 v3.33.1
 
 
 replace github.com/newrelic/go-agent/v3 => ../../..

--- a/v3/integrations/logcontext-v2/nrwriter/go.mod
+++ b/v3/integrations/logcontext-v2/nrwriter/go.mod
@@ -2,7 +2,7 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter
 
 go 1.20
 
-require github.com/newrelic/go-agent/v3 v3.32.0
+require github.com/newrelic/go-agent/v3 v3.33.1
 
 
 replace github.com/newrelic/go-agent/v3 => ../../..

--- a/v3/integrations/logcontext-v2/nrzap/go.mod
+++ b/v3/integrations/logcontext-v2/nrzap/go.mod
@@ -3,6 +3,9 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrzap
 go 1.20
 
 require (
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	go.uber.org/zap v1.24.0
 )
+
+
+replace github.com/newrelic/go-agent/v3 => ../../..

--- a/v3/integrations/logcontext-v2/nrzerolog/go.mod
+++ b/v3/integrations/logcontext-v2/nrzerolog/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrzerolog
 go 1.20
 
 require (
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/rs/zerolog v1.26.1
 )
 

--- a/v3/integrations/logcontext-v2/zerologWriter/go.mod
+++ b/v3/integrations/logcontext-v2/zerologWriter/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/zerologWriter
 go 1.20
 
 require (
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter v1.0.0
 	github.com/rs/zerolog v1.27.0
 )

--- a/v3/integrations/logcontext/nrlogrusplugin/go.mod
+++ b/v3/integrations/logcontext/nrlogrusplugin/go.mod
@@ -5,7 +5,7 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext/nrlogrusplugin
 go 1.20
 
 require (
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	// v1.4.0 is required for for the log.WithContext.
 	github.com/sirupsen/logrus v1.4.0
 )

--- a/v3/integrations/nramqp/go.mod
+++ b/v3/integrations/nramqp/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/nramqp
 go 1.20
 
 require (
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/rabbitmq/amqp091-go v1.9.0
 )
 replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nrawsbedrock/go.mod
+++ b/v3/integrations/nrawsbedrock/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.7.3
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.7.1
 	github.com/google/uuid v1.3.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrawssdk-v1/go.mod
+++ b/v3/integrations/nrawssdk-v1/go.mod
@@ -8,7 +8,7 @@ go 1.20
 require (
 	// v1.15.0 is the first aws-sdk-go version with module support.
 	github.com/aws/aws-sdk-go v1.34.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrawssdk-v2/go.mod
+++ b/v3/integrations/nrawssdk-v2/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.24.5
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.10
 	github.com/aws/smithy-go v1.13.3
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrb3/go.mod
+++ b/v3/integrations/nrb3/go.mod
@@ -2,7 +2,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrb3
 
 go 1.20
 
-require github.com/newrelic/go-agent/v3 v3.32.0
+require github.com/newrelic/go-agent/v3 v3.33.1
 
 
 replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nrecho-v3/go.mod
+++ b/v3/integrations/nrecho-v3/go.mod
@@ -8,7 +8,7 @@ require (
 	// v3.1.0 is the earliest v3 version of Echo that works with modules due
 	// to the github.com/rsc/letsencrypt import of v3.0.0.
 	github.com/labstack/echo v3.1.0+incompatible
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrecho-v4/go.mod
+++ b/v3/integrations/nrecho-v4/go.mod
@@ -6,7 +6,7 @@ go 1.20
 
 require (
 	github.com/labstack/echo/v4 v4.9.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrelasticsearch-v7/go.mod
+++ b/v3/integrations/nrelasticsearch-v7/go.mod
@@ -6,7 +6,7 @@ go 1.20
 
 require (
 	github.com/elastic/go-elasticsearch/v7 v7.17.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrfasthttp/examples/client-fasthttp/go.mod
+++ b/v3/integrations/nrfasthttp/examples/client-fasthttp/go.mod
@@ -3,7 +3,7 @@ module client-example
 go 1.20
 
 require (
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/newrelic/go-agent/v3/integrations/nrfasthttp v1.0.0
 	github.com/valyala/fasthttp v1.49.0
 )

--- a/v3/integrations/nrfasthttp/examples/server-fasthttp/go.mod
+++ b/v3/integrations/nrfasthttp/examples/server-fasthttp/go.mod
@@ -3,7 +3,7 @@ module server-example
 go 1.20
 
 require (
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/newrelic/go-agent/v3/integrations/nrfasthttp v1.0.0
 	github.com/valyala/fasthttp v1.49.0
 )

--- a/v3/integrations/nrfasthttp/go.mod
+++ b/v3/integrations/nrfasthttp/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrfasthttp
 go 1.20
 
 require (
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/valyala/fasthttp v1.49.0
 )
 

--- a/v3/integrations/nrgin/go.mod
+++ b/v3/integrations/nrgin/go.mod
@@ -6,7 +6,7 @@ go 1.20
 
 require (
 	github.com/gin-gonic/gin v1.9.1
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrgorilla/go.mod
+++ b/v3/integrations/nrgorilla/go.mod
@@ -7,7 +7,7 @@ go 1.20
 require (
 	// v1.7.0 is the earliest version of Gorilla using modules.
 	github.com/gorilla/mux v1.7.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrgraphgophers/go.mod
+++ b/v3/integrations/nrgraphgophers/go.mod
@@ -7,7 +7,7 @@ go 1.20
 require (
 	// graphql-go has no tagged releases as of Jan 2020.
 	github.com/graph-gophers/graphql-go v1.3.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrgraphqlgo/example/go.mod
+++ b/v3/integrations/nrgraphqlgo/example/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/graphql-go-handler v0.2.3
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/newrelic/go-agent/v3/integrations/nrgraphqlgo v1.0.0
 )
 

--- a/v3/integrations/nrgraphqlgo/go.mod
+++ b/v3/integrations/nrgraphqlgo/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/graphql-go/graphql v0.8.1
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrgrpc/go.mod
+++ b/v3/integrations/nrgrpc/go.mod
@@ -6,7 +6,7 @@ require (
 	// protobuf v1.3.0 is the earliest version using modules, we use v1.3.1
 	// because all dependencies were removed in this version.
 	github.com/golang/protobuf v1.5.3
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/newrelic/go-agent/v3/integrations/nrsecurityagent v1.1.0
 	// v1.15.0 is the earliest version of grpc using modules.
 	google.golang.org/grpc v1.56.3

--- a/v3/integrations/nrhttprouter/go.mod
+++ b/v3/integrations/nrhttprouter/go.mod
@@ -7,7 +7,7 @@ go 1.20
 require (
 	// v1.3.0 is the earliest version of httprouter using modules.
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrlambda/go.mod
+++ b/v3/integrations/nrlambda/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/aws/aws-lambda-go v1.41.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrlogrus/go.mod
+++ b/v3/integrations/nrlogrus/go.mod
@@ -5,7 +5,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrlogrus
 go 1.20
 
 require (
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrlogrus v1.0.0
 	// v1.1.0 is required for the Logger.GetLevel method, and is the earliest
 	// version of logrus using modules.

--- a/v3/integrations/nrlogxi/go.mod
+++ b/v3/integrations/nrlogxi/go.mod
@@ -7,7 +7,7 @@ go 1.20
 require (
 	// 'v1', at commit aebf8a7d67ab, is the only logxi release.
 	github.com/mgutz/logxi v0.0.0-20161027140823-aebf8a7d67ab
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrmicro/go.mod
+++ b/v3/integrations/nrmicro/go.mod
@@ -9,7 +9,7 @@ toolchain go1.22.3
 require (
 	github.com/golang/protobuf v1.5.4
 	github.com/micro/go-micro v1.8.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	google.golang.org/protobuf v1.34.1
 )
 

--- a/v3/integrations/nrmongo/go.mod
+++ b/v3/integrations/nrmongo/go.mod
@@ -5,7 +5,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrmongo
 go 1.20
 
 require (
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	// mongo-driver does not support modules as of Nov 2019.
 	go.mongodb.org/mongo-driver v1.10.2
 )

--- a/v3/integrations/nrmssql/go.mod
+++ b/v3/integrations/nrmssql/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/microsoft/go-mssqldb v0.19.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrmysql/go.mod
+++ b/v3/integrations/nrmysql/go.mod
@@ -7,7 +7,7 @@ require (
 	// v1.5.0 is the first mysql version to support gomod
 	github.com/go-sql-driver/mysql v1.6.0
 	// v3.3.0 includes the new location of ParseQuery
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrnats/go.mod
+++ b/v3/integrations/nrnats/go.mod
@@ -7,7 +7,7 @@ go 1.20
 require (
 	github.com/nats-io/nats-server v1.4.1
 	github.com/nats-io/nats.go v1.28.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrnats/test/go.mod
+++ b/v3/integrations/nrnats/test/go.mod
@@ -8,7 +8,7 @@ replace github.com/newrelic/go-agent/v3/integrations/nrnats v1.0.0 => ../
 require (
 	github.com/nats-io/nats-server v1.4.1
 	github.com/nats-io/nats.go v1.17.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/newrelic/go-agent/v3/integrations/nrnats v1.0.0
 )
 

--- a/v3/integrations/nropenai/go.mod
+++ b/v3/integrations/nropenai/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/pkoukk/tiktoken-go v0.1.6
 	github.com/sashabaranov/go-openai v1.20.2
 )

--- a/v3/integrations/nrpgx/example/sqlx/go.mod
+++ b/v3/integrations/nrpgx/example/sqlx/go.mod
@@ -4,7 +4,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrpgx/example/sqlx
 go 1.20
 require (
 	github.com/jmoiron/sqlx v1.2.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/newrelic/go-agent/v3/integrations/nrpgx v0.0.0
 )
 replace github.com/newrelic/go-agent/v3/integrations/nrpgx => ../../

--- a/v3/integrations/nrpgx/go.mod
+++ b/v3/integrations/nrpgx/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/jackc/pgx v3.6.2+incompatible
 	github.com/jackc/pgx/v4 v4.18.2
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrpgx5/go.mod
+++ b/v3/integrations/nrpgx5/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/egon12/pgsnap v0.0.0-20221022154027-2847f0124ed8
 	github.com/jackc/pgx/v5 v5.5.4
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/v3/integrations/nrpkgerrors/go.mod
+++ b/v3/integrations/nrpkgerrors/go.mod
@@ -5,7 +5,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrpkgerrors
 go 1.20
 
 require (
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	// v0.8.0 was the last release in 2016, and when
 	// major development on pkg/errors stopped.
 	github.com/pkg/errors v0.8.0

--- a/v3/integrations/nrpq/example/sqlx/go.mod
+++ b/v3/integrations/nrpq/example/sqlx/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.1.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/newrelic/go-agent/v3/integrations/nrpq v0.0.0
 )
 replace github.com/newrelic/go-agent/v3/integrations/nrpq => ../../

--- a/v3/integrations/nrpq/go.mod
+++ b/v3/integrations/nrpq/go.mod
@@ -6,7 +6,7 @@ require (
 	// NewConnector dsn parsing tests expect v1.1.0 error return behavior.
 	github.com/lib/pq v1.1.0
 	// v3.3.0 includes the new location of ParseQuery
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrredis-v7/go.mod
+++ b/v3/integrations/nrredis-v7/go.mod
@@ -5,7 +5,7 @@ go 1.20
 
 require (
 	github.com/go-redis/redis/v7 v7.0.0-beta.5
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrredis-v8/go.mod
+++ b/v3/integrations/nrredis-v8/go.mod
@@ -5,7 +5,7 @@ go 1.20
 
 require (
 	github.com/go-redis/redis/v8 v8.4.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrredis-v9/go.mod
+++ b/v3/integrations/nrredis-v9/go.mod
@@ -4,7 +4,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrredis-v9
 go 1.20
 
 require (
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/redis/go-redis/v9 v9.0.2
 )
 

--- a/v3/integrations/nrsarama/go.mod
+++ b/v3/integrations/nrsarama/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Shopify/sarama v1.38.1
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/v3/integrations/nrsecurityagent/go.mod
+++ b/v3/integrations/nrsecurityagent/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/newrelic/csec-go-agent v1.3.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/newrelic/go-agent/v3/integrations/nrsqlite3 v1.2.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/v3/integrations/nrsnowflake/go.mod
+++ b/v3/integrations/nrsnowflake/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrsnowflake
 go 1.20
 
 require (
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/snowflakedb/gosnowflake v1.6.19
 )
 

--- a/v3/integrations/nrsqlite3/go.mod
+++ b/v3/integrations/nrsqlite3/go.mod
@@ -7,7 +7,7 @@ go 1.20
 require (
 	github.com/mattn/go-sqlite3 v1.0.0
 	// v3.3.0 includes the new location of ParseQuery
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrstan/examples/go.mod
+++ b/v3/integrations/nrstan/examples/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrstan/examples
 go 1.20
 require (
 	github.com/nats-io/stan.go v0.5.0
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/newrelic/go-agent/v3/integrations/nrnats v0.0.0
 	github.com/newrelic/go-agent/v3/integrations/nrstan v0.0.0
 )

--- a/v3/integrations/nrstan/go.mod
+++ b/v3/integrations/nrstan/go.mod
@@ -8,7 +8,7 @@ toolchain go1.22.3
 
 require (
 	github.com/nats-io/stan.go v0.10.4
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 )
 
 

--- a/v3/integrations/nrstan/test/go.mod
+++ b/v3/integrations/nrstan/test/go.mod
@@ -9,7 +9,7 @@ toolchain go1.22.3
 require (
 	github.com/nats-io/nats-streaming-server v0.25.6
 	github.com/nats-io/stan.go v0.10.4
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	github.com/newrelic/go-agent/v3/integrations/nrstan v0.0.0
 )
 

--- a/v3/integrations/nrzap/go.mod
+++ b/v3/integrations/nrzap/go.mod
@@ -5,7 +5,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrzap
 go 1.20
 
 require (
-	github.com/newrelic/go-agent/v3 v3.32.0
+	github.com/newrelic/go-agent/v3 v3.33.1
 	// v1.12.0 is the earliest version of zap using modules.
 	go.uber.org/zap v1.12.0
 )


### PR DESCRIPTION
## 3.33.1
### Added
   - Increased max span events default limit to 2,000 to align with agent specifications
   - Added support for gRPC API endpoints and HTTP status codes in the nrsecurity integration
   - Added feature to detect route of an incoming request for all supported frameworks in the nrsecurity integration.
   - Updated support for latest New Relic Security Agent release.
### Fixed
   - Fixed an issue with nrzap attributes not properly being forwarded
   - Improved comments on nropenai
   - Fixed a minor bug relating to ExpectStatusCodes in `app_run.go`
### Support statement
We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
See the [Go agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy) for details about supported versions of the Go agent and third-party components.

