### PR TITLE
Support For Fiber v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,7 @@ jobs:
           - dirs: v3/integrations/nrelasticsearch-v7
           - dirs: v3/integrations/nrgin
           - dirs: v3/integrations/nrfiber
+          - dirs: v3/integrations/nrfiber-next
           - dirs: v3/integrations/nrgorilla
           - dirs: v3/integrations/nrgraphgophers
           - dirs: v3/integrations/nrlogrus

--- a/v3/integrations/nrfiber-next/LICENSE.txt
+++ b/v3/integrations/nrfiber-next/LICENSE.txt
@@ -1,0 +1,206 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+Versions 3.8.0 and above for this project are licensed under Apache 2.0. For
+prior versions of this project, please see the LICENCE.txt file in the root
+directory of that version for more information.

--- a/v3/integrations/nrfiber-next/README.md
+++ b/v3/integrations/nrfiber-next/README.md
@@ -1,0 +1,10 @@
+# v3/integrations/nrfiber-next [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrfiber-next?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrfiber-next)
+
+Package `nrfiber-next` instruments https://github.com/gofiber/fiber v3(next) applications.
+
+```go
+import "github.com/newrelic/go-agent/v3/integrations/nrfiber-next"
+```
+
+For more information, see
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrfiber-next).

--- a/v3/integrations/nrfiber-next/example/main.go
+++ b/v3/integrations/nrfiber-next/example/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/newrelic/go-agent/v3/integrations/nrfiber-next"
+	"github.com/newrelic/go-agent/v3/newrelic"
+)
+
+func v1login(c fiber.Ctx)  { c.WriteString("v1 login") }
+func v1submit(c fiber.Ctx) { c.WriteString("v1 submit") }
+func v1read(c fiber.Ctx)   { c.WriteString("v1 read") }
+
+func main() {
+	app, err := newrelic.NewApplication(
+		newrelic.ConfigAppName("fiber App"),
+		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+		newrelic.ConfigDebugLogger(os.Stdout),
+		newrelic.ConfigCodeLevelMetricsEnabled(true),
+	)
+	if nil != err {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	router := fiber.New()
+	router.Use(nrfiber.Middleware(app))
+
+	// 404 handler
+	router.Get("/404", func(c fiber.Ctx) error {
+		c.SendStatus(404)
+		c.WriteString("returning 404")
+		return nil
+	})
+
+	//
+	router.Get("/change", func(c fiber.Ctx) error {
+		c.SendStatus(404)
+		c.SendStatus(200)
+		c.WriteString("actually ok!")
+		return nil
+	})
+
+	// Headers
+	router.Get("/headers", func(c fiber.Ctx) error {
+		// Since fiber.Response buffers the response code, response headers
+		// can be set afterwards.
+		c.SendStatus(200)
+		c.Response().Header.Set("X-Custom", "custom value")
+		c.SendString(`{"zip":"zap"}`)
+		return nil
+	})
+
+	router.Get("/txn", func(c fiber.Ctx) error {
+		txn := nrfiber.Transaction(c.Context())
+		txn.SetName("custom-name")
+		c.WriteString("changed the name of the transaction!")
+		return nil
+	})
+
+	// Since the handler function name is used as the transaction name,
+	// anonymous functions do not get usefully named.  We encourage
+	// transforming anonymous functions into named functions.
+	router.Get("/anon", func(c fiber.Ctx) error {
+		return c.SendString("anonymous function handler")
+	})
+
+	v1 := router.Group("/v1")
+	v1.Get("/login", func(c fiber.Ctx) error {
+		v1login(c)
+		return nil
+	})
+	v1.Get("/submit", func(c fiber.Ctx) error {
+		v1submit(c)
+		return nil
+	})
+	v1.Get("/read", func(c fiber.Ctx) error {
+		v1read(c)
+		return nil
+	})
+
+	router.Listen(":8000")
+}

--- a/v3/integrations/nrfiber-next/example/main_test.go
+++ b/v3/integrations/nrfiber-next/example/main_test.go
@@ -1,0 +1,128 @@
+package main_test
+
+import (
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/newrelic/go-agent/v3/integrations/nrfiber-next"
+	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
+)
+
+func setupTestApp(t *testing.T) *fiber.App {
+	app := integrationsupport.NewBasicTestApp().Application
+	if app == nil {
+		t.Fatal("Failed to create New Relic application")
+	}
+	// Create a new Fiber app
+	router := fiber.New()
+	router.Use(nrfiber.Middleware(app))
+	return router
+}
+
+func TestRoutes404(t *testing.T) {
+	app := setupTestApp(t)
+	app.Get("/404", func(c fiber.Ctx) error {
+		c.SendStatus(404)
+		return c.SendString("returning 404")
+	})
+
+	req := httptest.NewRequest("GET", "/404", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != 404 {
+		t.Errorf("Expected status code 404, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "returning 404" {
+		t.Errorf("Expected body 'returning 404', got '%s'", string(body))
+	}
+}
+
+func TestRouteStatusChange(t *testing.T) {
+	app := setupTestApp(t)
+	app.Get("/change", func(c fiber.Ctx) error {
+		c.SendStatus(404)
+		c.SendStatus(200)
+		return c.SendString("actually ok!")
+	})
+
+	req := httptest.NewRequest("GET", "/change", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Errorf("Expected final status code 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "actually ok!" {
+		t.Errorf("Expected body 'actually ok!', got '%s'", string(body))
+	}
+}
+
+func TestCustomHeaders(t *testing.T) {
+	app := setupTestApp(t)
+	app.Get("/headers", func(c fiber.Ctx) error {
+		c.SendStatus(200)
+		c.Response().Header.Set("X-Custom", "custom value")
+		return c.SendString(`{"zip":"zap"}`)
+	})
+
+	req := httptest.NewRequest("GET", "/headers", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Header.Get("X-Custom") != "custom value" {
+		t.Errorf("Expected X-Custom header 'custom value', got '%s'", resp.Header.Get("X-Custom"))
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != `{"zip":"zap"}` {
+		t.Errorf("Expected body '{\"zip\":\"zap\"}', got '%s'", string(body))
+	}
+}
+
+func TestV1GroupRoutes(t *testing.T) {
+	app := setupTestApp(t)
+
+	v1 := app.Group("/v1")
+	v1.Get("/login", func(c fiber.Ctx) error {
+		return c.SendString("login")
+	})
+	v1.Get("/submit", func(c fiber.Ctx) error {
+		return c.SendString("submit")
+	})
+	v1.Get("/read", func(c fiber.Ctx) error {
+		return c.SendString("read")
+	})
+
+	paths := []string{"/v1/login", "/v1/submit", "/v1/read"}
+	expected := []string{"login", "submit", "read"}
+
+	for i, path := range paths {
+		req := httptest.NewRequest("GET", path, nil)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resp.StatusCode != 200 {
+			t.Errorf("Expected status code 200 for %s, got %d", path, resp.StatusCode)
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != expected[i] {
+			t.Errorf("Expected body '%s' for %s, got '%s'", expected[i], path, string(body))
+		}
+	}
+}

--- a/v3/integrations/nrfiber-next/go.mod
+++ b/v3/integrations/nrfiber-next/go.mod
@@ -1,0 +1,40 @@
+module github.com/newrelic/go-agent/v3/integrations/nrfiber-next
+
+go 1.23
+
+toolchain go1.23.10
+
+require (
+	github.com/gofiber/fiber/v3 v3.0.0-beta.4
+	github.com/newrelic/go-agent/v3 v3.39.0
+	github.com/stretchr/testify v1.10.0
+	github.com/valyala/fasthttp v1.58.0
+)
+
+require (
+	github.com/andybalholm/brotli v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
+	github.com/gofiber/schema v1.2.0 // indirect
+	github.com/gofiber/utils/v2 v2.0.0-beta.7 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/klauspost/compress v1.17.11 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tinylib/msgp v1.2.5 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/tcplisten v1.0.0 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
+	golang.org/x/crypto v0.31.0 // indirect
+	golang.org/x/net v0.31.0 // indirect
+	golang.org/x/sys v0.28.0 // indirect
+	golang.org/x/text v0.21.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240528184218-531527333157 // indirect
+	google.golang.org/grpc v1.65.0 // indirect
+	google.golang.org/protobuf v1.34.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nrfiber-next/nfiber_test.go
+++ b/v3/integrations/nrfiber-next/nfiber_test.go
@@ -1,0 +1,445 @@
+package nrfiber
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/newrelic/go-agent/v3/internal"
+	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+// TestMiddleware_NoNewRelicApp ensures requests proceed normally if no New Relic app is provided
+func TestMiddleware_NoNewRelicApp(t *testing.T) {
+	fiberApp := fiber.New()
+	fiberApp.Use(Middleware(nil))
+
+	fiberApp.Get("/no-nr", func(c fiber.Ctx) error {
+		return c.SendString("No NR App")
+	})
+
+	// Simulate a request
+	req, err := http.NewRequest("GET", "/no-nr", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make a test request
+	resp, err := fiberApp.Test(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestMiddleware_Success checks if the middleware correctly creates a New Relic transaction
+func TestMiddleware_Success(t *testing.T) {
+	// Create a test New Relic application
+	app := integrationsupport.NewBasicTestApp()
+
+	// Initialize Fiber app with New Relic middleware
+	fiberApp := fiber.New()
+	fiberApp.Use(Middleware(app.Application))
+
+	// Define a sample route
+	fiberApp.Get("/test", func(c fiber.Ctx) error {
+		return c.SendString("Hello, World!")
+	})
+
+	// Simulate a request
+	req, err := http.NewRequest("GET", "/test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make a test request
+	resp, err := fiberApp.Test(req)
+
+	// Verify that no error occurred
+	require.Nil(t, err)
+
+	// Read the response body
+	body, _ := io.ReadAll(resp.Body)
+
+	if respBody := string(body); respBody != "Hello, World!" {
+		t.Error("wrong response body", respBody)
+	}
+
+	// Assertions
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Check if the transaction was created
+	app.ExpectTxnMetrics(t, internal.WantTxn{
+		Name:          "GET /test",
+		IsWeb:         true,
+		UnknownCaller: true,
+	})
+}
+
+// TestMiddleware_AnonymousFunctions checks if the middleware correctly handles anonymous functions
+func TestMiddleware_AnonymousFunctions(t *testing.T) {
+	app := integrationsupport.NewBasicTestApp()
+	fiberApp := fiber.New()
+	fiberApp.Use(Middleware(app.Application))
+	fiberApp.Get("/helloAnon", func(c fiber.Ctx) error {
+		return c.SendString("Hello, anon!")
+	})
+
+	req, err := http.NewRequest("GET", "/helloAnon", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Make a test request
+	resp, err := fiberApp.Test(req)
+	// Verify that no error occurred
+	require.Nil(t, err)
+
+	// Read the response body
+	body, _ := io.ReadAll(resp.Body)
+
+	if respBody := string(body); respBody != "Hello, anon!" {
+		t.Error("wrong response body", respBody)
+	}
+
+	app.ExpectTxnMetrics(t, internal.WantTxn{
+		Name:          "GET /helloAnon",
+		IsWeb:         true,
+		UnknownCaller: true,
+	})
+
+}
+
+// TestMiddleware_ErrorHandling checks if the middleware captures errors correctly
+func TestMiddleware_ErrorHandling(t *testing.T) {
+	app := integrationsupport.NewBasicTestApp()
+	fiberApp := fiber.New()
+	fiberApp.Use(Middleware(app.Application))
+
+	// Define a route that returns an error
+	fiberApp.Get("/error", func(c fiber.Ctx) error {
+		return fiber.ErrInternalServerError
+	})
+
+	// Simulate a request
+	req, err := http.NewRequest("GET", "/error", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make a test request
+	resp, err := fiberApp.Test(req)
+
+	// Verify that no error occurred
+	require.Nil(t, err)
+
+	// Assertions
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	// Ensure the error is noticed in New Relic
+	app.ExpectErrors(t, []internal.WantError{{
+		TxnName: "WebTransaction/Go/GET /error",
+		Msg:     "Internal Server Error",
+	}})
+}
+
+// TestWrapHandler verifies that WrapHandler correctly wraps an existing handler
+func TestWrapHandler(t *testing.T) {
+	app := integrationsupport.NewBasicTestApp()
+	fiberApp := fiber.New()
+
+	wrappedHandler := WrapHandler(app.Application, "/wrapped", func(c fiber.Ctx) error {
+		return c.SendString("Wrapped Handler")
+	})
+
+	fiberApp.Get("/wrapped", wrappedHandler)
+
+	// Simulate a request
+	req, err := http.NewRequest("GET", "/wrapped", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make a test request
+	resp, err := fiberApp.Test(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Ensure the transaction was correctly named
+	// Check if the transaction was created
+	app.ExpectTxnMetrics(t, internal.WantTxn{
+		Name:          "GET /wrapped",
+		IsWeb:         true,
+		UnknownCaller: true,
+	})
+}
+
+// Test_GetTransactionName tests the getTransactionName function
+func Test_GetTransactionName(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		method   string
+		expected string
+	}{
+		{
+			name:     "Root path",
+			path:     "/",
+			method:   "GET",
+			expected: "GET /",
+		},
+		{
+			name:     "API path",
+			path:     "/api/users",
+			method:   "POST",
+			expected: "POST /api/users",
+		},
+		{
+			name:     "Empty path defaults to root",
+			path:     "",
+			method:   "DELETE",
+			expected: "DELETE /",
+		},
+		{
+			name:     "Path with query parameters",
+			path:     "/search?q=fiber",
+			method:   "GET",
+			expected: "GET /search",
+		},
+		{
+			name:     "Path with parameters",
+			path:     "/products/:id",
+			method:   "PUT",
+			expected: "PUT /products/:id",
+		},
+		{
+			name:     "Path with multiple parameters",
+			path:     "/users/:id/posts/:postID",
+			method:   "GET",
+			expected: "GET /users/:id/posts/:postID",
+		},
+		{
+			name:     "Path with trailing slash",
+			path:     "/products/",
+			method:   "PUT",
+			expected: "PUT /products/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a new Fiber app and request for testing
+			app := fiber.New()
+
+			fctx := &fasthttp.RequestCtx{}
+			fctx.Request.Header.SetMethod(tt.method)
+			fctx.Request.SetRequestURI(tt.path)
+
+			ctx := app.AcquireCtx(fctx)
+			ctx.Request().SetRequestURI(tt.path)
+			ctx.Request().Header.SetMethod(tt.method)
+
+			// Get the transaction name
+			result := getTransactionName(ctx)
+
+			// Verify the result
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Test_FastHeaderResponseWriter test the different header operations
+func Test_FastHeaderResponseWriter(t *testing.T) {
+	// Setup
+	app := fiber.New()
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+
+	t.Run("implements http.ResponseWriter", func(t *testing.T) {
+		// Verify that our implementation satisfies the http.ResponseWriter interface
+		var _ http.ResponseWriter = &fastHeaderResponseWriter{}
+	})
+
+	t.Run("header operations", func(t *testing.T) {
+		writer := newFastHeaderResponseWriter(ctx.Response())
+
+		// Test adding headers
+		writer.Header().Add("X-Test-Header", "value1")
+		writer.Header().Set("X-Single-Header", "single-value")
+
+		// Verify headers were stored in the wrapper
+		assert.Equal(t, []string{"value1"}, writer.header["X-Test-Header"])
+		assert.Equal(t, []string{"single-value"}, writer.header["X-Single-Header"])
+
+		// Verify headers aren't yet in the actual response
+		assert.Equal(t, "", string(ctx.Response().Header.Peek("X-Test-Header")))
+
+		// Apply headers and verify they're in the response
+		writer.applyHeaders()
+		assert.Equal(t, "value1", string(ctx.Response().Header.Peek("X-Test-Header")))
+		assert.Equal(t, "single-value", string(ctx.Response().Header.Peek("X-Single-Header")))
+	})
+
+	t.Run("status code handling", func(t *testing.T) {
+		writer := newFastHeaderResponseWriter(ctx.Response())
+
+		// Default status should be 200 OK
+		assert.Equal(t, http.StatusOK, writer.statusCode)
+
+		// Set status code
+		writer.WriteHeader(http.StatusNotFound)
+
+		// Check internal tracking
+		assert.Equal(t, http.StatusNotFound, writer.statusCode)
+
+		// Check fiber response status
+		assert.Equal(t, http.StatusNotFound, ctx.Response().StatusCode())
+	})
+
+	t.Run("write operation", func(t *testing.T) {
+		writer := newFastHeaderResponseWriter(ctx.Response())
+
+		// The Write method is a no-op but we should test it returns expected values
+		n, err := writer.Write([]byte("test"))
+		assert.Equal(t, 0, n)
+		assert.NoError(t, err)
+	})
+
+	t.Run("integration with fiber response", func(t *testing.T) {
+		writer := newFastHeaderResponseWriter(ctx.Response())
+
+		// Set headers via our wrapper
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("X-API-Key", "secret-key")
+
+		// Set status
+		writer.WriteHeader(http.StatusCreated)
+
+		// Apply headers
+		writer.applyHeaders()
+
+		// Check that fiber response has the correct values
+		assert.Equal(t, http.StatusCreated, ctx.Response().StatusCode())
+		assert.Equal(t, "application/json", string(ctx.Response().Header.Peek("Content-Type")))
+		assert.Equal(t, "secret-key", string(ctx.Response().Header.Peek("X-API-Key")))
+	})
+}
+
+// This test specifically verifies the behavior when multiple values are set for a header
+func Test_MultiValueHeaders(t *testing.T) {
+	app := fiber.New()
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+
+	writer := newFastHeaderResponseWriter(ctx.Response())
+
+	// Add multiple Set-Cookie headers (common use case for multi-value headers)
+	writer.Header().Add("Set-Cookie", "cookie1=value1; Path=/")
+	writer.Header().Add("Set-Cookie", "cookie2=value2; Path=/")
+
+	// Apply headers
+	writer.applyHeaders()
+
+	// Fiber should handle multiple values properly for Set-Cookie
+	// Get all Set-Cookie headers
+	cookies := []string{}
+	ctx.Response().Header.VisitAllCookie(func(key, value []byte) {
+		cookies = append(cookies, string(value))
+	})
+
+	// Should have two cookies
+	assert.Len(t, cookies, 2)
+	assert.Contains(t, cookies, "cookie1=value1; Path=/")
+	assert.Contains(t, cookies, "cookie2=value2; Path=/")
+}
+
+// This test verifies that our response writer correctly interacts with a New Relic transaction
+func Test_FastHeaderResponseWriterWithNRTransaction(t *testing.T) {
+	// This is a mock test to demonstrate interaction with NR transaction
+	// In a real test, you would use a mock for the New Relic transaction
+
+	app := fiber.New()
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+
+	writer := newFastHeaderResponseWriter(ctx.Response())
+
+	// Set custom headers
+	writer.Header().Set("Content-Type", "application/json")
+	writer.Header().Set("X-Custom-Header", "custom-value")
+
+	// Set a non-200 status code
+	writer.WriteHeader(http.StatusBadRequest)
+
+	// Apply the headers
+	writer.applyHeaders()
+
+	// Verify response state
+	assert.Equal(t, http.StatusBadRequest, writer.statusCode)
+	assert.Equal(t, http.StatusBadRequest, ctx.Response().StatusCode())
+	assert.Equal(t, "application/json", string(ctx.Response().Header.Peek("Content-Type")))
+	assert.Equal(t, "custom-value", string(ctx.Response().Header.Peek("X-Custom-Header")))
+}
+
+// This test verifies that header manipulations after WriteHeader still work
+func Test_HeadersAfterWriteHeader(t *testing.T) {
+	app := fiber.New()
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+
+	writer := newFastHeaderResponseWriter(ctx.Response())
+
+	// Set status code first
+	writer.WriteHeader(http.StatusAccepted)
+
+	// Then manipulate headers
+	writer.Header().Set("X-Late-Header", "late-value")
+
+	// Apply headers
+	writer.applyHeaders()
+
+	// Verify everything was set correctly
+	assert.Equal(t, http.StatusAccepted, ctx.Response().StatusCode())
+	assert.Equal(t, "late-value", string(ctx.Response().Header.Peek("X-Late-Header")))
+}
+
+// Test_RouterGroup tests the router group functionality
+func Test_RouterGroup(t *testing.T) {
+	// Create a new Fiber app and router group for testing
+	app := integrationsupport.NewBasicTestApp()
+	router := fiber.New()
+	router.Use(Middleware(app.Application))
+	group := router.Group("/group")
+	group.Get("/hello", func(c fiber.Ctx) error {
+		return c.SendString("hello response")
+	})
+
+	// Simulate a request
+	req, err := http.NewRequest("GET", "/group/hello", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make a test request
+	resp, err := router.Test(req)
+
+	// Verify that no error occurred
+	require.Nil(t, err)
+
+	// Read the response body
+	body, _ := io.ReadAll(resp.Body)
+
+	if respBody := string(body); respBody != "hello response" {
+		t.Error("wrong response body", respBody)
+	}
+	// Ensure the transaction was correctly named
+	app.ExpectTxnMetrics(t, internal.WantTxn{
+		Name:          "GET /group/hello",
+		IsWeb:         true,
+		UnknownCaller: true,
+	})
+}

--- a/v3/integrations/nrfiber-next/nrfiber-next.go
+++ b/v3/integrations/nrfiber-next/nrfiber-next.go
@@ -26,7 +26,7 @@ import (
 )
 
 func init() {
-	internal.TrackUsage("integration", "framework", "fiber", "v1")
+	internal.TrackUsage("integration", "framework", "fiber", "v3")
 }
 
 // fastHeaderResponseWriter is a lightweight wrapper around Fiber's response

--- a/v3/integrations/nrfiber-next/nrfiber.go
+++ b/v3/integrations/nrfiber-next/nrfiber.go
@@ -1,0 +1,233 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package nrfiber instruments https://github.com/gofiber/fiber applications.
+//
+// Use this package to instrument inbound requests handled by a fiber.App.
+// Call nrfiber.Middleware to get a fiber.Handler which can be added to your
+// application as a middleware:
+//
+//	app := fiber.New()
+//	// Add the nrfiber middleware before other middlewares or routes:
+//	app.Use(nrfiber.Middleware(newrelicApp))
+//
+// Example: https://github.com/newrelic/go-agent/tree/master/v3/integrations/nrfiber/example/main.go
+package nrfiber
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/newrelic/go-agent/v3/internal"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/fasthttpadaptor"
+)
+
+func init() {
+	internal.TrackUsage("integration", "framework", "fiber", "v1")
+}
+
+// fastHeaderResponseWriter is a lightweight wrapper around Fiber's response
+// that implements http.ResponseWriter interface
+type fastHeaderResponseWriter struct {
+	fiberResponse *fasthttp.Response
+	header        http.Header // cached header to avoid repeated conversions
+	statusCode    int
+}
+
+func newFastHeaderResponseWriter(resp *fasthttp.Response) *fastHeaderResponseWriter {
+	return &fastHeaderResponseWriter{
+		fiberResponse: resp,
+		header:        make(http.Header),
+		statusCode:    resp.StatusCode(),
+	}
+}
+
+func (w *fastHeaderResponseWriter) Header() http.Header {
+	// Return cached headers to avoid repeated conversions
+	return w.header
+}
+
+func (w *fastHeaderResponseWriter) Write([]byte) (int, error) {
+	// This is a no-op as we don't actually write anything here
+	return 0, nil
+}
+
+func (w *fastHeaderResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+	w.fiberResponse.SetStatusCode(statusCode)
+}
+
+// Apply cached headers to the actual Fiber response
+func (w *fastHeaderResponseWriter) applyHeaders() {
+	for key, values := range w.header {
+		for _, value := range values {
+			w.fiberResponse.Header.Set(key, value)
+		}
+	}
+}
+
+// Transaction returns the Transaction from the context if it exists.
+func Transaction(ctx context.Context) *newrelic.Transaction {
+	if ctx == nil {
+		return nil
+	}
+	if txn, ok := ctx.Value(internal.TransactionContextKey).(*newrelic.Transaction); ok {
+		return txn
+	}
+	return nil
+}
+
+// FromContext extracts a New Relic transaction from a Fiber context.
+func FromContext(c fiber.Ctx) *newrelic.Transaction {
+	return newrelic.FromContext(c.Context())
+}
+
+// getTransactionName returns a transaction name based on the request path.
+func getTransactionName(c fiber.Ctx) string {
+	path := c.Path()
+	if path == "" {
+		path = "/"
+	}
+
+	return string(c.Method()) + " " + path
+}
+
+// fastHTTPToRequest efficiently converts FastHTTP request to http.Request
+// using fasthttpadaptor which is optimized for this purpose
+func fastHTTPToRequest(ctx *fasthttp.RequestCtx) *http.Request {
+	req := &http.Request{}
+	fasthttpadaptor.ConvertRequest(ctx, req, true)
+	return req
+}
+
+// Middleware creates a Fiber middleware handler that instruments requests with New Relic.
+// It starts a New Relic transaction for each request, sets web request and response details,
+// and handles error tracking. If no New Relic application is configured, it passes the request through.
+//
+//	router := fiber.New()
+//	// Add the nrfiber middleware before other middlewares or routes:
+//	router.Use(nrfiber.Middleware(app))
+func Middleware(app *newrelic.Application) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		// If no New Relic application is configured, do nothing
+		if app == nil {
+			return c.Next()
+		}
+
+		// Create New Relic transaction
+		txnName := getTransactionName(c)
+		txn := app.StartTransaction(txnName)
+		defer txn.End()
+
+		// Store transaction in context for retrieval in handlers
+		ctx := context.WithValue(c.Context(), internal.TransactionContextKey, txn)
+		c.SetContext(ctx)
+
+		// Create optimized response writer wrapper
+		w := newFastHeaderResponseWriter(c.Response())
+
+		// Set security agent attributes if present
+		if newrelic.IsSecurityAgentPresent() {
+			txn.SetCsecAttributes(newrelic.AttributeCsecRoute, string(c.Request().URI().Path()))
+		}
+
+		// Set web response object
+		txn.SetWebResponse(w)
+
+		// Use fasthttpadaptor to efficiently convert to http.Request
+		httpReq := fastHTTPToRequest(c.RequestCtx())
+		txn.SetWebRequestHTTP(httpReq)
+
+		// Execute next handlers
+		err := c.Next()
+
+		// Apply any headers that were set through the ResponseWriter interface
+		w.applyHeaders()
+
+		// Report error if any occurred
+		if err != nil {
+			txn.NoticeError(err)
+		}
+
+		// Update response status code in transaction
+		txn.SetWebResponse(w).WriteHeader(c.Response().StatusCode())
+
+		// Send security event if agent is present
+		if newrelic.IsSecurityAgentPresent() {
+			// Convert fiber response headers to http.Header for security event
+			headers := make(http.Header)
+			c.Response().Header.VisitAll(func(key, value []byte) {
+				headers.Add(string(key), string(value))
+			})
+
+			newrelic.GetSecurityAgentInterface().SendEvent(
+				"RESPONSE_HEADER",
+				headers,
+				txn.GetLinkingMetadata().TraceID,
+			)
+		}
+
+		return err
+	}
+}
+
+// WrapHandler wraps an existing Fiber handler with New Relic instrumentation
+//
+// fiberApp := fiber.New()
+//
+//	wrappedHandler := WrapHandler(app.Application, "/wrapped", func(c fiber.Ctx) error {
+//		 return c.SendString("Wrapped Handler")
+//	})
+//
+// fiberApp.Get("/wrapped", wrappedHandler)
+func WrapHandler(app *newrelic.Application, pattern string, handler fiber.Handler) fiber.Handler {
+	if app == nil {
+		return handler
+	}
+
+	return func(c fiber.Ctx) error {
+		// Get transaction from context if middleware is already applied
+		if txn := Transaction(c.Context()); txn != nil {
+			// Update name if this is a more specific handler
+			txn.SetName(string(c.Method()) + " " + pattern)
+			return handler(c)
+		}
+
+		// If no transaction exists, create a new one
+		txn := app.StartTransaction(string(c.Method()) + " " + pattern)
+		defer txn.End()
+
+		// Store in context
+		ctx := context.WithValue(c.Context(), internal.TransactionContextKey, txn)
+		c.SetContext(ctx)
+
+		// Create optimized response writer wrapper
+		w := newFastHeaderResponseWriter(c.Response())
+
+		// Set web response object
+		txn.SetWebResponse(w)
+
+		// Use fasthttpadaptor to efficiently convert to http.Request
+		httpReq := fastHTTPToRequest(c.RequestCtx())
+		txn.SetWebRequestHTTP(httpReq)
+
+		// Call the handler
+		err := handler(c)
+
+		// Apply any headers that were set through the ResponseWriter interface
+		w.applyHeaders()
+
+		// Update response status code in transaction
+		txn.SetWebResponse(w).WriteHeader(c.Response().StatusCode())
+
+		// Report error if any occurred
+		if err != nil {
+			txn.NoticeError(err)
+		}
+
+		return err
+	}
+}

--- a/v3/integrations/nrfiber-next/nrfiber_context_test.go
+++ b/v3/integrations/nrfiber-next/nrfiber_context_test.go
@@ -1,0 +1,100 @@
+package nrfiber
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/newrelic/go-agent/v3/internal"
+	"github.com/newrelic/go-agent/v3/internal/integrationsupport"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMiddleware_ContextPropagation tests that the middleware correctly propagates the transaction context
+func TestMiddleware_ContextPropagation(t *testing.T) {
+	app := integrationsupport.NewBasicTestApp()
+	router := fiber.New()
+	router.Use(Middleware(app.Application))
+	router.Get("/txn", func(c fiber.Ctx) error {
+		txn := FromContext(c)
+		if txn == nil {
+			t.Error("Transaction is nil")
+		}
+		if txn.Name() != "GET /txn" {
+			t.Error("wrong transaction name", txn.Name())
+		}
+		txn.NoticeError(errors.New("ooops"))
+		c.WriteString("accessTransactionFromContext")
+		return nil
+	})
+
+	req, err := http.NewRequest("GET", "/txn", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := router.Test(req)
+	body, _ := io.ReadAll(resp.Body)
+
+	if respBody := string(body); respBody != "accessTransactionFromContext" {
+		t.Error("wrong response body", respBody)
+	}
+
+	app.ExpectTxnMetrics(t, internal.WantTxn{
+		Name:          "GET /txn",
+		IsWeb:         true,
+		NumErrors:     1,
+		UnknownCaller: true,
+		ErrorByCaller: true,
+	})
+}
+
+// Test_Transaction tests that the Transaction function retrieves the
+// transaction from the context correctly.
+// It also tests the behavior when the context is nil or does not contain
+// a transaction.
+func Test_Transaction(t *testing.T) {
+	// Create a mock transaction
+	mockTxn := &newrelic.Transaction{}
+
+	// Create a context with the transaction
+	ctx := context.WithValue(context.Background(), internal.TransactionContextKey, mockTxn)
+
+	// Retrieve the transaction from the context
+	resultTxn := Transaction(ctx)
+
+	// Verify the transaction was correctly retrieved
+	assert.Equal(t, mockTxn, resultTxn)
+
+	// Test with nil context
+	assert.Nil(t, Transaction(nil))
+
+	// Test with context but no transaction
+	emptyCtx := context.Background()
+	assert.Nil(t, Transaction(emptyCtx))
+}
+
+// TestNewContext_Transaction tests that nrfiber.Transaction will find a transaction
+// added to a context using newrelic.NewContext.
+func TestNewContext_Transaction(t *testing.T) {
+	// This tests that nrfiber.Transaction will find a transaction added to
+	// to a context using newrelic.NewContext.
+	app := integrationsupport.NewBasicTestApp()
+	txn := app.StartTransaction("name")
+	ctx := newrelic.NewContext(context.Background(), txn)
+	if tx := Transaction(ctx); nil != tx {
+		tx.NoticeError(errors.New("problem"))
+	}
+	txn.End()
+
+	app.ExpectTxnMetrics(t, internal.WantTxn{
+		Name:          "name",
+		IsWeb:         false,
+		NumErrors:     1,
+		UnknownCaller: true,
+		ErrorByCaller: true,
+	})
+}


### PR DESCRIPTION
## Links
https://docs.gofiber.io/next/


## Details
There was a critical change in Fiber v3 - instead of pointers ctx.Fiber now is passed as interface in handler functions.
Because now this is going to be standard for Fiber moving forward i decided to implement this change.
All tests that are currently exist for Fiber v2 were replicated.
