### PR TITLE
move linking metadata to the log message

### DIFF
--- a/v3/integrations/logcontext-v2/nrslog/handler_test.go
+++ b/v3/integrations/logcontext-v2/nrslog/handler_test.go
@@ -698,7 +698,7 @@ func BenchmarkLinkingStringEnrichment(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		h.enrichRecord(app.Application, &record)
+		h.enrichRecord(app.Application, nil, &record)
 	}
 }
 


### PR DESCRIPTION
Fix: log-context linking metadata can only be stored in the message of a log, not as an attribute