### PR TITLE
Improve performance of trace id generation

### DIFF
--- a/v3/internal/trace_id_generator_test.go
+++ b/v3/internal/trace_id_generator_test.go
@@ -32,3 +32,18 @@ func BenchmarkTraceIDGenerator(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkTraceIDGeneratorParallel(b *testing.B) {
+	tg := NewTraceIDGenerator(12345)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			if id := tg.GenerateSpanID(); id == "" {
+				b.Fatal(id)
+			}
+		}
+	})
+}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

Related-to: https://github.com/newrelic/go-agent/issues/767

## Details

Tried out various improvements for the linked issue, this PR improves the performance of the trace ID generation by doing the hex encoding in-place and avoiding an allocation. We see this function appearing in a high-throughput system, and hope that making it faster will also help us understand our own performance better.

benchstat for allocation avoidance:

```
goos: linux
goarch: amd64
pkg: github.com/newrelic/go-agent/v3/internal
cpu: AMD Ryzen 9 7940HS w/ Radeon 780M Graphics     
                            │ before.txt  │              after.txt              │
                            │   sec/op    │   sec/op     vs base                │
TraceIDGenerator-16           43.33n ± 3%   30.85n ± 1%  -28.81% (p=0.000 n=10)
TraceIDGeneratorParallel-16   71.23n ± 4%   60.40n ± 2%  -15.22% (p=0.000 n=10)
geomean                       55.56n        43.16n       -22.31%

                            │ before.txt │             after.txt              │
                            │    B/op    │    B/op     vs base                │
TraceIDGenerator-16           32.00 ± 0%   16.00 ± 0%  -50.00% (p=0.000 n=10)
TraceIDGeneratorParallel-16   32.00 ± 0%   16.00 ± 0%  -50.00% (p=0.000 n=10)
geomean                       32.00        16.00       -50.00%

                            │ before.txt │             after.txt              │
                            │ allocs/op  │ allocs/op   vs base                │
TraceIDGenerator-16           2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
TraceIDGeneratorParallel-16   2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
geomean                       2.000        1.000       -50.00%
```