### PR TITLE
Update nrslog example

### DIFF
--- a/v3/integrations/logcontext-v2/nrslog/example/main.go
+++ b/v3/integrations/logcontext-v2/nrslog/example/main.go
@@ -21,7 +21,10 @@ func main() {
 	}
 
 	app.WaitForConnection(time.Second * 5)
-	log := slog.New(nrslog.TextHandler(app, os.Stdout, &slog.HandlerOptions{}))
+
+	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{})
+	nrHandler := nrslog.WrapHandler(app, handler)
+	log := slog.New(nrHandler)
 
 	log.Info("I am a log message")
 


### PR DESCRIPTION
nrslog in logs in context used a deprecated version of the nrslog API. We update the example to reflect better how to use it using the new API so that users can reference it and integrate the new API in their code.