### PR TITLE
Release 3.37.0 (version set and final changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 3.37.0
+### Enhanced
+  - Implemented a new approach to integrating New Relic with SLOG that is more lightweight, out of the way, and collects richer data. These changes have been constructed to be completely backwards-compatible with v1 of nrslog. Changes include:
+     - Wrapping `slog.Handler` objects with errors to allow users to handle invalid use cases
+     - A complete rework of log enrichment so that New Relic linking metadata does not invalidate JSON, BSON, or YAML scanners. This new approach will instead inject the linking metadata as a key-value pair.
+     - Complete support for `With()`, `WithGroup()`, and attributes for automatic instrumentation.
+     - Performance operations.
+     - Robust testing (close to 90% coverage).
+     - **This updates logcontext-v2/nrslog to v1.4.0.**
+  - Now custom application tags (labels) may be added to all forwarded log events.
+     - Enabled if `ConfigAppLogForwardingLabelsEnabled(true)` or `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_ENABLED=TRUE`
+     - May exclude labels named in `ConfigAppLogForwardingLabelsExclude("label1","label2",...)` or `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE="label1,label2,..."`
+     - Labels are defined via `ConfigLabels(...)` or `NEW_RELIC_LABELS`
+  - Added memory allocation limit detection/response mechanism to facilitate calling custom functions to perform application-specific resource management functionality, report custom metrics or events, or take other appropriate actions, in response to rising heap memory size.
+
+### Support statement
+We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
+See the [Go agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy) for details about supported versions of the Go agent and third-party components.
+
+### Fixed
+  - Added protection around transaction methods to gracefully return when the transaction object is `nil`.
+
 ## 3.36.0
 ### Enhanced
   - Internal improvements to securityagent integration to better support trace handling and other support for security analysis of applications under test, now v1.3.4; affects the following other integrations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,13 @@
      - Labels are defined via `ConfigLabels(...)` or `NEW_RELIC_LABELS`
   - Added memory allocation limit detection/response mechanism to facilitate calling custom functions to perform application-specific resource management functionality, report custom metrics or events, or take other appropriate actions, in response to rising heap memory size.
 
+### Fixed
+  - Added protection around transaction methods to gracefully return when the transaction object is `nil`.
+
 ### Support statement
 We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
 See the [Go agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy) for details about supported versions of the Go agent and third-party components.
 
-### Fixed
-  - Added protection around transaction methods to gracefully return when the transaction object is `nil`.
 
 ## 3.36.0
 ### Enhanced

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Go is a compiled language, and doesn’t use a virtual machine. This means that 
 
 ### Compatibility and Requirements
 
-For the latest version of the agent, Go 1.18+ is required.
+For the latest version of the agent, Go 1.22+ is required.
 
 Linux, OS X, and Windows (Vista, Server 2008 and later) are supported.
 

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -1,11 +1,12 @@
 module github.com/newrelic/go-agent/v3
 
-go 1.21
+go 1.22
 
 require (
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2
 )
+
 
 retract v3.22.0 // release process error corrected in v3.22.1
 

--- a/v3/integrations/logcontext-v2/logWriter/go.mod
+++ b/v3/integrations/logcontext-v2/logWriter/go.mod
@@ -1,9 +1,9 @@
 module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/logWriter
 
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter v1.0.0
 )
 

--- a/v3/integrations/logcontext-v2/nrlogrus/go.mod
+++ b/v3/integrations/logcontext-v2/nrlogrus/go.mod
@@ -1,9 +1,9 @@
 module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrlogrus
 
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/sirupsen/logrus v1.8.1
 )
 

--- a/v3/integrations/logcontext-v2/nrslog/go.mod
+++ b/v3/integrations/logcontext-v2/nrslog/go.mod
@@ -1,7 +1,8 @@
 module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrslog
 
-go 1.21
+go 1.22
 
-require github.com/newrelic/go-agent/v3 v3.36.0
+require github.com/newrelic/go-agent/v3 v3.37.0
+
 
 replace github.com/newrelic/go-agent/v3 => ../../..

--- a/v3/integrations/logcontext-v2/nrwriter/go.mod
+++ b/v3/integrations/logcontext-v2/nrwriter/go.mod
@@ -1,8 +1,8 @@
 module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter
 
-go 1.21
+go 1.22
 
