### PR TITLE
added mutex guards around appRun for code level metrics

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -3,10 +3,9 @@ module github.com/newrelic/go-agent/v3
 go 1.20
 
 require (
-	github.com/golang/protobuf v1.5.3
 	google.golang.org/grpc v1.56.3
+	google.golang.org/protobuf v1.5.3
 )
-
 
 retract v3.22.0 // release process error corrected in v3.22.1
 

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -3,10 +3,17 @@ module github.com/newrelic/go-agent/v3
 go 1.20
 
 require (
-	google.golang.org/protobuf v1.5.3
+	github.com/golang/protobuf v1.5.3
 	google.golang.org/grpc v1.56.3
 )
 
+require (
+	golang.org/x/net v0.9.0 // indirect
+	golang.org/x/sys v0.7.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
+	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
+	google.golang.org/protobuf v1.30.0 // indirect
+)
 
 retract v3.22.0 // release process error corrected in v3.22.1
 

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -7,6 +7,7 @@ require (
 	google.golang.org/grpc v1.56.3
 )
 
+
 retract v3.22.0 // release process error corrected in v3.22.1
 
 retract v3.25.0 // release process error corrected in v3.25.1

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -3,8 +3,8 @@ module github.com/newrelic/go-agent/v3
 go 1.20
 
 require (
-	google.golang.org/grpc v1.56.3
 	google.golang.org/protobuf v1.5.3
+	google.golang.org/grpc v1.56.3
 )
 
 retract v3.22.0 // release process error corrected in v3.22.1

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -7,13 +7,6 @@ require (
 	google.golang.org/grpc v1.56.3
 )
 
-require (
-	golang.org/x/net v0.9.0 // indirect
-	golang.org/x/sys v0.7.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
-	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
-)
 
 retract v3.22.0 // release process error corrected in v3.22.1
 

--- a/v3/newrelic/application.go
+++ b/v3/newrelic/application.go
@@ -18,10 +18,14 @@ type Application struct {
 /*
 // IsAIMonitoringEnabled returns true if monitoring for the specified mode of the named integration is enabled.
 func (app *Application) IsAIMonitoringEnabled(integration string, streaming bool) bool {
-	if app == nil || app.app == nil || app.app.run == nil {
+	if app == nil || app.app == nil {
 		return false
 	}
-	aiconf := app.app.run.Config.AIMonitoring
+	run, _ := app.app.getState()
+	if run == nil {
+		return false
+	}
+	aiconf := run.Config.AIMonitoring
 	if !aiconf.Enabled {
 		return false
 	}

--- a/v3/newrelic/instrumentation.go
+++ b/v3/newrelic/instrumentation.go
@@ -52,13 +52,16 @@ func WrapHandle(app *Application, pattern string, handler http.Handler, options 
 		var tOptions *traceOptSet
 		var txnOptionList []TraceOption
 
-		if app.app != nil && app.app.run != nil && app.app.run.Config.CodeLevelMetrics.Enabled {
-			tOptions = resolveCLMTraceOptions(options)
-			if tOptions != nil && !tOptions.SuppressCLM && (tOptions.DemandCLM || app.app.run.Config.CodeLevelMetrics.Scope == 0 || (app.app.run.Config.CodeLevelMetrics.Scope&TransactionCLM) != 0) {
-				// we are for sure collecting CLM here, so go to the trouble of collecting this code location if nothing else has yet.
-				if tOptions.LocationOverride == nil {
-					if loc, err := cache.FunctionLocation(handler, handler.ServeHTTP); err == nil {
-						WithCodeLocation(loc)(tOptions)
+		if app.app != nil {
+			run, _ := app.app.getState()
+			if run != nil && run.Config.CodeLevelMetrics.Enabled {
+				tOptions = resolveCLMTraceOptions(options)
+				if tOptions != nil && !tOptions.SuppressCLM && (tOptions.DemandCLM || run.Config.CodeLevelMetrics.Scope == 0 || (run.Config.CodeLevelMetrics.Scope&TransactionCLM) != 0) {
+					// we are for sure collecting CLM here, so go to the trouble of collecting this code location if nothing else has yet.
+					if tOptions.LocationOverride == nil {
+						if loc, err := cache.FunctionLocation(handler, handler.ServeHTTP); err == nil {
+							WithCodeLocation(loc)(tOptions)
+						}
 					}
 				}
 			}
@@ -96,13 +99,16 @@ func AddCodeLevelMetricsTraceOptions(app *Application, options []TraceOption, ca
 		return options
 	}
 
-	if app.app != nil && app.app.run != nil && app.app.run.Config.CodeLevelMetrics.Enabled {
-		tOptions = resolveCLMTraceOptions(options)
-		if tOptions != nil && !tOptions.SuppressCLM && (tOptions.DemandCLM || app.app.run.Config.CodeLevelMetrics.Scope == 0 || (app.app.run.Config.CodeLevelMetrics.Scope&TransactionCLM) != 0) {
-			// we are for sure collecting CLM here, so go to the trouble of collecting this code location if nothing else has yet.
-			if tOptions.LocationOverride == nil {
-				if loc, err := cache.FunctionLocation(cachedLocations); err == nil {
-					WithCodeLocation(loc)(tOptions)
+	if app.app != nil {
+		run, _ := app.app.getState()
+		if run != nil && run.Config.CodeLevelMetrics.Enabled {
+			tOptions = resolveCLMTraceOptions(options)
+			if tOptions != nil && !tOptions.SuppressCLM && (tOptions.DemandCLM || run.Config.CodeLevelMetrics.Scope == 0 || (run.Config.CodeLevelMetrics.Scope&TransactionCLM) != 0) {
+				// we are for sure collecting CLM here, so go to the trouble of collecting this code location if nothing else has yet.
+				if tOptions.LocationOverride == nil {
+					if loc, err := cache.FunctionLocation(cachedLocations); err == nil {
+						WithCodeLocation(loc)(tOptions)
+					}
 				}
 			}
 		}

--- a/v3/newrelic/secure_agent.go
+++ b/v3/newrelic/secure_agent.go
@@ -42,7 +42,8 @@ type securityAgent interface {
 func (app *Application) RegisterSecurityAgent(s securityAgent) {
 	if app != nil && app.app != nil && s != nil {
 		secureAgent = s
-		if app.app.run != nil {
+		run, _ := app.app.getState()
+		if run != nil {
 			secureAgent.RefreshState(getLinkedMetaData(app.app))
 		}
 	}


### PR DESCRIPTION
Corrects access to the internal `app.app.run` structure by protecting that access with a mutex, in order to prevent race conditions.