### PR TITLE
remove all extraneous version constraints

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3
 go 1.20
 
 require (
-	github.com/golang/protobuf v1.5.3
+	google.golang.org/protobuf v1.5.3
 	google.golang.org/grpc v1.56.3
 )
 

--- a/v3/integrations/nrmssql/nrmssql.go
+++ b/v3/integrations/nrmssql/nrmssql.go
@@ -1,9 +1,6 @@
 // Copyright 2020 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build go1.10
-// +build go1.10
-
 // Package nrmssql instruments github.com/microsoft/go-mssqldb.
 //
 // Use this package to instrument your MSSQL calls without having to manually

--- a/v3/newrelic/sql_driver.go
+++ b/v3/newrelic/sql_driver.go
@@ -1,9 +1,6 @@
 // Copyright 2020 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build go1.10
-// +build go1.10
-
 package newrelic
 
 import (

--- a/v3/newrelic/trace_observer.go
+++ b/v3/newrelic/trace_observer.go
@@ -1,11 +1,6 @@
 // Copyright 2020 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build go1.9
-// +build go1.9
-
-// This build tag is necessary because GRPC/ProtoBuf libraries only support Go version 1.9 and up.
-
 package newrelic
 
 import (

--- a/v3/newrelic/trace_observer_impl_test.go
+++ b/v3/newrelic/trace_observer_impl_test.go
@@ -1,11 +1,6 @@
 // Copyright 2020 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build go1.9
-// +build go1.9
-
-// This build tag is necessary because Infinite Tracing is only supported for Go version 1.9 and up
-
 package newrelic
 
 import (

--- a/v3/newrelic/trace_observer_test.go
+++ b/v3/newrelic/trace_observer_test.go
@@ -1,11 +1,6 @@
 // Copyright 2020 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build go1.9
-// +build go1.9
-
-// This build tag is necessary because Infinite Tracing is only supported for Go version 1.9 and up
-
 package newrelic
 
 import (


### PR DESCRIPTION
Fixes #939.

As per the README, Go 1.18+ is already required. Thus version constraints for 1.9 and 1.10 are unnecessary. (And these currently cause issues with 1.23rc2 due to https://github.com/golang/go/issues/68658.)