### PR TITLE
chore: add support for go 1.25

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.23.0, 1.24.0, stable]
+        go-version: [1.24.0, 1.25.0, stable]
     continue-on-error: true
     steps:
       - name: Checkout go-agent code
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.23.0, 1.24.0, stable]
+        go-version: [1.24.0, 1.25.0, stable]
     continue-on-error: true
     steps:
       - name: Checkout go-agent code
@@ -104,7 +104,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        go-version: [1.23.0, 1.24.0, latest]
+        go-version: [1.24.0, 1.25.0, latest]
         core-test: ${{ fromJson(needs.setup-core-matrix.outputs.CORE_MATRIX) }}
         runner: [ubuntu-latest, ubuntu-24.04-arm]
     continue-on-error: true
@@ -139,7 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.23.0, 1.24.0, latest]
+        go-version: [1.24.0, 1.25.0, latest]
         integration-test: ${{ fromJson(needs.setup-integration-matrix.outputs.INTEGRATION_MATRIX) }}
     continue-on-error: true
     steps:
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
-        go-version: [1.23.0, 1.24.0, latest]
+        go-version: [1.24.0, 1.25.0, latest]
         integration-test: ${{ fromJson(needs.setup-integration-matrix.outputs.INTEGRATION_MATRIX) }}
     continue-on-error: true
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG GO_VERSION
 
 # Takes in go version
-FROM golang:${GO_VERSION:-1.24}
+FROM golang:${GO_VERSION:-1.25}
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       context: .
       dockerfile: ./Dockerfile
       args:
-        GO_VERSION: ${GO_VERSION:-1.24}
+        GO_VERSION: ${GO_VERSION:-1.25}
     environment:
       PG_HOST: postgres
       PG_PORT: 5432
@@ -63,7 +63,7 @@ services:
       context: .
       dockerfile: ./Dockerfile
       args:
-        GO_VERSION: ${GO_VERSION:-1.24}
+        GO_VERSION: ${GO_VERSION:-1.25}
     environment:
       PG_HOST: postgres
       PG_PORT: 5432


### PR DESCRIPTION
## Links

## Details

Upgrade support for building and testing go 1.24 and 1.25.
Deprecate testing support for 1.23.
