### PR TITLE
test: Fix failing httptest

### DIFF
--- a/v3/newrelic/internal_set_web_response_test.go
+++ b/v3/newrelic/internal_set_web_response_test.go
@@ -42,7 +42,7 @@ func TestSetWebResponseSuccess(t *testing.T) {
 	txn := app.StartTransaction("hello")
 	w := httptest.NewRecorder()
 	rw := txn.SetWebResponse(w)
-	rw.WriteHeader(123)
+	rw.WriteHeader(200)
 	hdr := rw.Header()
 	hdr.Set("zip", "zap")
 	body := "should not panic"
@@ -51,7 +51,7 @@ func TestSetWebResponseSuccess(t *testing.T) {
 		t.Error(err, n)
 	}
 	txn.End()
-	if w.Code != 123 {
+	if w.Code != 200 {
 		t.Error(w.Code)
 	}
 	if w.HeaderMap.Get("zip") != "zap" {
@@ -62,8 +62,8 @@ func TestSetWebResponseSuccess(t *testing.T) {
 	}
 	app.ExpectTxnEvents(t, []internal.WantEvent{{
 		AgentAttributes: map[string]interface{}{
-			"httpResponseCode": 123,
-			"http.statusCode":  123,
+			"httpResponseCode": 200,
+			"http.statusCode":  200,
 		},
 		Intrinsics: map[string]interface{}{"name": "OtherTransaction/Go/hello"},
 	}})


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

<!--
Any relevant links that will help reviewers.
-->

## Details
HTTP test fails after release of Go 1.26.  Response codes 1XX do not have a body automatically which these tests check for.
<!--
In-depth description of changes, other technical notes, etc.
-->
