### PR TITLE
 Use error.Error() string for log attributes

### DIFF
--- a/v3/newrelic/attributes_from_internal.go
+++ b/v3/newrelic/attributes_from_internal.go
@@ -461,6 +461,12 @@ func writeAttributeValueJSON(w *jsonFieldsWriter, key string, val interface{}) {
 			v = v[:maxAttributeLengthBytes]
 		}
 		w.stringField(key, v)
+	case error:
+		value := v.Error()
+		if len(value) > maxAttributeLengthBytes {
+			value = value[:maxAttributeLengthBytes]
+		}
+		w.stringField(key, value)
 	case bool:
 		if v {
 			w.rawField(key, `true`)

--- a/v3/newrelic/log_events_test.go
+++ b/v3/newrelic/log_events_test.go
@@ -4,6 +4,7 @@
 package newrelic
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -88,12 +89,13 @@ func TestBasicLogEventWithAttributes(t *testing.T) {
 		C: c{"hello"},
 	}
 
-	events := newLogEvents(testCommonAttributes, loggingConfigEnabled(5))
+	events := newLogEvents(testCommonAttributes, loggingConfigEnabled(6))
 	events.Add(sampleLogEvent(0.5, infoLevel, "message1", map[string]any{"two": "hi"}))
 	events.Add(sampleLogEvent(0.5, infoLevel, "message2", map[string]any{"struct": st}))
 	events.Add(sampleLogEvent(0.5, infoLevel, "message3", map[string]any{"map": map[string]string{"hi": "hello"}}))
 	events.Add(sampleLogEvent(0.5, infoLevel, "message4", map[string]any{"slice": []string{"hi", "hello", "test"}}))
 	events.Add(sampleLogEvent(0.5, infoLevel, "message5", map[string]any{"array": [2]int{1, 2}}))
+	events.Add(sampleLogEvent(0.5, infoLevel, "message6", map[string]any{"error": errors.New("test error")}))
 
 	json, err := events.CollectorJSON(agentRunID)
 	if nil != err {
@@ -105,15 +107,16 @@ func TestBasicLogEventWithAttributes(t *testing.T) {
 		`{"level":"INFO","message":"message2","timestamp":123456,"attributes":{"struct":"{\"A\":\"a\",\"B\":1,\"C\":{\"D\":\"hello\"}}"}},` +
 		`{"level":"INFO","message":"message3","timestamp":123456,"attributes":{"map":"{\"hi\":\"hello\"}"}},` +
 		`{"level":"INFO","message":"message4","timestamp":123456,"attributes":{"slice":"[\"hi\",\"hello\",\"test\"]"}},` +
-		`{"level":"INFO","message":"message5","timestamp":123456,"attributes":{"array":"[1,2]"}}]}]`
+		`{"level":"INFO","message":"message5","timestamp":123456,"attributes":{"array":"[1,2]"}},` +
+		`{"level":"INFO","message":"message6","timestamp":123456,"attributes":{"error":"test error"}}]}]`
 
 	if string(json) != expected {
 		t.Error("actual not equal to expected:\n", string(json), "\n", expected)
 	}
-	if events.numSeen != 5 {
+	if events.numSeen != 6 {
 		t.Error(events.numSeen)
 	}
-	if events.NumSaved() != 5 {
+	if events.NumSaved() != 6 {
 		t.Error(events.NumSaved())
 	}
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

<!--
Any relevant links that will help reviewers.
-->
Running against the latest agent version [v3.34.0](https://github.com/newrelic/go-agent/releases/tag/v3.34.0)

w/ Logrus LogsInContext configured ([doc](https://docs.newrelic.com/docs/logs/logs-context/configure-logs-context-go/#3-logrus))

Related to new functionality added in 
_Capture Log Attributes in the Agent_  https://github.com/newrelic/go-agent/pull/900
_Using Logrus attributes_ https://github.com/newrelic/go-agent/pull/937

## Details

Currently, when errors are logged with the Logs in Context integration, the type is emitted instead of the error string.  

```
log.WithError(fmt.Errorf("this is the error message")).Error("Something went wrong")
```

Console output:
> {"error":"this is the error message","level":"error","msg":"Something went wrong"}

NewRelic Log:
> {"error":"*errors.errorString","level":"error","msg":"Something went wrong"}

This change aligns the NewRelic log attribute with the console output
<!--
In-depth description of changes, other technical notes, etc.
-->
