### PR TITLE
feat(nrlambda): Add attribute for aws.lambda.eventSource.eventType

### DIFF
--- a/v3/integrations/nrlambda/events.go
+++ b/v3/integrations/nrlambda/events.go
@@ -65,6 +65,53 @@ func getEventSourceARN(event interface{}) string {
 	return ""
 }
 
+func getEventSourceEventType(event any) string {
+	switch event.(type) {
+	case events.ALBTargetGroupRequest:
+		return "alb"
+	case *events.ALBTargetGroupRequest:
+		return "alb"
+	case events.APIGatewayProxyRequest:
+		return "apiGateway"
+	case *events.APIGatewayProxyRequest:
+		return "apiGateway"
+	case events.CloudWatchEvent:
+		return "cloudWatch_scheduled"
+	case *events.CloudWatchEvent:
+		return "cloudWatch_scheduled"
+	case events.SimpleEmailEvent:
+		return "ses"
+	case *events.SimpleEmailEvent:
+		return "ses"
+	case events.KinesisFirehoseEvent:
+		return "firehose"
+	case *events.KinesisFirehoseEvent:
+		return "firehose"
+	case events.KinesisEvent:
+		return "kinesis"
+	case *events.KinesisEvent:
+		return "kinesis"
+	case events.DynamoDBEvent:
+		return "dynamo_streams"
+	case *events.DynamoDBEvent:
+		return "dynamo_streams"
+	case events.SQSEvent:
+		return "sqs"
+	case *events.SQSEvent:
+		return "sqs"
+	case events.S3Event:
+		return "s3"
+	case *events.S3Event:
+		return "s3"
+	case events.SNSEvent:
+		return "sns"
+	case *events.SNSEvent:
+		return "sns"
+	}
+
+	return ""
+}
+
 func eventWebRequest(event interface{}) *newrelic.WebRequest {
 	var path string
 	var request newrelic.WebRequest

--- a/v3/integrations/nrlambda/events.go
+++ b/v3/integrations/nrlambda/events.go
@@ -65,48 +65,77 @@ func getEventSourceARN(event interface{}) string {
 	return ""
 }
 
+const (
+	eventTypeALB                 = "alb"
+	eventTypeAPIGateway          = "apiGateway"
+	eventTypeCloudWatchScheduled = "cloudWatch_scheduled"
+	eventTypeSES                 = "ses"
+	eventTypeFirehose            = "firehose"
+	eventTypeKinesis             = "kinesis"
+	eventTypeDynamoStreams       = "dynamo_streams"
+	eventTypeSQS                 = "sqs"
+	eventTypeS3                  = "s3"
+	eventTypeSNS                 = "sns"
+)
+
 func getEventSourceEventType(event any) string {
 	switch event.(type) {
 	case events.ALBTargetGroupRequest:
-		return "alb"
+		return eventTypeALB
 	case *events.ALBTargetGroupRequest:
-		return "alb"
+		return eventTypeALB
 	case events.APIGatewayProxyRequest:
-		return "apiGateway"
+		return eventTypeAPIGateway
 	case *events.APIGatewayProxyRequest:
-		return "apiGateway"
+		return eventTypeAPIGateway
+	case events.APIGatewayV2HTTPRequest:
+		return eventTypeAPIGateway
+	case *events.APIGatewayV2HTTPRequest:
+		return eventTypeAPIGateway
+	case events.APIGatewayWebsocketProxyRequest:
+		return eventTypeAPIGateway
+	case *events.APIGatewayWebsocketProxyRequest:
+		return eventTypeAPIGateway
 	case events.CloudWatchEvent:
-		return "cloudWatch_scheduled"
+		return eventTypeCloudWatchScheduled
 	case *events.CloudWatchEvent:
-		return "cloudWatch_scheduled"
+		return eventTypeCloudWatchScheduled
 	case events.SimpleEmailEvent:
-		return "ses"
+		return eventTypeSES
 	case *events.SimpleEmailEvent:
-		return "ses"
+		return eventTypeSES
 	case events.KinesisFirehoseEvent:
-		return "firehose"
+		return eventTypeFirehose
 	case *events.KinesisFirehoseEvent:
-		return "firehose"
+		return eventTypeFirehose
 	case events.KinesisEvent:
-		return "kinesis"
+		return eventTypeKinesis
 	case *events.KinesisEvent:
-		return "kinesis"
+		return eventTypeKinesis
+	case events.KinesisTimeWindowEvent:
+		return eventTypeKinesis
+	case *events.KinesisTimeWindowEvent:
+		return eventTypeKinesis
 	case events.DynamoDBEvent:
-		return "dynamo_streams"
+		return eventTypeDynamoStreams
 	case *events.DynamoDBEvent:
-		return "dynamo_streams"
+		return eventTypeDynamoStreams
+	case events.DynamoDBTimeWindowEvent:
+		return eventTypeDynamoStreams
+	case *events.DynamoDBTimeWindowEvent:
+		return eventTypeDynamoStreams
 	case events.SQSEvent:
-		return "sqs"
+		return eventTypeSQS
 	case *events.SQSEvent:
-		return "sqs"
+		return eventTypeSQS
 	case events.S3Event:
-		return "s3"
+		return eventTypeS3
 	case *events.S3Event:
-		return "s3"
+		return eventTypeS3
 	case events.SNSEvent:
-		return "sns"
+		return eventTypeSNS
 	case *events.SNSEvent:
-		return "sns"
+		return eventTypeSNS
 	}
 
 	return ""

--- a/v3/integrations/nrlambda/events_test.go
+++ b/v3/integrations/nrlambda/events_test.go
@@ -124,6 +124,62 @@ func TestGetEventAttributes(t *testing.T) {
 	}
 }
 
+func TestGetEventSourceEventType(t *testing.T) {
+	testcases := []struct {
+		Name      string
+		Input     interface{}
+		EventType string
+	}{
+		{Name: "nil expect \"\"", Input: nil, EventType: ""},
+		{Name: "int (unsupported) expect \"\"", Input: 22, EventType: ""},
+
+		{Name: "ALBTargetGroupRequest expect alb", Input: events.ALBTargetGroupRequest{}, EventType: "alb"},
+		{Name: "*ALBTargetGroupRequest expect alb", Input: &events.ALBTargetGroupRequest{}, EventType: "alb"},
+
+		{Name: "APIGatewayProxyRequest expect apiGateway", Input: events.APIGatewayProxyRequest{}, EventType: "apiGateway"},
+		{Name: "*APIGatewayProxyRequest expect apiGateway", Input: &events.APIGatewayProxyRequest{}, EventType: "apiGateway"},
+		{Name: "APIGatewayV2HTTPRequest expect apiGateway", Input: events.APIGatewayV2HTTPRequest{}, EventType: "apiGateway"},
+		{Name: "*APIGatewayV2HTTPRequest expect apiGateway", Input: &events.APIGatewayV2HTTPRequest{}, EventType: "apiGateway"},
+		{Name: "APIGatewayWebsocketProxyRequest expect apiGateway", Input: events.APIGatewayWebsocketProxyRequest{}, EventType: "apiGateway"},
+		{Name: "*APIGatewayWebsocketProxyRequest expect apiGateway", Input: &events.APIGatewayWebsocketProxyRequest{}, EventType: "apiGateway"},
+
+		{Name: "CloudWatchEvent expect cloudWatch_scheduled", Input: events.CloudWatchEvent{}, EventType: "cloudWatch_scheduled"},
+		{Name: "*CloudWatchEvent expect cloudWatch_scheduled", Input: &events.CloudWatchEvent{}, EventType: "cloudWatch_scheduled"},
+
+		{Name: "SimpleEmailEvent expect ses", Input: events.SimpleEmailEvent{}, EventType: "ses"},
+		{Name: "*SimpleEmailEvent expect ses", Input: &events.SimpleEmailEvent{}, EventType: "ses"},
+
+		{Name: "KinesisFirehoseEvent expect firehose", Input: events.KinesisFirehoseEvent{}, EventType: "firehose"},
+		{Name: "*KinesisFirehoseEvent expect firehose", Input: &events.KinesisFirehoseEvent{}, EventType: "firehose"},
+
+		{Name: "KinesisEvent expect kinesis", Input: events.KinesisEvent{}, EventType: "kinesis"},
+		{Name: "*KinesisEvent expect kinesis", Input: &events.KinesisEvent{}, EventType: "kinesis"},
+		{Name: "KinesisTimeWindowEvent expect kinesis", Input: events.KinesisTimeWindowEvent{}, EventType: "kinesis"},
+		{Name: "*KinesisTimeWindowEvent expect kinesis", Input: &events.KinesisTimeWindowEvent{}, EventType: "kinesis"},
+
+		{Name: "DynamoDBEvent expect dynamo_streams", Input: events.DynamoDBEvent{}, EventType: "dynamo_streams"},
+		{Name: "*DynamoDBEvent expect dynamo_streams", Input: &events.DynamoDBEvent{}, EventType: "dynamo_streams"},
+		{Name: "DynamoDBTimeWindowEvent expect dynamo_streams", Input: events.DynamoDBTimeWindowEvent{}, EventType: "dynamo_streams"},
+		{Name: "*DynamoDBTimeWindowEvent expect dynamo_streams", Input: &events.DynamoDBTimeWindowEvent{}, EventType: "dynamo_streams"},
+
+		{Name: "SQSEvent expect sqs", Input: events.SQSEvent{}, EventType: "sqs"},
+		{Name: "*SQSEvent expect sqs", Input: &events.SQSEvent{}, EventType: "sqs"},
+
+		{Name: "S3Event expect s3", Input: events.S3Event{}, EventType: "s3"},
+		{Name: "*S3Event expect s3", Input: &events.S3Event{}, EventType: "s3"},
+
+		{Name: "SNSEvent expect sns", Input: events.SNSEvent{}, EventType: "sns"},
+		{Name: "*SNSEvent expect sns", Input: &events.SNSEvent{}, EventType: "sns"},
+	}
+
+	for _, testcase := range testcases {
+		eventType := getEventSourceEventType(testcase.Input)
+		if eventType != testcase.EventType {
+			t.Error(testcase.Name, eventType, testcase.EventType)
+		}
+	}
+}
+
 func TestEventWebRequest(t *testing.T) {
 	// First test a type that does not count as a web request.
 	req := eventWebRequest(22)

--- a/v3/integrations/nrlambda/handler.go
+++ b/v3/integrations/nrlambda/handler.go
@@ -51,6 +51,11 @@ func requestEvent(ctx context.Context, event interface{}) {
 		integrationsupport.AddAgentAttribute(txn, newrelic.AttributeAWSLambdaEventSourceARN, sourceARN, nil)
 	}
 
+	// keep the same logic for getting the sourceArn
+	if sourceEventType := getEventSourceEventType(event); "" != sourceEventType {
+		integrationsupport.AddAgentAttribute(txn, newrelic.AttributeAWSLambdaEventSourceEventType, sourceEventType, nil)
+	}
+
 	if request := eventWebRequest(event); nil != request {
 		txn.SetWebRequest(*request)
 	}

--- a/v3/integrations/nrlambda/handler_test.go
+++ b/v3/integrations/nrlambda/handler_test.go
@@ -279,8 +279,9 @@ func TestSetWebRequest(t *testing.T) {
 		},
 		UserAttributes: map[string]interface{}{},
 		AgentAttributes: map[string]interface{}{
-			"aws.lambda.coldStart": true,
-			"request.uri":          "//:4000",
+			"aws.lambda.coldStart":             true,
+			"request.uri":                      "//:4000",
+			"aws.lambda.eventSource.eventType": "apiGateway",
 		},
 	}})
 	app.Private.(internal.Expect).ExpectSpanEvents(t, []internal.WantEvent{{
@@ -296,8 +297,9 @@ func TestSetWebRequest(t *testing.T) {
 		},
 		UserAttributes: map[string]interface{}{},
 		AgentAttributes: map[string]interface{}{
-			"aws.lambda.coldStart": true,
-			"request.uri":          "//:4000",
+			"aws.lambda.coldStart":             true,
+			"request.uri":                      "//:4000",
+			"aws.lambda.eventSource.eventType": "apiGateway",
 		},
 	}})
 	if 0 == buf.Len() {
@@ -367,8 +369,9 @@ func TestDistributedTracing(t *testing.T) {
 		},
 		UserAttributes: map[string]interface{}{},
 		AgentAttributes: map[string]interface{}{
-			"aws.lambda.coldStart": true,
-			"request.uri":          "//:4000",
+			"aws.lambda.coldStart":             true,
+			"request.uri":                      "//:4000",
+			"aws.lambda.eventSource.eventType": "apiGateway",
 		},
 	}})
 	app.Private.(internal.Expect).ExpectSpanEvents(t, []internal.WantEvent{{
@@ -386,13 +389,14 @@ func TestDistributedTracing(t *testing.T) {
 		},
 		UserAttributes: map[string]interface{}{},
 		AgentAttributes: map[string]interface{}{
-			"aws.lambda.coldStart":     true,
-			"parent.account":           "1",
-			"parent.app":               "1",
-			"parent.transportDuration": internal.MatchAnything,
-			"parent.transportType":     "HTTPS",
-			"parent.type":              "App",
-			"request.uri":              "//:4000",
+			"aws.lambda.coldStart":             true,
+			"parent.account":                   "1",
+			"parent.app":                       "1",
+			"parent.transportDuration":         internal.MatchAnything,
+			"parent.transportType":             "HTTPS",
+			"parent.type":                      "App",
+			"request.uri":                      "//:4000",
+			"aws.lambda.eventSource.eventType": "apiGateway",
 		},
 	}})
 	if 0 == buf.Len() {
@@ -442,8 +446,9 @@ func TestEventARN(t *testing.T) {
 		},
 		UserAttributes: map[string]interface{}{},
 		AgentAttributes: map[string]interface{}{
-			"aws.lambda.coldStart":       true,
-			"aws.lambda.eventSource.arn": "ARN",
+			"aws.lambda.coldStart":             true,
+			"aws.lambda.eventSource.arn":       "ARN",
+			"aws.lambda.eventSource.eventType": "dynamo_streams",
 		},
 	}})
 	app.Private.(internal.Expect).ExpectSpanEvents(t, []internal.WantEvent{{
@@ -459,8 +464,9 @@ func TestEventARN(t *testing.T) {
 		},
 		UserAttributes: map[string]interface{}{},
 		AgentAttributes: map[string]interface{}{
-			"aws.lambda.coldStart":       true,
-			"aws.lambda.eventSource.arn": "ARN",
+			"aws.lambda.coldStart":             true,
+			"aws.lambda.eventSource.arn":       "ARN",
+			"aws.lambda.eventSource.eventType": "dynamo_streams",
 		},
 	}})
 	if 0 == buf.Len() {

--- a/v3/newrelic/attributes.go
+++ b/v3/newrelic/attributes.go
@@ -79,10 +79,11 @@ const (
 
 // AWS Lambda specific attributes:
 const (
-	AttributeAWSRequestID            = "aws.requestId"
-	AttributeAWSLambdaARN            = "aws.lambda.arn"
-	AttributeAWSLambdaColdStart      = "aws.lambda.coldStart"
-	AttributeAWSLambdaEventSourceARN = "aws.lambda.eventSource.arn"
+	AttributeAWSRequestID                  = "aws.requestId"
+	AttributeAWSLambdaARN                  = "aws.lambda.arn"
+	AttributeAWSLambdaColdStart            = "aws.lambda.coldStart"
+	AttributeAWSLambdaEventSourceARN       = "aws.lambda.eventSource.arn"
+	AttributeAWSLambdaEventSourceEventType = "aws.lambda.eventSource.eventType"
 )
 
 // AWS OpenSearch specific attributes for Span only

--- a/v3/newrelic/attributes_from_internal.go
+++ b/v3/newrelic/attributes_from_internal.go
@@ -55,6 +55,7 @@ var (
 		AttributeResponseCodeDeprecated:          usualDests,
 		AttributeAWSRequestID:                    usualDests,
 		AttributeAWSLambdaARN:                    usualDests,
+		AttributeAWSLambdaEventSourceEventType:   usualDests,
 		AttributeAWSLambdaColdStart:              usualDests,
 		AttributeAWSLambdaEventSourceARN:         usualDests,
 		AttributeMessageRoutingKey:               usualDests,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

<!--
Any relevant links that will help reviewers.
-->

## Details
### Issue
`aws.lambda.eventSource.eventType` is not added as an agent attribute
### Goals
Add the above event type as an agent attribute, depending on the event, for all supported events in the lambda aws sdk
### Implementation
The event type is added similarly to the `eventSourceArn` with a switch statement.  It is added as an agent attribute in the same area
### How To test
I have local lambdas set up to test different event types.
<!--
In-depth description of changes, other technical notes, etc.
-->