-require github.com/newrelic/go-agent/v3 v3.36.0
+require github.com/newrelic/go-agent/v3 v3.37.0
 
 
 replace github.com/newrelic/go-agent/v3 => ../../..

--- a/v3/integrations/logcontext-v2/nrzap/go.mod
+++ b/v3/integrations/logcontext-v2/nrzap/go.mod
@@ -1,9 +1,9 @@
 module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrzap
 
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	go.uber.org/zap v1.24.0
 )
 

--- a/v3/integrations/logcontext-v2/nrzerolog/go.mod
+++ b/v3/integrations/logcontext-v2/nrzerolog/go.mod
@@ -1,9 +1,9 @@
 module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrzerolog
 
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/rs/zerolog v1.26.1
 )
 

--- a/v3/integrations/logcontext-v2/zerologWriter/go.mod
+++ b/v3/integrations/logcontext-v2/zerologWriter/go.mod
@@ -1,9 +1,9 @@
 module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/zerologWriter
 
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter v1.0.0
 	github.com/rs/zerolog v1.27.0
 )

--- a/v3/integrations/logcontext/nrlogrusplugin/go.mod
+++ b/v3/integrations/logcontext/nrlogrusplugin/go.mod
@@ -2,10 +2,10 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext/nrlogrusplugin
 
 // As of Dec 2019, the logrus go.mod file uses 1.13:
 // https://github.com/sirupsen/logrus/blob/master/go.mod
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	// v1.4.0 is required for for the log.WithContext.
 	github.com/sirupsen/logrus v1.4.0
 )

--- a/v3/integrations/nramqp/go.mod
+++ b/v3/integrations/nramqp/go.mod
@@ -1,9 +1,9 @@
 module github.com/newrelic/go-agent/v3/integrations/nramqp
 
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/rabbitmq/amqp091-go v1.9.0
 )
 replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nrawsbedrock/go.mod
+++ b/v3/integrations/nrawsbedrock/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/go-agent/v3/integrations/nrawsbedrock
 
-go 1.21
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.26.0
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.7.3
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.7.1
 	github.com/google/uuid v1.6.0
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrawssdk-v1/go.mod
+++ b/v3/integrations/nrawssdk-v1/go.mod
@@ -3,12 +3,12 @@ module github.com/newrelic/go-agent/v3/integrations/nrawssdk-v1
 // As of Dec 2019, aws-sdk-go's go.mod does not specify a Go version.  1.6 is
 // the earliest version of Go tested by aws-sdk-go's CI:
 // https://github.com/aws/aws-sdk-go/blob/master/.travis.yml
