### PR TITLE
feat(transaction-is-ended): add IsEnded() method (#995)

### DIFF
--- a/v3/newrelic/internal_txn.go
+++ b/v3/newrelic/internal_txn.go
@@ -54,6 +54,14 @@ type thread struct {
 	thread *tracingThread
 }
 
+func (thd *thread) IsEnded() bool {
+	txn := thd.txn
+	txn.Lock()
+	defer txn.Unlock()
+
+	return txn.finished
+}
+
 func (txn *txn) markStart(now time.Time) {
 	txn.Start = now
 	// The mainThread is considered active now.

--- a/v3/newrelic/internal_txn_test.go
+++ b/v3/newrelic/internal_txn_test.go
@@ -1018,3 +1018,32 @@ func TestPanicNilRecovery(t *testing.T) {
 		},
 	})
 }
+
+func TestIsEndedInternal(t *testing.T) {
+	tests := []struct {
+		name     string
+		txn      *txn
+		expected bool
+	}{
+		{
+			name:     "finished transaction",
+			txn:      &txn{finished: true},
+			expected: true,
+		},
+		{
+			name:     "unfinished transaction",
+			txn:      &txn{finished: false},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			thread := &thread{txn: tt.txn}
+			result := thread.IsEnded()
+			if result != tt.expected {
+				t.Errorf("IsEnded() = %v; want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/v3/newrelic/transaction.go
+++ b/v3/newrelic/transaction.go
@@ -243,10 +243,10 @@ func (txn *Transaction) SetWebRequestHTTP(r *http.Request) {
 // If the transaction is nil, the thread is nil, or the transaction is finished, it returns true.
 // Otherwise, it returns thread.finished value.
 func (txn *Transaction) IsEnded() bool {
-	if txn == nil || txn.thread == nil || txn.thread.txn == nil {
+	if nilTransaction(txn) {
 		return true
 	}
-	return txn.thread.txn.finished
+	return txn.thread.IsEnded()
 }
 
 func transport(r *http.Request) TransportType {

--- a/v3/newrelic/transaction.go
+++ b/v3/newrelic/transaction.go
@@ -239,6 +239,16 @@ func (txn *Transaction) SetWebRequestHTTP(r *http.Request) {
 	txn.SetWebRequest(wr)
 }
 
+// IsEnded returns transaction end status.
+// If the transaction is nil, the thread is nil, or the transaction is finished, it returns true.
+// Otherwise, it returns thread.finished value.
+func (txn *Transaction) IsEnded() bool {
+	if txn == nil || txn.thread == nil || txn.thread.txn == nil {
+		return true
+	}
+	return txn.thread.txn.finished
+}
+
 func transport(r *http.Request) TransportType {
 	if strings.HasPrefix(r.Proto, "HTTP") {
 		if r.TLS != nil {

--- a/v3/newrelic/transaction_test.go
+++ b/v3/newrelic/transaction_test.go
@@ -6,6 +6,29 @@ import (
 	"testing"
 )
 
+func TestIsEnded(t *testing.T) {
+	tests := []struct {
+		name     string
+		txn      *Transaction
+		expected bool
+	}{
+		{"txn is nil", nil, true},
+		{"thread is nil", &Transaction{thread: nil}, true},
+		{"txn.thread.txn is nil", &Transaction{thread: &thread{}}, true},
+		{"txn.thread.txn.finished is true", &Transaction{thread: &thread{txn: &txn{finished: true}}}, true},
+		{"txn.thread.txn.finished is false", &Transaction{thread: &thread{txn: &txn{finished: false}}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.txn.IsEnded()
+			if result != tt.expected {
+				t.Errorf("IsEnded() = %v; want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestTransaction_MethodsWithNilTransaction(t *testing.T) {
 	var nilTxn *Transaction
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

- Issue: [#995](https://github.com/newrelic/go-agent/issues/995)

<!--
Any relevant links that will help reviewers.
-->

## Details

This pull request introduces a new `IsEnded()` method for the `Transaction` type. It addresses the issue raised in [#995](https://github.com/newrelic/go-agent/issues/995) where there was no straightforward way to determine if a transaction has ended.

**Changes include:**

- **New Method Implementation:**  
  The `IsEnded()` method has been added to check the internal transaction state. It ensures that a transaction is considered ended if it is nil, if its thread is nil, or if the underlying transaction's `finished` flag is set.

  ```go
  func (t *Transaction) IsEnded() bool {
      if t == nil || t.thread == nil || t.thread.txn == nil {
          return true
      }
      return t.thread.txn.finished
  }


- **Unit Tests:**

  Unit tests have been added to verify that:
    - A nil Transaction returns true for IsEnded().
    - A Transaction with a nil thread or nil txn returns true.
    - An active transaction returns false.
    - A finished transaction returns true.

These changes ensure robust transaction state checking across different scenarios.
Closes [#995](https://github.com/newrelic/go-agent/issues/995).




