### PR TITLE
fix: nrslog handler slog.Group

### DIFF
--- a/v3/integrations/logcontext-v2/nrslog/handler.go
+++ b/v3/integrations/logcontext-v2/nrslog/handler.go
@@ -131,6 +131,18 @@ func (h NRHandler) Enabled(ctx context.Context, lvl slog.Level) bool {
 func (h NRHandler) Handle(ctx context.Context, record slog.Record) error {
 	attrs := map[string]interface{}{}
 
+	var processAttr func(attr slog.Attr) interface{}
+	processAttr = func(attr slog.Attr) interface{} {
+		if attr.Value.Kind() == slog.KindGroup {
+			groupMap := make(map[string]interface{})
+			for _, groupAttr := range attr.Value.Group() {
+				groupMap[groupAttr.Key] = processAttr(groupAttr)
+			}
+			return groupMap
+		}
+		return attr.Value.Any()
+	}
+
 	record.Attrs(func(attr slog.Attr) bool {
 		attrs[attr.Key] = attr.Value.Any()
 		return true


### PR DESCRIPTION
added processing for slog.Group when nested withing a log

## Details

When a log.Group is added in newrelic it is replaced with a map key value that modifies the original values and empty values are stored.

e.g. of code:
https://github.com/newrelic/go-agent/tree/master/v3/integrations/logcontext-v2/nrslog/example

```
package main

import (
	"log/slog"
	"os"
	"time"

	"github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrslog"
	"github.com/newrelic/go-agent/v3/newrelic"
)

func main() {
	app, err := newrelic.NewApplication(
		newrelic.ConfigAppName("my-wesome-nrapp"),
		newrelic.ConfigFromEnvironment(),
		newrelic.ConfigAppLogEnabled(true),
	)
	if err != nil {
		panic(err)
	}

	app.WaitForConnection(time.Second * 5)
	log := slog.New(nrslog.TextHandler(app, os.Stdout, &slog.HandlerOptions{}))

	log.Info("I am a log message")

	log.Info("I am a log group inside a log message",
		slog.String("foo", "bar"),
		slog.Int("answer", 42),
		slog.Group("user",
			slog.String("name", "John Smith"),
			slog.String("email", "john.smith@example.com"),
			slog.Int("age", 23),
		),
	)

	log.Info("All Done!")

	app.Shutdown(time.Second * 10)
}

```

Which is displayed in newrelic/logs
```
{
  "answer": 42,
  "entity.guid": "some_entity_guid",
  "entity.guids": "some_entity_guids",
  "entity.name": "my-wesome-nrapp",
  "foo": "bar",
  "hostname": "hostname_example",
  "level": "INFO",
  "message": "I am a log group inside a log message",
  "newrelic.logPattern": "nr.DID_NOT_MATCH",
  "newrelic.source": "logs.APM",
  "timestamp": 1735243287475,
  "user": "[{\"Key\":\"name\",\"Value\":{}},{\"Key\":\"email\",\"Value\":{}},{\"Key\":\"age\",\"Value\":{}}]"
}
```

