### PR TITLE
redis-v9 datastore enhancements

### DIFF
--- a/v3/integrations/nrredis-v9/go.mod
+++ b/v3/integrations/nrredis-v9/go.mod
@@ -8,5 +8,4 @@ require (
 	github.com/redis/go-redis/v9 v9.0.2
 )
 
-
 replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nrredis-v9/nrredis.go
+++ b/v3/integrations/nrredis-v9/nrredis.go
@@ -9,7 +9,9 @@ package nrredis
 
 import (
 	"context"
+	"fmt"
 	"net"
+	"slices"
 	"strings"
 
 	"github.com/newrelic/go-agent/v3/internal"
@@ -22,6 +24,13 @@ func init() { internal.TrackUsage("integration", "datastore", "redis") }
 type contextKeyType struct{}
 
 type hook struct {
+	includeKeys        bool
+	operationSet       []string
+	agentConfiguration struct {
+		retrieved              bool
+		queryParametersEnabled bool
+		rawQueryEnabled        bool
+	}
 	segment newrelic.DatastoreSegment
 }
 
@@ -31,6 +40,56 @@ var (
 	segmentContextKey = contextKeyType(struct{}{})
 )
 
+// NewHookWithOptions is like NewHook but allows integration-specific
+// options to be included as well, such as ConfigDatastoreKeysEanbled.
+func NewHookWithOptions(opts *redis.Options, o ...nrredisOpts) redis.Hook {
+	h := hook{}
+	for _, opt := range o {
+		opt(&h)
+	}
+	return newHook(h, opts)
+}
+
+type nrredisOpts func(*hook)
+
+// ConfigDatastoreKeysEnabled controls whether we report the names of
+// keys along with the datastore operations in our telemetry. Since the
+// keys themselves might contain sensitive information in some databases
+// unlike, say, the general case of a parameterized SQL query with placeholders,
+// this is disabled by default. However, if you know your keys are safe to
+// expose in your telemetry data and wish to see them there, call this method
+// on your hook value with a true parameter.
+//
+// N.B. for Redis database operations, note that for our purposes what we are
+// referring to here as "keys" are in fact merely the 2nd parameter in the
+// operation parameter list being sent to the Redis server. Typically this
+// will be the key or similar ID for the operation at hand, but this will vary
+// based on the particular operation being performed. Take care to ensure that
+// it is acceptable to record this parameter in your telemetry dataset before
+// enabling this option, or restrict the operations for which you wish to expose
+// this data by also specifying the ConfigLimitOperations option.
+//
+// If the agent has also enabled raw database queries via the ConfigDatastoreRawQuery
+// option, then the full redis operation will be exposed instead of just the operation
+// and following parameter since that option enables the forwarding of the full database
+// command string and all data.
+func ConfigDatastoreKeysEnabled(enabled bool) func(*hook) {
+	return func(h *hook) {
+		h.includeKeys = enabled
+	}
+}
+
+// ConfigLimitOperations restricts the set of operations which will report their
+// keys (assuming ConfigDatastoreKeysEnabled is also given with a true value)
+// to only those operations whose names match those passed to this option.
+func ConfigLimitOperations(name ...string) func(*hook) {
+	return func(h *hook) {
+		for _, n := range name {
+			h.operationSet = append(h.operationSet, n)
+		}
+	}
+}
+
 // NewHook creates a redis.Hook to instrument Redis calls.  Add it to your
 // client, then ensure that all calls contain a context which includes the
 // transaction.  The options are optional.  Provide them to get instance metrics
@@ -38,6 +97,10 @@ var (
 // redis.Client, redis.ClusterClient, and redis.Ring.
 func NewHook(opts *redis.Options) redis.Hook {
 	h := hook{}
+	return newHook(h, opts)
+}
+
+func newHook(h hook, opts *redis.Options) redis.Hook {
 	h.segment.Product = newrelic.DatastoreRedis
 	if opts == nil {
 		return h
@@ -95,6 +158,38 @@ func (h hook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
 		ctx = h.before(ctx, cmd.Name())
 		err := next(ctx, cmd)
 		h.after(ctx)
+		if ctx != nil && h.includeKeys {
+			// Only go to the expense of collecting this data if we are going to
+			// possibly be reporting it out later, so check the agent's configuration
+			// (but only once)
+			if !h.agentConfiguration.retrieved {
+				if txn := newrelic.FromContext(ctx); txn != nil {
+					if cfg, isValid := txn.Application().Config(); isValid {
+						h.agentConfiguration.retrieved = true
+						h.agentConfiguration.queryParametersEnabled = cfg.DatastoreTracer.QueryParameters.Enabled
+						h.agentConfiguration.rawQueryEnabled = cfg.DatastoreTracer.RawQuery.Enabled
+					}
+				}
+			}
+			operationName := cmd.Name()
+			if len(h.operationSet) == 0 || slices.ContainsFunc(h.operationSet, func(op string) bool { return strings.EqualFold(operationName, op) }) {
+				args := cmd.Args()
+				if args != nil && len(args) > 0 {
+					if h.agentConfiguration.rawQueryEnabled {
+						h.segment.RawQuery = fmt.Sprintf("%v", args)
+					}
+					if len(args) > 1 {
+						if h.agentConfiguration.queryParametersEnabled {
+							if h.segment.QueryParameters == nil {
+								h.segment.QueryParameters = make(map[string]any)
+							}
+							h.segment.QueryParameters["key"] = args[1]
+							h.segment.ParameterizedQuery = fmt.Sprintf("%v %v", args[0], args[1])
+						}
+					}
+				}
+			}
+		}
 		return err
 	}
 }

--- a/v3/integrations/nrredis-v9/nrredis_db_test.go
+++ b/v3/integrations/nrredis-v9/nrredis_db_test.go
@@ -1,0 +1,109 @@
+//go:build local_redis_test
+// +build local_redis_test
+
+// Copyright 2023 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nrredis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/newrelic/go-agent/v3/internal"
+	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	redis "github.com/redis/go-redis/v9"
+)
+
+// Performs live database testing with an instance of a local Redis database
+// on port 6379.
+func TestRealDatabaseOperations(t *testing.T) {
+	db := redis.NewClient(&redis.Options{
+		Addr: "localhost:6379",
+	})
+
+	app := integrationsupport.NewTestApp(nil, nil)
+	//txn := app.StartTransaction("build")
+	ctx := context.Background()
+	//ctx := newrelic.NewContext(context.Background(), txn)
+	db.AddHook(NewHookWithOptions(nil,
+		ConfigDatastoreKeysEnabled(true),
+		ConfigLimitOperations("get", "set"),
+	))
+
+	size, err := db.DBSize(ctx).Result()
+	if err != nil {
+		t.Fatalf("unable to get db size: %v", err)
+	}
+	if size != 0 {
+		t.Fatalf("database is not empty (size=%v), refusing to overwrite existing data; empty database before running tests", size)
+	}
+
+	testData := []struct {
+		Key   string
+		Value any
+	}{
+		{"Foo", "Bar"},
+		{"Spam", "Eggs"},
+		{"answer", 42},
+		{"maybe", true},
+	}
+
+	for i, d := range testData {
+		if err := db.Set(ctx, d.Key, d.Value, 0).Err(); err != nil {
+			t.Fatalf("database store of item %d failed: %v", i, err)
+		}
+	}
+	//txn.End()
+	txn2 := app.StartTransaction("query")
+	ctx2 := newrelic.NewContext(context.Background(), txn2)
+	for i, d := range testData {
+		r := db.Get(ctx2, d.Key)
+		v, err := r.Result()
+		if err != nil {
+			t.Fatalf("retrieval of item %d failed: %v", i, err)
+		}
+		switch d.Value.(type) {
+		case int:
+			ri, err := r.Int()
+			if err != nil {
+				t.Errorf("retrieved value \"%s\" of item %d isn't an integer", v, i)
+			}
+			if ri != d.Value {
+				t.Errorf("retrieved value of item %d was %v, expected %v", i, ri, d.Value)
+			}
+		case bool:
+			rb, err := r.Bool()
+			if err != nil {
+				t.Errorf("retrieved value \"%s\" of item %d isn't a boolean", v, i)
+			}
+			if rb != d.Value {
+				t.Errorf("retrieved value of item %d was %v, expected %v", i, rb, d.Value)
+			}
+		default:
+			if v != d.Value {
+				t.Errorf("retrieved value of item %d was %v, expected %v", i, v, d.Value)
+			}
+		}
+	}
+	txn2.End()
+	app.ExpectMetrics(t, []internal.WantMetric{
+		{Name: "OtherTransaction/Go/query", Forced: nil},
+		{Name: "OtherTransactionTotalTime/Go/query", Forced: nil},
+		{Name: "OtherTransaction/all", Forced: nil},
+		{Name: "OtherTransactionTotalTime", Forced: nil},
+		{Name: "Datastore/operation/Redis/get", Forced: nil},
+		{Name: "Datastore/operation/Redis/get", Scope: "OtherTransaction/Go/query", Forced: nil},
+		{Name: "Datastore/all", Forced: nil},
+		{Name: "Datastore/allOther", Forced: nil},
+		{Name: "Datastore/Redis/all", Forced: nil},
+		{Name: "Datastore/Redis/allOther", Forced: nil},
+		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther", Forced: nil},
+		{Name: "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all", Forced: nil},
+	})
+	//app.ExpectSpanEvents(t, []internal.WantEvent{})
+	app.ExpectSlowQueries(t, []internal.WantSlowQuery{})
+	// c.DatastoreTracer.SlowQuery.Threshold = 10 * time.Millisecond
+	// c.DatastoreTracer.RawQuery.Enabled = true
+}

--- a/v3/integrations/nrredis-v9/util/empty_db.go
+++ b/v3/integrations/nrredis-v9/util/empty_db.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func main() {
+	db := redis.NewClient(&redis.Options{
+		Addr: "localhost:6379",
+	})
+	ctx := context.Background()
+	size, err := db.DBSize(ctx).Result()
+	if err != nil {
+		log.Fatalf("unable to determine database size: %v", err)
+	}
+	if size == 0 {
+		log.Fatalf("database is already empty; Nothing to do here")
+	}
+
+	fmt.Printf("database size: %v. Empty database? [y/N] ", size)
+	reader := bufio.NewReader(os.Stdin)
+	input, _ := reader.ReadString('\n')
+	if strings.ToLower(strings.TrimSpace(input)) != "y" {
+		log.Fatalf("abandoning operation at user request")
+	}
+
+	// we'll retrieve and remove the contents individually so we also show what they were
+	// since we also use this as a debugging tool of sorts for the data in the database.
+	keys, err := db.Keys(ctx, "*").Result()
+	if err != nil {
+		log.Fatalf("unable to retrieve the keys: %v", err)
+	}
+
+	for i, key := range keys {
+		v, err := db.Get(ctx, key).Result()
+		if err != nil {
+			log.Fatalf("unable to retrieve value #%d (key \"%s\"): %v", i, key, err)
+		}
+		fmt.Printf("#%d: %s: %s\n", i, key, v)
+		if err = db.Del(ctx, key).Err(); err != nil {
+			log.Fatalf("unable to delete value #%d (key \"%s\"): %v", i, key, err)
+		}
+	}
+}


### PR DESCRIPTION
Addresses [Issue 1005](https://github.com/newrelic/go-agent/issues/1005).
This wasn't actually a bug *per se*, but the implementation of our agents currently don't include Redis parameters normally when reporting datastore telemetry since we can't necessarily assume they are the same sorts of things as, say, a parameterized query in a SQL database operation where we can report the parameterized query without the parameters. In this case, the key of a Redis operation might contain sensitive information depending upon how a particular database is organized. Generalizing further, the Redis database operations themselves comprise a large number of varied requests between client and server which overall have their 2nd data field as the interesting "key" or "id" value to report but not **all** of them in every case, so simply reporting that value may not always be the right thing to do.

As such, we didn't want to satisfy this customer request in a way that inadvertently might cause accidental issues at the same time, so the solution presented here seeks to address all of the above issues safely. The existing behavior remains the default. However, an enhanced reporting option may be enabled by the user if desired through a combination of APM agent and Redis integration package configuration options:

- A new hook function, `NewHookWithOptions`, should be used instead of `NewHook`, which allows the specification of configuration options for the integration package in addition to the Redis client configuration structure. (We added a new function to avoid a breaking change to existing users.)
- To this function you may pass `ConfigDatastoreKeysEnabled(true)` to have the integration package start reporting query details for Redis operations. If your agent is also set to recored paramaterized query strings (which it is by default), this will include the redis operation name ("get", "set", etc) plus the next parameter (typically the key).
- If you want to limit the Redis operations for which the query data is reported, also include the configuration option `ConfigLimitOperations("get", "set", ...)` with a list of the operation names you wish to have those details reported for.
- If the agent's configuration includes `ConfigDatastoreRawQuery(true)`, then the **full** database query data is included in the telemetry, which this PR now has the Redis integration also honor this configuration request. Use this setting with caution.
