### PR TITLE
nrlambda: add support for MultiValueHeaders in event responses

### DIFF
--- a/v3/integrations/nrlambda/events.go
+++ b/v3/integrations/nrlambda/events.go
@@ -119,27 +119,43 @@ func eventWebRequest(event interface{}) *newrelic.WebRequest {
 func eventResponse(event interface{}) *response {
 	var code int
 	var headers map[string]string
+	var multiValueHeaders map[string][]string
 
 	switch r := event.(type) {
 	case events.APIGatewayProxyResponse:
 		code = r.StatusCode
 		headers = r.Headers
+		multiValueHeaders = r.MultiValueHeaders
 	case *events.APIGatewayProxyResponse:
 		return eventResponse(safeDereference(r))
 
 	case events.ALBTargetGroupResponse:
 		code = r.StatusCode
 		headers = r.Headers
+		multiValueHeaders = r.MultiValueHeaders
 	case *events.ALBTargetGroupResponse:
 		return eventResponse(safeDereference(r))
 
 	default:
 		return nil
 	}
-	hdr := make(http.Header, len(headers))
+
+	// https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format
+	// 	"If you specify values for both headers and multiValueHeaders, API Gateway merges them into a single list.
+	// 	If the same key-value pair is specified in both, only the values from multiValueHeaders will appear in the merged list."
+	//
+	// To match API Gateway's behavior, copy headers and then multiValueHeaders, so the latter takes priority for a given header key.
+	hdr := make(http.Header, len(headers)+len(multiValueHeaders))
 	for k, v := range headers {
-		hdr.Add(k, v)
+		hdr.Set(k, v)
 	}
+	for k, v := range multiValueHeaders {
+		if len(v) == 0 {
+			continue
+		}
+		hdr.Set(k, v[0])
+	}
+
 	return &response{
 		code:   code,
 		header: hdr,


### PR DESCRIPTION
Fixes #1072.

## Links

n/a

## Details

Adds support for `MultiValueHeaders` in `APIGatewayProxyResponse` and `ALBTargetGroupResponse`.
