### PR TITLE
fix(examples/server): Bump example Dockerfile Go version to 1.25

### DIFF
--- a/v3/examples/server/Dockerfile
+++ b/v3/examples/server/Dockerfile
@@ -35,7 +35,7 @@
 #	/set_name
 #	/version
 #
-FROM golang:1.22
+FROM golang:1.25
 MAINTAINER Steve Willoughby <swilloughby@newrelic.com>
 WORKDIR /go
 RUN git clone https://github.com/newrelic/go-agent


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

<!--
Any relevant links that will help reviewers.
-->

## Details
### Issue
Go version of `examples/server/Dockerfile` behind current 1.24 version in repo
### Goals
Bump to current version
### Implementation
Bump Go 1.22 to 1.25
### How to test
 - From the root of the repo, navigate to the server directory: `cd v3/examples/server`
 - Build the image locally: `docker build -t go-agent-test .`
 - Test it out locally: `docker run -e NEW_RELIC_LICENSE_KEY="YOUR_KEY_HERE" -p 127.0.0.1:8000:8000 go-agent-test`
 - Navigate to [localhost:8000](localhost:8000)
 - Test out some of these [endpoints](https://github.com/newrelic/go-agent/blob/f3a9acaf5c3fb24c87e114e6fe7463b98ff3b99f/v3/examples/server/Dockerfile#L17) and ensure they are reporting to the account associated with your license key
