### PR TITLE
feat: add support for 'WITH' clause in SQL parsing

### DIFF
--- a/v3/newrelic/sqlparse/sqlparse.go
+++ b/v3/newrelic/sqlparse/sqlparse.go
@@ -24,6 +24,7 @@ var (
 	tablePattern      = `(` + `\s+` + basicTable + `|` + `\s*` + enclosedTable + `)`
 	extractTableRegex = regexp.MustCompile(`[\s` + "`" + `"'\(\)\{\}\[\]]*`)
 	updateRegex       = regexp.MustCompile(`(?is)^update(?:\s+(?:low_priority|ignore|or|rollback|abort|replace|fail|only))*` + tablePattern)
+	withRegex         = regexp.MustCompile(`(?is)^with(?:\s+recursive)?.*\)\s*select.*?\sfrom` + tablePattern)
 	sqlOperations     = map[string]*regexp.Regexp{
 		"select":   regexp.MustCompile(`(?is)^.*\sfrom` + tablePattern),
 		"delete":   regexp.MustCompile(`(?is)^.*\sfrom` + tablePattern),
@@ -39,7 +40,7 @@ var (
 		"alter":    nil,
 		"commit":   nil,
 		"rollback": nil,
-		"with":     nil,
+		"with":     withRegex,
 	}
 	firstWordRegex   = regexp.MustCompile(`^\w+`)
 	cCommentRegex    = regexp.MustCompile(`(?is)/\*.*?\*/`)

--- a/v3/newrelic/sqlparse/sqlparse_test.go
+++ b/v3/newrelic/sqlparse/sqlparse_test.go
@@ -198,10 +198,11 @@ func TestExtractTable(t *testing.T) {
 }
 func TestParseSQLWith(t *testing.T) {
 	for _, tc := range []sqlTestcase{
-		{Input: "WITH cte AS (SELECT * FROM users) SELECT * FROM cte", Operation: "with", Table: ""},
-		{Input: "WITH RECURSIVE cte AS (SELECT id FROM employees) SELECT * FROM cte", Operation: "with", Table: ""},
-		{Input: "with temp AS (SELECT id FROM foo) SELECT * FROM temp", Operation: "with", Table: ""},
-		{Input: "  WITH cte AS (SELECT * FROM bar) SELECT * FROM cte", Operation: "with", Table: ""},
+		{Input: "WITH cte AS (SELECT * FROM users) SELECT * FROM cte", Operation: "with", Table: "cte"},
+		{Input: "Select * FROM cte; WITH cte AS (SELECT * FROM users) SELECT * FROM cte;", Operation: "select", Table: "cte"},
+		{Input: "WITH RECURSIVE cte AS (SELECT id FROM employees) SELECT * FROM cte", Operation: "with", Table: "cte"},
+		{Input: "with temp AS (SELECT id FROM foo) SELECT * FROM temp", Operation: "with", Table: "temp"},
+		{Input: "  WITH cte AS (SELECT * FROM bar) SELECT * FROM cte", Operation: "with", Table: "cte"},
 	} {
 		tc.test(t)
 	}


### PR DESCRIPTION
Add support for "WITH" clause in SQL parsing

Addresses https://github.com/newrelic/go-agent/issues/1121