-go 1.21
+go 1.22
 
 require (
 	// v1.15.0 is the first aws-sdk-go version with module support.
 	github.com/aws/aws-sdk-go v1.34.0
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrawssdk-v2/go.mod
+++ b/v3/integrations/nrawssdk-v2/go.mod
@@ -2,9 +2,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrawssdk-v2
 
 // As of May 2021, the aws-sdk-go-v2 go.mod file uses 1.15:
 // https://github.com/aws/aws-sdk-go-v2/blob/master/go.mod
-go 1.21
-
-toolchain go1.21.0
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.4
@@ -14,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.61.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.34.6
 	github.com/aws/smithy-go v1.20.4
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrb3/go.mod
+++ b/v3/integrations/nrb3/go.mod
@@ -1,8 +1,8 @@
 module github.com/newrelic/go-agent/v3/integrations/nrb3
 
-go 1.21
+go 1.22
 
-require github.com/newrelic/go-agent/v3 v3.36.0
+require github.com/newrelic/go-agent/v3 v3.37.0
 
 
 replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nrecho-v3/go.mod
+++ b/v3/integrations/nrecho-v3/go.mod
@@ -2,13 +2,13 @@ module github.com/newrelic/go-agent/v3/integrations/nrecho-v3
 
 // 1.7 is the earliest version of Go tested by v3.1.0:
 // https://github.com/labstack/echo/blob/v3.1.0/.travis.yml
-go 1.21
+go 1.22
 
 require (
 	// v3.1.0 is the earliest v3 version of Echo that works with modules due
 	// to the github.com/rsc/letsencrypt import of v3.0.0.
 	github.com/labstack/echo v3.1.0+incompatible
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrecho-v4/go.mod
+++ b/v3/integrations/nrecho-v4/go.mod
@@ -2,11 +2,11 @@ module github.com/newrelic/go-agent/v3/integrations/nrecho-v4
 
 // As of Jun 2022, the echo go.mod file uses 1.17:
 // https://github.com/labstack/echo/blob/master/go.mod
-go 1.21
+go 1.22
 
 require (
 	github.com/labstack/echo/v4 v4.9.0
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrelasticsearch-v7/go.mod
+++ b/v3/integrations/nrelasticsearch-v7/go.mod
@@ -2,11 +2,11 @@ module github.com/newrelic/go-agent/v3/integrations/nrelasticsearch-v7
 
 // As of Jan 2020, the v7 elasticsearch go.mod uses 1.11:
 // https://github.com/elastic/go-elasticsearch/blob/7.x/go.mod
-go 1.21
+go 1.22
 
 require (
 	github.com/elastic/go-elasticsearch/v7 v7.17.0
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrfasthttp/examples/client-fasthttp/go.mod
+++ b/v3/integrations/nrfasthttp/examples/client-fasthttp/go.mod
@@ -1,9 +1,9 @@
 module client-example
 
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/newrelic/go-agent/v3/integrations/nrfasthttp v1.0.0
 	github.com/valyala/fasthttp v1.49.0
 )

--- a/v3/integrations/nrfasthttp/examples/server-fasthttp/go.mod
+++ b/v3/integrations/nrfasthttp/examples/server-fasthttp/go.mod
@@ -1,9 +1,9 @@
 module server-example
 
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/newrelic/go-agent/v3/integrations/nrfasthttp v1.0.0
 	github.com/valyala/fasthttp v1.49.0
 )

--- a/v3/integrations/nrfasthttp/go.mod
+++ b/v3/integrations/nrfasthttp/go.mod
@@ -1,9 +1,9 @@
 module github.com/newrelic/go-agent/v3/integrations/nrfasthttp
 
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/valyala/fasthttp v1.49.0
 )
 

--- a/v3/integrations/nrgin/go.mod
+++ b/v3/integrations/nrgin/go.mod
@@ -2,11 +2,11 @@ module github.com/newrelic/go-agent/v3/integrations/nrgin
 
 // As of Dec 2019, the gin go.mod file uses 1.12:
 // https://github.com/gin-gonic/gin/blob/master/go.mod
-go 1.21
+go 1.22
 
 require (
 	github.com/gin-gonic/gin v1.9.1
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrgorilla/go.mod
+++ b/v3/integrations/nrgorilla/go.mod
@@ -2,12 +2,12 @@ module github.com/newrelic/go-agent/v3/integrations/nrgorilla
 
 // As of Dec 2019, the gorilla/mux go.mod file uses 1.12:
 // https://github.com/gorilla/mux/blob/master/go.mod
-go 1.21
+go 1.22
 
 require (
 	// v1.7.0 is the earliest version of Gorilla using modules.
 	github.com/gorilla/mux v1.7.0
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrgraphgophers/go.mod
+++ b/v3/integrations/nrgraphgophers/go.mod
@@ -2,12 +2,12 @@ module github.com/newrelic/go-agent/v3/integrations/nrgraphgophers
 
 // As of Jan 2020, the graphql-go go.mod file uses 1.13:
 // https://github.com/graph-gophers/graphql-go/blob/master/go.mod
-go 1.21
+go 1.22
 
 require (
 	// graphql-go has no tagged releases as of Jan 2020.
 	github.com/graph-gophers/graphql-go v1.3.0
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrgraphqlgo/example/go.mod
+++ b/v3/integrations/nrgraphqlgo/example/go.mod
@@ -1,11 +1,11 @@
 module github.com/newrelic/go-agent/v3/integrations/nrgraphqlgo/example
 
-go 1.21
+go 1.22
 
 require (
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/graphql-go-handler v0.2.3
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/newrelic/go-agent/v3/integrations/nrgraphqlgo v1.0.0
 )
 

--- a/v3/integrations/nrgraphqlgo/go.mod
+++ b/v3/integrations/nrgraphqlgo/go.mod
@@ -1,10 +1,10 @@
 module github.com/newrelic/go-agent/v3/integrations/nrgraphqlgo
 
-go 1.21
+go 1.22
 
 require (
 	github.com/graphql-go/graphql v0.8.1
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrgrpc/go.mod
+++ b/v3/integrations/nrgrpc/go.mod
@@ -1,12 +1,12 @@
 module github.com/newrelic/go-agent/v3/integrations/nrgrpc
 
-go 1.21
+go 1.22
 
 require (
 	// protobuf v1.3.0 is the earliest version using modules, we use v1.3.1
 	// because all dependencies were removed in this version.
 	github.com/golang/protobuf v1.5.4
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/newrelic/go-agent/v3/integrations/nrsecurityagent v1.1.0
 	// v1.15.0 is the earliest version of grpc using modules.
 	google.golang.org/grpc v1.65.0

--- a/v3/integrations/nrhttprouter/go.mod
+++ b/v3/integrations/nrhttprouter/go.mod
@@ -2,12 +2,12 @@ module github.com/newrelic/go-agent/v3/integrations/nrhttprouter
 
 // As of Dec 2019, the httprouter go.mod file uses 1.7:
 // https://github.com/julienschmidt/httprouter/blob/master/go.mod
-go 1.21
+go 1.22
 
 require (
 	// v1.3.0 is the earliest version of httprouter using modules.
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrlambda/go.mod
+++ b/v3/integrations/nrlambda/go.mod
@@ -1,10 +1,10 @@
 module github.com/newrelic/go-agent/v3/integrations/nrlambda
 
-go 1.21
+go 1.22
 
 require (
 	github.com/aws/aws-lambda-go v1.41.0
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrlogrus/go.mod
+++ b/v3/integrations/nrlogrus/go.mod
@@ -2,10 +2,10 @@ module github.com/newrelic/go-agent/v3/integrations/nrlogrus
 
 // As of Dec 2019, the logrus go.mod file uses 1.13:
 // https://github.com/sirupsen/logrus/blob/master/go.mod
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrlogrus v1.0.0
 	// v1.1.0 is required for the Logger.GetLevel method, and is the earliest
 	// version of logrus using modules.

--- a/v3/integrations/nrlogxi/go.mod
+++ b/v3/integrations/nrlogxi/go.mod
@@ -2,12 +2,12 @@ module github.com/newrelic/go-agent/v3/integrations/nrlogxi
 
 // As of Dec 2019, logxi requires 1.3+:
 // https://github.com/mgutz/logxi#requirements
-go 1.21
+go 1.22
 
 require (
 	// 'v1', at commit aebf8a7d67ab, is the only logxi release.
 	github.com/mgutz/logxi v0.0.0-20161027140823-aebf8a7d67ab
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrmicro/go.mod
+++ b/v3/integrations/nrmicro/go.mod
@@ -2,15 +2,15 @@ module github.com/newrelic/go-agent/v3/integrations/nrmicro
 
 // As of Dec 2019, the go-micro go.mod file uses 1.13:
 // https://github.com/micro/go-micro/blob/master/go.mod
-go 1.21
+go 1.22
 
-toolchain go1.23.4
+toolchain go1.24.0
 
 require (
 	github.com/golang/protobuf v1.5.4
 	github.com/micro/go-micro v1.8.0
-	github.com/newrelic/go-agent/v3 v3.36.0
-	google.golang.org/protobuf v1.36.2
+	github.com/newrelic/go-agent/v3 v3.37.0
+	google.golang.org/protobuf v1.36.4
 )
 
 

--- a/v3/integrations/nrmongo/go.mod
+++ b/v3/integrations/nrmongo/go.mod
@@ -2,10 +2,10 @@ module github.com/newrelic/go-agent/v3/integrations/nrmongo
 
 // As of Dec 2019, 1.10 is the mongo-driver requirement:
 // https://github.com/mongodb/mongo-go-driver#requirements
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	// mongo-driver does not support modules as of Nov 2019.
 	go.mongodb.org/mongo-driver v1.10.2
 )

--- a/v3/integrations/nrmssql/go.mod
+++ b/v3/integrations/nrmssql/go.mod
@@ -1,10 +1,10 @@
 module github.com/newrelic/go-agent/v3/integrations/nrmssql
 
-go 1.21
+go 1.22
 
 require (
 	github.com/microsoft/go-mssqldb v0.19.0
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrmysql/go.mod
+++ b/v3/integrations/nrmysql/go.mod
@@ -1,13 +1,13 @@
 module github.com/newrelic/go-agent/v3/integrations/nrmysql
 
 // 1.10 is the Go version in mysql's go.mod
-go 1.21
+go 1.22
 
 require (
 	// v1.5.0 is the first mysql version to support gomod
 	github.com/go-sql-driver/mysql v1.6.0
 	// v3.3.0 includes the new location of ParseQuery
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrnats/go.mod
+++ b/v3/integrations/nrnats/go.mod
@@ -2,14 +2,14 @@ module github.com/newrelic/go-agent/v3/integrations/nrnats
 
 // As of Jun 2023, 1.19 is the earliest version of Go tested by nats:
 // https://github.com/nats-io/nats.go/blob/master/.travis.yml
-go 1.21
+go 1.22
 
 toolchain go1.23.4
 
 require (
 	github.com/nats-io/nats-server v1.4.1
 	github.com/nats-io/nats.go v1.36.0
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrnats/test/go.mod
+++ b/v3/integrations/nrnats/test/go.mod
@@ -1,14 +1,14 @@
 module github.com/newrelic/go-agent/v3/integrations/test
 
 // This module exists to avoid having extra nrnats module dependencies.
-go 1.21
+go 1.22
 
 replace github.com/newrelic/go-agent/v3/integrations/nrnats v1.0.0 => ../
 
 require (
 	github.com/nats-io/nats-server v1.4.1
 	github.com/nats-io/nats.go v1.17.0
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/newrelic/go-agent/v3/integrations/nrnats v1.0.0
 )
 

--- a/v3/integrations/nropenai/go.mod
+++ b/v3/integrations/nropenai/go.mod
@@ -1,10 +1,10 @@
 module github.com/newrelic/go-agent/v3/integrations/nropenai
 
-go 1.21
+go 1.22
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/pkoukk/tiktoken-go v0.1.6
 	github.com/sashabaranov/go-openai v1.20.2
 )

--- a/v3/integrations/nrpgx/example/sqlx/go.mod
+++ b/v3/integrations/nrpgx/example/sqlx/go.mod
@@ -1,10 +1,10 @@
 // This sqlx example is a separate module to avoid adding sqlx dependency to the
 // nrpgx go.mod file.
 module github.com/newrelic/go-agent/v3/integrations/nrpgx/example/sqlx
-go 1.21
+go 1.22
 require (
 	github.com/jmoiron/sqlx v1.2.0
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/newrelic/go-agent/v3/integrations/nrpgx v0.0.0
 )
 replace github.com/newrelic/go-agent/v3/integrations/nrpgx => ../../

--- a/v3/integrations/nrpgx/go.mod
+++ b/v3/integrations/nrpgx/go.mod
@@ -1,11 +1,11 @@
 module github.com/newrelic/go-agent/v3/integrations/nrpgx
 
-go 1.21
+go 1.22
 
 require (
 	github.com/jackc/pgx v3.6.2+incompatible
 	github.com/jackc/pgx/v4 v4.18.2
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrpgx5/go.mod
+++ b/v3/integrations/nrpgx5/go.mod
@@ -1,13 +1,13 @@
 module github.com/newrelic/go-agent/v3/integrations/nrpgx5
 
-go 1.21
+go 1.22
 
-toolchain go1.23.4
+toolchain go1.24.0
 
 require (
 	github.com/egon12/pgsnap v0.0.0-20221022154027-2847f0124ed8
 	github.com/jackc/pgx/v5 v5.5.4
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/v3/integrations/nrpkgerrors/go.mod
+++ b/v3/integrations/nrpkgerrors/go.mod
@@ -2,10 +2,10 @@ module github.com/newrelic/go-agent/v3/integrations/nrpkgerrors
 
 // As of Dec 2019, 1.11 is the earliest version of Go tested by pkg/errors:
 // https://github.com/pkg/errors/blob/master/.travis.yml
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	// v0.8.0 was the last release in 2016, and when
 	// major development on pkg/errors stopped.
 	github.com/pkg/errors v0.8.0

--- a/v3/integrations/nrpq/example/sqlx/go.mod
+++ b/v3/integrations/nrpq/example/sqlx/go.mod
@@ -1,11 +1,11 @@
 // This sqlx example is a separate module to avoid adding sqlx dependency to the
 // nrpq go.mod file.
 module github.com/newrelic/go-agent/v3/integrations/nrpq/example/sqlx
-go 1.21
+go 1.22
 require (
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.1.0
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/newrelic/go-agent/v3/integrations/nrpq v0.0.0
 )
 replace github.com/newrelic/go-agent/v3/integrations/nrpq => ../../

--- a/v3/integrations/nrpq/go.mod
+++ b/v3/integrations/nrpq/go.mod
@@ -1,12 +1,12 @@
 module github.com/newrelic/go-agent/v3/integrations/nrpq
 
-go 1.21
+go 1.22
 
 require (
 	// NewConnector dsn parsing tests expect v1.1.0 error return behavior.
 	github.com/lib/pq v1.1.0
 	// v3.3.0 includes the new location of ParseQuery
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrredis-v7/go.mod
+++ b/v3/integrations/nrredis-v7/go.mod
@@ -1,11 +1,11 @@
 module github.com/newrelic/go-agent/v3/integrations/nrredis-v7
 
 // https://github.com/go-redis/redis/blob/master/go.mod
-go 1.21
+go 1.22
 
 require (
 	github.com/go-redis/redis/v7 v7.0.0-beta.5
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrredis-v8/go.mod
+++ b/v3/integrations/nrredis-v8/go.mod
@@ -1,11 +1,11 @@
 module github.com/newrelic/go-agent/v3/integrations/nrredis-v8
 
 // https://github.com/go-redis/redis/blob/master/go.mod
-go 1.21
+go 1.22
 
 require (
 	github.com/go-redis/redis/v8 v8.4.0
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrredis-v9/go.mod
+++ b/v3/integrations/nrredis-v9/go.mod
@@ -1,10 +1,10 @@
 module github.com/newrelic/go-agent/v3/integrations/nrredis-v9
 
 // https://github.com/redis/go-redis/blob/a38f75b640398bd709ee46c778a23e80e09d48b5/go.mod#L3
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/redis/go-redis/v9 v9.0.2
 )
 

--- a/v3/integrations/nrsarama/go.mod
+++ b/v3/integrations/nrsarama/go.mod
@@ -1,12 +1,12 @@
 module github.com/newrelic/go-agent/v3/integrations/nrsarama
 
-go 1.21
+go 1.22
 
-toolchain go1.23.4
+toolchain go1.24.0
 
 require (
 	github.com/Shopify/sarama v1.38.1
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/v3/integrations/nrsecurityagent/go.mod
+++ b/v3/integrations/nrsecurityagent/go.mod
@@ -1,10 +1,10 @@
 module github.com/newrelic/go-agent/v3/integrations/nrsecurityagent
 
-go 1.21
+go 1.22
 
 require (
 	github.com/newrelic/csec-go-agent v1.6.0
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/newrelic/go-agent/v3/integrations/nrsqlite3 v1.2.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/v3/integrations/nrslog/go.mod
+++ b/v3/integrations/nrslog/go.mod
@@ -1,10 +1,10 @@
 module github.com/newrelic/go-agent/v3/integrations/nrslog
 
 // The new log/slog package in Go 1.21 brings structured logging to the standard library.
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/v3/integrations/nrsnowflake/go.mod
+++ b/v3/integrations/nrsnowflake/go.mod
@@ -1,9 +1,9 @@
 module github.com/newrelic/go-agent/v3/integrations/nrsnowflake
 
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/snowflakedb/gosnowflake v1.6.19
 )
 

--- a/v3/integrations/nrsqlite3/go.mod
+++ b/v3/integrations/nrsqlite3/go.mod
@@ -2,12 +2,12 @@ module github.com/newrelic/go-agent/v3/integrations/nrsqlite3
 
 // As of Dec 2019, 1.9 is the oldest version of Go tested by go-sqlite3:
 // https://github.com/mattn/go-sqlite3/blob/master/.travis.yml
-go 1.21
+go 1.22
 
 require (
 	github.com/mattn/go-sqlite3 v1.0.0
 	// v3.3.0 includes the new location of ParseQuery
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrstan/examples/go.mod
+++ b/v3/integrations/nrstan/examples/go.mod
@@ -1,9 +1,9 @@
 module github.com/newrelic/go-agent/v3/integrations/nrstan/examples
 // This module exists to avoid a dependency on nrnrats.
-go 1.21
+go 1.22
 require (
 	github.com/nats-io/stan.go v0.5.0
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/newrelic/go-agent/v3/integrations/nrnats v0.0.0
 	github.com/newrelic/go-agent/v3/integrations/nrstan v0.0.0
 )

--- a/v3/integrations/nrstan/go.mod
+++ b/v3/integrations/nrstan/go.mod
@@ -2,13 +2,13 @@ module github.com/newrelic/go-agent/v3/integrations/nrstan
 
 // As of Dec 2019, 1.11 is the earliest Go version tested by Stan:
 // https://github.com/nats-io/stan.go/blob/master/.travis.yml
-go 1.21
+go 1.22
 
 toolchain go1.23.4
 
 require (
 	github.com/nats-io/stan.go v0.10.4
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 )
 
 

--- a/v3/integrations/nrstan/test/go.mod
+++ b/v3/integrations/nrstan/test/go.mod
@@ -2,14 +2,14 @@ module github.com/newrelic/go-agent/v3/integrations/nrstan/test
 
 // This module exists to avoid a dependency on
 // github.com/nats-io/nats-streaming-server in nrstan.
-go 1.21
+go 1.22
 
 toolchain go1.23.4
 
 require (
 	github.com/nats-io/nats-streaming-server v0.25.6
 	github.com/nats-io/stan.go v0.10.4
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/newrelic/go-agent/v3/integrations/nrstan v0.0.0
 )
 

--- a/v3/integrations/nrzap/go.mod
+++ b/v3/integrations/nrzap/go.mod
@@ -2,10 +2,10 @@ module github.com/newrelic/go-agent/v3/integrations/nrzap
 
 // As of Dec 2019, zap has 1.13 in their go.mod file:
 // https://github.com/uber-go/zap/blob/master/go.mod
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	// v1.12.0 is the earliest version of zap using modules.
 	go.uber.org/zap v1.12.0
 )

--- a/v3/integrations/nrzerolog/go.mod
+++ b/v3/integrations/nrzerolog/go.mod
@@ -1,9 +1,9 @@
 module github.com/newrelic/go-agent/v3/integrations/nrzerolog
 
-go 1.21
+go 1.22
 
 require (
-	github.com/newrelic/go-agent/v3 v3.36.0
+	github.com/newrelic/go-agent/v3 v3.37.0
 	github.com/rs/zerolog v1.28.0
 )
 replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/newrelic/transaction.go
+++ b/v3/newrelic/transaction.go
@@ -333,11 +333,7 @@ func (txn *Transaction) startSegmentAt(at time.Time) SegmentStartTime {
 //	// ... code you want to time here ...
 //	segment.End()
 func (txn *Transaction) StartSegment(name string) *Segment {
-	if nilTransaction(txn) {
-		return &Segment{} // return a non-nil Segment to avoid nil dereference
-	}
-
-	if IsSecurityAgentPresent() && txn.thread.thread != nil && txn.thread.thread.threadID > 0 {
+	if IsSecurityAgentPresent() && !nilTransaction(txn) && txn.thread.thread != nil && txn.thread.thread.threadID > 0 {
 		// async segment start
 		secureAgent.SendEvent("NEW_GOROUTINE_LINKER", txn.thread.getCsecData())
 	}

--- a/v3/newrelic/version.go
+++ b/v3/newrelic/version.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Version is the full string version of this Go Agent.
-	Version = "3.36.0"
+	Version = "3.37.0"
 )
 
 var (


### PR DESCRIPTION
## 3.37.0
### Enhanced
  - Implemented a new approach to integrating New Relic with SLOG that is more lightweight, out of the way, and collects richer data. These changes have been constructed to be completely backwards-compatible with v1 of nrslog. Changes include:
     - Wrapping `slog.Handler` objects with errors to allow users to handle invalid use cases
     - A complete rework of log enrichment so that New Relic linking metadata does not invalidate JSON, BSON, or YAML scanners. This new approach will instead inject the linking metadata as a key-value pair.
     - Complete support for `With()`, `WithGroup()`, and attributes for automatic instrumentation.
     - Performance operations.
     - Robust testing (close to 90% coverage).
     - **This updates logcontext-v2/nrslog to v1.4.0.**
  - Now custom application tags (labels) may be added to all forwarded log events.
     - Enabled if `ConfigAppLogForwardingLabelsEnabled(true)` or `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_ENABLED=TRUE`
     - May exclude labels named in `ConfigAppLogForwardingLabelsExclude("label1","label2",...)` or `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE="label1,label2,..."`
     - Labels are defined via `ConfigLabels(...)` or `NEW_RELIC_LABELS`
  - Added memory allocation limit detection/response mechanism to facilitate calling custom functions to perform application-specific resource management functionality, report custom metrics or events, or take other appropriate actions, in response to rising heap memory size.

### Support statement
We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
See the [Go agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy) for details about supported versions of the Go agent and third-party components.

