### PR TITLE
added SessionResetter into driver_conn optional interfaces

### DIFF
--- a/v3/internal/tools/interface-wrapping/driver_conn.json
+++ b/v3/internal/tools/interface-wrapping/driver_conn.json
@@ -13,6 +13,7 @@
 		"driver.NamedValueChecker",
 		"driver.Pinger",
 		"driver.Queryer",
-		"driver.QueryerContext"
+		"driver.QueryerContext",
+		"driver.SessionResetter"
 	]
 }

--- a/v3/newrelic/sql_driver_optional_methods.go
+++ b/v3/newrelic/sql_driver_optional_methods.go
@@ -164,6 +164,7 @@ func optionalMethodsConn(conn *wrapConn) driver.Conn {
 		i5 int32 = 1 << 5
 		i6 int32 = 1 << 6
 		i7 int32 = 1 << 7
+		i8 int32 = 1 << 8
 	)
 	var interfaceSet int32
 	if _, ok := conn.original.(driver.ConnBeginTx); ok {
@@ -189,6 +190,9 @@ func optionalMethodsConn(conn *wrapConn) driver.Conn {
 	}
 	if _, ok := conn.original.(driver.QueryerContext); ok {
 		interfaceSet |= i7
+	}
+	if _, ok := conn.original.(driver.SessionResetter); ok {
+		interfaceSet |= i8
 	}
 	switch interfaceSet {
 	default: // No optional interfaces implemented
@@ -2239,5 +2243,2309 @@ func optionalMethodsConn(conn *wrapConn) driver.Conn {
 			driver.Queryer
 			driver.QueryerContext
 		}{conn, conn, conn, conn, conn, conn, conn, conn, conn}
+	case i8:
+		return struct {
+			driver.Conn
+			driver.SessionResetter
+		}{conn, conn}
+	case i0 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.SessionResetter
+		}{conn, conn, conn}
+	case i1 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.SessionResetter
+		}{conn, conn, conn}
+	case i0 | i1 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i2 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.SessionResetter
+		}{conn, conn, conn}
+	case i0 | i2 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i1 | i2 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i1 | i2 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i3 | i8:
+		return struct {
+			driver.Conn
+			driver.ExecerContext
+			driver.SessionResetter
+		}{conn, conn, conn}
+	case i0 | i3 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ExecerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i1 | i3 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i1 | i3 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i2 | i3 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.ExecerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i2 | i3 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.ExecerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i1 | i2 | i3 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i3 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i4 | i8:
+		return struct {
+			driver.Conn
+			driver.NamedValueChecker
+			driver.SessionResetter
+		}{conn, conn, conn}
+	case i0 | i4 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.NamedValueChecker
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i1 | i4 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.NamedValueChecker
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i1 | i4 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.NamedValueChecker
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i2 | i4 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.NamedValueChecker
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i2 | i4 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.NamedValueChecker
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i1 | i2 | i4 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.NamedValueChecker
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i4 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.NamedValueChecker
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i3 | i4 | i8:
+		return struct {
+			driver.Conn
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i3 | i4 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i1 | i3 | i4 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i1 | i3 | i4 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i2 | i3 | i4 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i2 | i3 | i4 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i3 | i4 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i3 | i4 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i5 | i8:
+		return struct {
+			driver.Conn
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn}
+	case i0 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i1 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i1 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i2 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i2 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i1 | i2 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i3 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ExecerContext
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i3 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ExecerContext
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i1 | i3 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i1 | i3 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i2 | i3 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.ExecerContext
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i2 | i3 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.ExecerContext
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i3 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i3 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i4 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i4 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i1 | i4 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i1 | i4 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i2 | i4 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i2 | i4 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i4 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i4 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i3 | i4 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i3 | i4 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i3 | i4 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i3 | i4 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i2 | i3 | i4 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i2 | i3 | i4 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i3 | i4 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i3 | i4 | i5 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i6 | i8:
+		return struct {
+			driver.Conn
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn}
+	case i0 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i1 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i1 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i2 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i2 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i1 | i2 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i3 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ExecerContext
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i3 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ExecerContext
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i1 | i3 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i1 | i3 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i2 | i3 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.ExecerContext
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i2 | i3 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.ExecerContext
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i3 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i3 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i4 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i4 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i1 | i4 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i1 | i4 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i2 | i4 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i2 | i4 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i4 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i4 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i3 | i4 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i3 | i4 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i3 | i4 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i3 | i4 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i2 | i3 | i4 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i2 | i3 | i4 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i3 | i4 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i3 | i4 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i1 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i1 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i2 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i2 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i3 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ExecerContext
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i3 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ExecerContext
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i3 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i3 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i2 | i3 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.ExecerContext
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i2 | i3 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.ExecerContext
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i3 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i3 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i4 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i4 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i4 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i4 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i2 | i4 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i2 | i4 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i4 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i4 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i3 | i4 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i3 | i4 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i3 | i4 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i3 | i4 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i2 | i3 | i4 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i2 | i3 | i4 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i3 | i4 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i3 | i4 | i5 | i6 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn, conn}
+	case i7 | i8:
+		return struct {
+			driver.Conn
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn}
+	case i0 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i1 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i1 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i2 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i2 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i1 | i2 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i3 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ExecerContext
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i3 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ExecerContext
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i1 | i3 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i1 | i3 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i2 | i3 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.ExecerContext
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i2 | i3 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.ExecerContext
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i3 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i3 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i4 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.NamedValueChecker
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i4 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.NamedValueChecker
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i1 | i4 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.NamedValueChecker
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i1 | i4 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.NamedValueChecker
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i2 | i4 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.NamedValueChecker
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i2 | i4 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.NamedValueChecker
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i4 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.NamedValueChecker
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i4 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.NamedValueChecker
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i3 | i4 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i3 | i4 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i3 | i4 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i3 | i4 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i2 | i3 | i4 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i2 | i3 | i4 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i3 | i4 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i3 | i4 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i1 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i1 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i2 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i2 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i3 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ExecerContext
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i3 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ExecerContext
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i3 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i3 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i2 | i3 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.ExecerContext
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i2 | i3 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.ExecerContext
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i3 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i3 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i4 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i4 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i4 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i4 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i2 | i4 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i2 | i4 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i4 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i4 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i3 | i4 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i3 | i4 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i3 | i4 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i3 | i4 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i2 | i3 | i4 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i2 | i3 | i4 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i3 | i4 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i3 | i4 | i5 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn, conn}
+	case i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn}
+	case i0 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i1 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i1 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i2 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i2 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i3 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ExecerContext
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i3 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ExecerContext
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i3 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i3 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i2 | i3 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.ExecerContext
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i2 | i3 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.ExecerContext
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i3 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i3 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i4 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i4 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i4 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i4 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i2 | i4 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i2 | i4 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i4 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i4 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i3 | i4 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i3 | i4 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i3 | i4 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i3 | i4 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i2 | i3 | i4 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i2 | i3 | i4 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i3 | i4 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i3 | i4 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn, conn}
+	case i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn}
+	case i0 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i1 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i2 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i2 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i3 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ExecerContext
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i3 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ExecerContext
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i3 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i3 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i2 | i3 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.ExecerContext
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i2 | i3 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.ExecerContext
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i3 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i3 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn, conn}
+	case i4 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn}
+	case i0 | i4 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i4 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i4 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i2 | i4 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i2 | i4 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i4 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i4 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn, conn}
+	case i3 | i4 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i3 | i4 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i3 | i4 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i3 | i4 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn, conn}
+	case i2 | i3 | i4 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i2 | i3 | i4 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn, conn}
+	case i1 | i2 | i3 | i4 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn, conn}
+	case i0 | i1 | i2 | i3 | i4 | i5 | i6 | i7 | i8:
+		return struct {
+			driver.Conn
+			driver.ConnBeginTx
+			driver.ConnPrepareContext
+			driver.Execer
+			driver.ExecerContext
+			driver.NamedValueChecker
+			driver.Pinger
+			driver.Queryer
+			driver.QueryerContext
+			driver.SessionResetter
+		}{conn, conn, conn, conn, conn, conn, conn, conn, conn, conn}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links
N/A
<!--
Any relevant links that will help reviewers.
-->

