### PR TITLE
update nrwriter version tag to 1.0.2

### DIFF
--- a/v3/integrations/logcontext-v2/zerologWriter/go.mod
+++ b/v3/integrations/logcontext-v2/zerologWriter/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 require (
 	github.com/newrelic/go-agent/v3 v3.41.0
-	github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter v1.0.0
+	github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter v1.0.2
 	github.com/rs/zerolog v1.27.0
 )
 


### PR DESCRIPTION
## Details

The current required nrwriter version imports integrationsupport pacakge from /v3/internal that was moved to /v3/newrelic in [commit](https://github.com/newrelic/go-agent/commit/d123a76059601c148428fe2dfe1661c784301b65#diff-a8083be9e1280da0246b46f968ebd0a4d4b6af5f2d1b8fd3e0dafe912becfba5)

## Error Log
Moving to 1.0.2 fixes this go mod tidy error

go: github.com/hiicharm/go-boilerplate/internal/logger imports
        github.com/newrelic/go-agent/v3/integrations/logcontext-v2/zerologWriter imports
        github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter tested by
        github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter.test imports
        github.com/newrelic/go-agent/v3/internal/integrationsupport: module github.com/newrelic/go-agent/v3@latest found (v3.41.0), but does not contain package github.com/newrelic/go-agent/v3/internal/integrationsupport


