### PR TITLE
Remove special handling of panic(nil)

### DIFF
--- a/v3/newrelic/internal_test.go
+++ b/v3/newrelic/internal_test.go
@@ -753,6 +753,7 @@ func TestPanicInt(t *testing.T) {
 	app.ExpectMetrics(t, backgroundErrorMetrics)
 }
 
+/* superseded now by TestPanicNilRecovery.
 func TestPanicNil(t *testing.T) {
 	app := testApp(nil, func(cfg *Config) {
 		enableRecordPanics(cfg)
@@ -769,6 +770,7 @@ func TestPanicNil(t *testing.T) {
 	app.ExpectErrorEvents(t, []internal.WantEvent{})
 	app.ExpectMetrics(t, backgroundMetrics)
 }
+*/
 
 func TestResponseCodeError(t *testing.T) {
 	app := testApp(nil, ConfigDistributedTracerEnabled(false), t)

--- a/v3/newrelic/internal_txn.go
+++ b/v3/newrelic/internal_txn.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
-	"runtime"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -446,16 +445,11 @@ func (thd *thread) End(recovered interface{}) error {
 
 	txn.finished = true
 
-	// It used to be the case that panic(nil) would cause recover() to return nil,
-	// which we test for here. However, that is no longer the case, hence the extra
-	// check at this point to stop panic(nil) from propagating here. (as of Go 1.21)
 	if recovered != nil {
-		if _, isNilPanic := recovered.(*runtime.PanicNilError); !isNilPanic {
-			e := txnErrorFromPanic(time.Now(), recovered)
-			e.Stack = getStackTrace()
-			thd.noticeErrorInternal(e, nil, false)
-			log.Println(string(debug.Stack()))
-		}
+		e := txnErrorFromPanic(time.Now(), recovered)
+		e.Stack = getStackTrace()
+		thd.noticeErrorInternal(e, nil, false)
+		log.Println(string(debug.Stack()))
 	}
 
 	txn.markEnd(time.Now(), thd.thread)
@@ -547,13 +541,8 @@ func (thd *thread) End(recovered interface{}) error {
 		}
 	}
 
-	// Note that if a consumer uses `panic(nil)`, the panic will not
-	// propagate.  Update: well, not anymore. Go now returns an actual
-	// non-nil value in this case.
 	if recovered != nil {
-		if _, isNilPanic := recovered.(*runtime.PanicNilError); !isNilPanic {
-			panic(recovered)
-		}
+		panic(recovered)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes [issue 975](https://github.com/newrelic/go-agent/issues/975) by removing the special handling that was wrapped around instrumented functions that experience a `panic(nil)`. Previously the code sought to keep the pre-Go-1.21 behavior of not propagating nil panics, but a better approach is to not treat them any differently than other panics.