## Details

### Problem
The nrmysql driver in newrelic/go-agent does not properly handle connection reuse in case of last query was errored when MySQL closes an idle connection and application try to reuse it, This leads to a "commands out of sync" error when the same connection is used again.

Steps to Reproduce
The following test program demonstrates the issue:


```
package main

import (
	"database/sql"
	"fmt"
	"time"

	_ "github.com/go-sql-driver/mysql"
	_ "github.com/newrelic/go-agent/v3/integrations/nrmysql"
)

func main() {
	mysqlConnString := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local", "user", "pass", "127.0.0.1", "3306", "db_name")
	mdb, err := sql.Open("nrmysql", mysqlConnString)
	fmt.Println("mysql open error:", err)

	mdb.Ping()
	fmt.Println("ping error:", err)

	// This query will fail
	q("select * from table_not_exists", mdb)

	// Simulate MySQL closing the connection after idle time (e.g., 10s)
	time.Sleep(time.Second * 12)

	// This will result in "commands out of sync" error
	q("select * from users", mdb)
}

func q(sql string, mdb *sql.DB) {
	rows, err := mdb.Query(sql)
	if err == nil {
		cols, _ := rows.Columns()
		columns := make([]interface{}, len(cols))
		columnPointers := make([]interface{}, len(cols))
		for i := range columns {
			columnPointers[i] = &columns[i]
		}
		rows.Next()
		scanErr := rows.Scan(columnPointers...)
		fmt.Println("mysql query error:", err, scanErr, columns)
	} else {
		fmt.Println("mysql query error:", err)
	}
}
```
### Root Cause

The repository provides an SQL driver that implements various sql package interfaces. One of these interfaces is **driver.SessionResetter**, which is already implemented in [sql_driver.go](https://github.com/newrelic/go-agent/blob/master/v3/newrelic/sql_driver.go#L260). However, the optionalMethodsConn type in [sql_driver_optional_methods.go](https://github.com/newrelic/go-agent/blob/master/v3/newrelic/sql_driver_optional_methods.go#L155) did not support **driver.SessionResetter**.

### Solution
- Updated internal/tools/interface-wrapping to include SessionResetter.
- Regenerated optionalMethodsConn to ensure SessionResetter is properly implemented.
- This allows MySQL driver resetSession method to be called  to determine whether the connection is still valid before reuse.


### Additional Notes
- The interface-wrapping tool was updated to recognize SessionResetter.
- optionalMethodsConn was regenerated to reflect this change.
- Tests have been validated to ensure correctness.
- No breaking changes introduced.