### PR TITLE
feat(nrlogrus): Local log decoration within message

### DIFF
--- a/v3/integrations/logcontext-v2/nrlogrus/formatter.go
+++ b/v3/integrations/logcontext-v2/nrlogrus/formatter.go
@@ -5,6 +5,7 @@ package nrlogrus
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/newrelic/go-agent/v3/internal"
 	newrelic "github.com/newrelic/go-agent/v3/newrelic"
@@ -37,7 +38,10 @@ func (f ContextFormatter) recordLog(logData newrelic.LogData, txn *newrelic.Tran
 }
 
 // enrichLog enriches the buffer with linking metadata
-func (f ContextFormatter) enrichLog(buf *bytes.Buffer, txn *newrelic.Transaction) error {
+func (f ContextFormatter) enrichLog(buf *bytes.Buffer, txn *newrelic.Transaction, cfg newrelic.Config) error {
+	if !cfg.ApplicationLogging.Enabled || !cfg.ApplicationLogging.LocalDecorating.Enabled {
+		return nil // not an error we just don't enrich the log
+	}
 	if txn != nil {
 		return newrelic.EnrichLog(buf, newrelic.FromTxn(txn))
 	}
@@ -60,11 +64,14 @@ func (f ContextFormatter) Format(e *logrus.Entry) ([]byte, error) {
 
 	f.recordLog(logData, txn)
 
-	cfg, _ := f.app.Config()
+	cfg, ok := f.app.Config()
+	if !ok {
+		return nil, fmt.Errorf("couldn't retrieve app config")
+	}
 
 	if cfg.ApplicationLogging.LocalDecorating.WithinMessageField {
 		msgBuf := bytes.NewBufferString(e.Message)
-		if err := f.enrichLog(msgBuf, txn); err != nil {
+		if err := f.enrichLog(msgBuf, txn, cfg); err != nil {
 			return nil, err
 		}
 		e.Message = msgBuf.String()
@@ -77,7 +84,7 @@ func (f ContextFormatter) Format(e *logrus.Entry) ([]byte, error) {
 
 	b := bytes.NewBuffer(bytes.TrimRight(logBytes, "\n"))
 	if !cfg.ApplicationLogging.LocalDecorating.WithinMessageField {
-		if err := f.enrichLog(b, txn); err != nil {
+		if err := f.enrichLog(b, txn, cfg); err != nil {
 			return nil, err
 		}
 	}

--- a/v3/integrations/logcontext-v2/nrlogrus/formatter.go
+++ b/v3/integrations/logcontext-v2/nrlogrus/formatter.go
@@ -35,12 +35,8 @@ func (f ContextFormatter) Format(e *logrus.Entry) ([]byte, error) {
 		Attributes: e.Data,
 	}
 
-	logBytes, err := f.formatter.Format(e)
-	if err != nil {
-		return nil, err
-	}
-	logBytes = bytes.TrimRight(logBytes, "\n")
-	b := bytes.NewBuffer(logBytes)
+	messageBytes := []byte(e.Message)
+	messageBuf := bytes.NewBuffer(messageBytes)
 
 	ctx := e.Context
 	var txn *newrelic.Transaction
@@ -49,17 +45,26 @@ func (f ContextFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	}
 	if txn != nil {
 		txn.RecordLog(logData)
-		err := newrelic.EnrichLog(b, newrelic.FromTxn(txn))
+		err := newrelic.EnrichLog(messageBuf, newrelic.FromTxn(txn))
 		if err != nil {
 			return nil, err
 		}
 	} else {
 		f.app.RecordLog(logData)
-		err := newrelic.EnrichLog(b, newrelic.FromApp(f.app))
+		err := newrelic.EnrichLog(messageBuf, newrelic.FromApp(f.app))
 		if err != nil {
 			return nil, err
 		}
 	}
-	b.WriteString("\n")
+	e.Message = messageBuf.String()
+
+	logBytes, err := f.formatter.Format(e)
+	if err != nil {
+		return nil, err
+	}
+	logBytes = bytes.TrimRight(logBytes, "\n")
+	b := bytes.NewBuffer(logBytes)
+	b.WriteString("\n") // do i need this
+
 	return b.Bytes(), nil
 }

--- a/v3/integrations/logcontext-v2/nrlogrus/formatter.go
+++ b/v3/integrations/logcontext-v2/nrlogrus/formatter.go
@@ -27,6 +27,23 @@ func NewFormatter(app *newrelic.Application, formatter logrus.Formatter) Context
 	}
 }
 
+// recordLog records the log data to the transaction or application
+func (f ContextFormatter) recordLog(logData newrelic.LogData, txn *newrelic.Transaction) {
+	if txn != nil {
+		txn.RecordLog(logData)
+	} else {
+		f.app.RecordLog(logData)
+	}
+}
+
+// enrichLog enriches the buffer with linking metadata
+func (f ContextFormatter) enrichLog(buf *bytes.Buffer, txn *newrelic.Transaction) error {
+	if txn != nil {
+		return newrelic.EnrichLog(buf, newrelic.FromTxn(txn))
+	}
+	return newrelic.EnrichLog(buf, newrelic.FromApp(f.app))
+}
+
 // Format renders a single log entry.
 func (f ContextFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	logData := newrelic.LogData{
@@ -35,36 +52,36 @@ func (f ContextFormatter) Format(e *logrus.Entry) ([]byte, error) {
 		Attributes: e.Data,
 	}
 
-	messageBytes := []byte(e.Message)
-	messageBuf := bytes.NewBuffer(messageBytes)
-
 	ctx := e.Context
 	var txn *newrelic.Transaction
 	if ctx != nil {
 		txn = newrelic.FromContext(ctx)
 	}
-	if txn != nil {
-		txn.RecordLog(logData)
-		err := newrelic.EnrichLog(messageBuf, newrelic.FromTxn(txn))
-		if err != nil {
+
+	f.recordLog(logData, txn)
+
+	cfg, _ := f.app.Config()
+
+	if cfg.ApplicationLogging.LocalDecorating.WithinMessageField {
+		msgBuf := bytes.NewBufferString(e.Message)
+		if err := f.enrichLog(msgBuf, txn); err != nil {
 			return nil, err
 		}
-	} else {
-		f.app.RecordLog(logData)
-		err := newrelic.EnrichLog(messageBuf, newrelic.FromApp(f.app))
-		if err != nil {
-			return nil, err
-		}
+		e.Message = msgBuf.String()
 	}
-	e.Message = messageBuf.String()
 
 	logBytes, err := f.formatter.Format(e)
 	if err != nil {
 		return nil, err
 	}
-	logBytes = bytes.TrimRight(logBytes, "\n")
-	b := bytes.NewBuffer(logBytes)
-	b.WriteString("\n") // do i need this
 
+	b := bytes.NewBuffer(bytes.TrimRight(logBytes, "\n"))
+	if !cfg.ApplicationLogging.LocalDecorating.WithinMessageField {
+		if err := f.enrichLog(b, txn); err != nil {
+			return nil, err
+		}
+	}
+
+	b.WriteString("\n")
 	return b.Bytes(), nil
 }

--- a/v3/integrations/logcontext-v2/nrlogrus/formatter.go
+++ b/v3/integrations/logcontext-v2/nrlogrus/formatter.go
@@ -19,12 +19,24 @@ func init() { internal.TrackUsage("integration", "logcontext-v2", "logrus") }
 type ContextFormatter struct {
 	app       *newrelic.Application
 	formatter logrus.Formatter
+	enricher  logEnricher
+}
+
+type logEnricher interface {
+	Enrich(buf *bytes.Buffer, opts newrelic.EnricherOption) error
+}
+
+type defaultEnricher struct{}
+
+func (e *defaultEnricher) Enrich(buf *bytes.Buffer, opts newrelic.EnricherOption) error {
+	return newrelic.EnrichLog(buf, opts)
 }
 
 func NewFormatter(app *newrelic.Application, formatter logrus.Formatter) ContextFormatter {
 	return ContextFormatter{
 		app:       app,
 		formatter: formatter,
+		enricher:  &defaultEnricher{},
 	}
 }
 
@@ -43,9 +55,9 @@ func (f ContextFormatter) enrichLog(buf *bytes.Buffer, txn *newrelic.Transaction
 		return nil // not an error we just don't enrich the log
 	}
 	if txn != nil {
-		return newrelic.EnrichLog(buf, newrelic.FromTxn(txn))
+		return f.enricher.Enrich(buf, newrelic.FromTxn(txn))
 	}
-	return newrelic.EnrichLog(buf, newrelic.FromApp(f.app))
+	return f.enricher.Enrich(buf, newrelic.FromApp(f.app))
 }
 
 // Format renders a single log entry.

--- a/v3/integrations/logcontext-v2/nrlogrus/formatter_test.go
+++ b/v3/integrations/logcontext-v2/nrlogrus/formatter_test.go
@@ -638,6 +638,26 @@ func buildApp(appInitialized bool, logForwardingEnabled, localDecoratingEnabled,
 		newrelic.ConfigAppLogDecoratingWithinMessage(logDecoratingWithinMessage),
 	)
 }
+func validateMessageField(t *testing.T, byts []byte, decorationDisabled bool) {
+	var entry map[string]string
+	if err := json.Unmarshal(byts, &entry); err != nil {
+		t.Fatalf("Failed to unmarshal logger entry: %v", err)
+	}
+	s, ok := entry["msg"]
+	if !ok {
+		t.Fatal("No message field found")
+	}
+	validateMessageFieldStr(t, s, decorationDisabled)
+}
+
+func validateMessageFieldStr(t *testing.T, str string, decorationDisabled bool) {
+	logcontext.ValidateNRLinkingString(t, bytes.NewBufferString(str), &logcontext.DecorationExpect{
+		EntityGUID:         integrationsupport.TestEntityGUID,
+		Hostname:           host,
+		EntityName:         integrationsupport.SampleAppName,
+		DecorationDisabled: decorationDisabled, // we expect the NR-LINKING string to be within the message field
+	})
+}
 
 func TestLogWithMessageLogDecorating(t *testing.T) {
 	tests := []struct {
@@ -648,31 +668,101 @@ func TestLogWithMessageLogDecorating(t *testing.T) {
 		logDecoratingWithinMessage bool
 	}{
 		{
-			name:                       "Within message field",
+			name:                       "Hello world logged. All config set to true.",
 			message:                    "Hello World",
 			logForwardingEnabled:       true,
 			localDecoratingEnabled:     true,
 			logDecoratingWithinMessage: true,
 		},
 		{
-			name:                       "Not within message field",
+			name:                       "Hello world logged. Log decorating within message set to false.",
 			message:                    "Hello World",
 			logForwardingEnabled:       true,
 			localDecoratingEnabled:     true,
 			logDecoratingWithinMessage: false,
 		},
 		{
-			name:                       "Empty string logged. Decorator should be within message field.",
+			name:                       "Empty string logged.  All config set to true",
 			message:                    "",
 			logForwardingEnabled:       true,
 			localDecoratingEnabled:     true,
 			logDecoratingWithinMessage: true,
 		},
 		{
-			name:                       "Empty string logged. Decorater should not be within empty message field.",
+			name:                       "Empty string logged. Log decorating withing message set to false.",
 			message:                    "",
 			logForwardingEnabled:       true,
 			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: false,
+		},
+		{
+			name:                       "Hello world logged. Log decorating set to false.",
+			message:                    "Hello World",
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     false,
+			logDecoratingWithinMessage: true,
+		},
+		{
+			name:                       "Hello world logged. Log decorating and log decorating within message set to false.",
+			message:                    "Hello World",
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     false,
+			logDecoratingWithinMessage: false,
+		},
+		{
+			name:                       "Empty string logged. Log decorating set to false.",
+			message:                    "",
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     false,
+			logDecoratingWithinMessage: true,
+		},
+		{
+			name:                       "Empty string logged. Log decorating and log decorating within message set to false.",
+			message:                    "",
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     false,
+			logDecoratingWithinMessage: false,
+		},
+		{
+			name:                       "Hello world logged. Log forwarding set to false.",
+			message:                    "Hello World",
+			logForwardingEnabled:       false,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: true,
+		},
+		{
+			name:                       "Hello world logged. Log forwarding and log decorating within message set to false.",
+			message:                    "Hello World",
+			logForwardingEnabled:       false,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: false,
+		},
+		{
+			name:                       "Hello world logged. All config set to false.",
+			message:                    "Hello World",
+			logForwardingEnabled:       false,
+			localDecoratingEnabled:     false,
+			logDecoratingWithinMessage: false,
+		},
+		{
+			name:                       "Empty string logged. Log forwarding set to false.",
+			message:                    "",
+			logForwardingEnabled:       false,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: true,
+		},
+		{
+			name:                       "Empty string logged. Log forwarding and log decorating within message set to false.",
+			message:                    "",
+			logForwardingEnabled:       false,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: false,
+		},
+		{
+			name:                       "Empty string logged. All config set to false.",
+			message:                    "",
+			logForwardingEnabled:       false,
+			localDecoratingEnabled:     false,
 			logDecoratingWithinMessage: false,
 		},
 	}
@@ -682,86 +772,68 @@ func TestLogWithMessageLogDecorating(t *testing.T) {
 		"JSON": newJSONLogger,
 	}
 
-	validateMessageField := func(t *testing.T, byts []byte, decorationDisabled bool) {
-		var entry map[string]string
-		if err := json.Unmarshal(byts, &entry); err != nil {
-			t.Fatalf("Failed to unmarshal logger entry: %v", err)
-		}
-		s, ok := entry["msg"]
-		if !ok {
-			t.Fatal("No message field found")
-		}
-		logcontext.ValidateNRLinkingString(t, bytes.NewBufferString(s), &logcontext.DecorationExpect{
-			EntityGUID:         integrationsupport.TestEntityGUID,
-			Hostname:           host,
-			EntityName:         integrationsupport.SampleAppName,
-			DecorationDisabled: decorationDisabled, // we expect the NR-LINKING string to be within the message field
-		})
-	}
-
-	validateMessageFieldStr := func(t *testing.T, str string, decorationDisabled bool) {
-		logcontext.ValidateNRLinkingString(t, bytes.NewBufferString(str), &logcontext.DecorationExpect{
-			EntityGUID:         integrationsupport.TestEntityGUID,
-			Hostname:           host,
-			EntityName:         integrationsupport.SampleAppName,
-			DecorationDisabled: decorationDisabled, // we expect the NR-LINKING string to be within the message field
-		})
-	}
-
 	var re = regexp.MustCompile(`(?m)msg="[^"]*"`)
 	for _, tt := range tests {
 		for key, buildLog := range buildLoggers {
+
 			testName := fmt.Sprintf("%s: %s", key, tt.name)
 			t.Run(testName, func(t *testing.T) {
 				app := buildApp(true, tt.logForwardingEnabled, tt.localDecoratingEnabled, tt.logDecoratingWithinMessage)
 				out := bytes.NewBuffer([]byte{})
 				log := buildLog(out, app.Application)
-				message := tt.message
-				log.Info(message)
+				log.Info(tt.message)
 
 				// if we expect the log decorating to be within the message check if its there
-				if tt.logDecoratingWithinMessage {
-					if key == "Text" {
-						s := out.String()
-						sl := re.FindStringSubmatch(s)
-						if len(sl) == 0 {
-							if tt.message != "" {
-								t.Fatal("couldn't find msg field in string")
+				if tt.localDecoratingEnabled {
+					if tt.logDecoratingWithinMessage {
+						if key == "Text" {
+							sl := re.FindStringSubmatch(out.String())
+							if len(sl) == 0 {
+								if tt.message != "" {
+									t.Fatal("couldn't find msg field in string")
+								}
+							} else {
+								validateMessageFieldStr(t, sl[0], false)
 							}
-						}
-						validateMessageFieldStr(t, sl[0], false)
-
-					} else {
-						validateMessageField(t, out.Bytes(), false)
-					}
-				} else {
-					// NR-LINKING STRING SHOULD BE AT THE END so breaks JSON formatting
-					if key == "Text" {
-						s := out.String()
-						sl := re.FindStringSubmatch(s)
-						if len(sl) == 0 {
-							if tt.message != "" {
-								t.Fatal("couldn't find msg field in string")
-							}
-							// empty message case means there is nothing to check
 						} else {
-							validateMessageFieldStr(t, sl[0], true)
+							validateMessageField(t, out.Bytes(), false)
 						}
 					} else {
-						split := strings.Split(out.String(), "NR-LINKING")
-						if len(split) != 2 {
-							t.Fatalf("expected log decoration, but NR-LINKING data was missing: %s", out.String())
+						// NR-LINKING STRING SHOULD BE AT THE END so breaks JSON formatting
+						if key == "Text" {
+							sl := re.FindStringSubmatch(out.String())
+							if len(sl) == 0 {
+								if tt.message != "" {
+									t.Fatal("couldn't find msg field in string")
+								}
+								// msg field doesn't exist so split out whole string
+								split := strings.Split(out.String(), "NR-LINKING")
+								if len(split) != 2 {
+									t.Fatalf("expected log decoration, but NR-LINKING data was missing: %s", out.String())
+								}
+								validateMessageFieldStr(t, split[0], true)
+							} else {
+								validateMessageFieldStr(t, sl[0], true)
+							}
+						} else {
+							// split so formatting works and we can check msg field for no NR-LINKING
+							split := strings.Split(out.String(), "NR-LINKING")
+							if len(split) != 2 {
+								t.Fatalf("expected log decoration, but NR-LINKING data was missing: %s", out.String())
+							}
+							validateMessageField(t, []byte(split[0]), true)
 						}
-						validateMessageField(t, []byte(split[0]), true)
 					}
-				}
 
+				}
 				// still validate log as a whole not mattering where NR-LINKING string is
 				logcontext.ValidateDecoratedOutput(t, out, &logcontext.DecorationExpect{
-					EntityGUID: integrationsupport.TestEntityGUID,
-					Hostname:   host,
-					EntityName: integrationsupport.SampleAppName,
+					EntityGUID:         integrationsupport.TestEntityGUID,
+					Hostname:           host,
+					EntityName:         integrationsupport.SampleAppName,
+					DecorationDisabled: !tt.localDecoratingEnabled,
 				})
+
 			})
 		}
 	}

--- a/v3/integrations/logcontext-v2/nrlogrus/formatter_test.go
+++ b/v3/integrations/logcontext-v2/nrlogrus/formatter_test.go
@@ -3,6 +3,7 @@ package nrlogrus
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"testing"
 
@@ -18,14 +19,27 @@ var (
 	host, _ = sysinfo.Hostname()
 )
 
+type calledChecker interface {
+	WasCalled() bool
+}
 type testEnricher struct {
 	called bool
+	err    error
 }
 
 func (e *testEnricher) Enrich(buf *bytes.Buffer, opts newrelic.EnricherOption) error {
 	e.called = true
-	return nil
+	return e.ErrOrNil()
 }
+
+func (e *testEnricher) WasCalled() bool {
+	return e.called
+}
+
+func (e *testEnricher) ErrOrNil() error {
+	return e.err
+}
+
 func newTextLogger(out io.Writer, app *newrelic.Application) *logrus.Logger {
 	l := logrus.New()
 	l.Formatter = NewFormatter(app, &logrus.TextFormatter{
@@ -367,4 +381,234 @@ func TestContextFormatter_enrichLog(t *testing.T) {
 
 		})
 	}
+}
+
+func TestContextFormatter_Format(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for receiver constructor.
+		formatter                  logrus.Formatter
+		enricher                   logEnricher
+		appInitialized             bool
+		logForwardingEnabled       bool
+		localDecoratingEnabled     bool
+		logDecoratingWithinMessage bool
+		// Named input parameters for target function.
+		e           *logrus.Entry
+		want        []byte
+		wantErr     bool
+		wantCallSpy bool
+	}{
+		{
+			name:                       "Couldn't retrieve app config and all log enabling set to true. Should return with error and nil bytes.",
+			formatter:                  &logrus.TextFormatter{},
+			appInitialized:             false,
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: true,
+			e:                          &logrus.Entry{},
+			want:                       nil,
+			wantErr:                    true,
+			wantCallSpy:                false,
+		},
+		{
+			name:                       "Couldn't retrieve app config and all log enabling set to false. Should return with error and nil bytes.",
+			formatter:                  &logrus.TextFormatter{},
+			appInitialized:             false,
+			logForwardingEnabled:       false,
+			localDecoratingEnabled:     false,
+			logDecoratingWithinMessage: false,
+			e:                          &logrus.Entry{},
+			want:                       nil,
+			wantErr:                    true,
+			wantCallSpy:                false,
+		},
+		{
+			name:                       "Couldn't retrieve app config and some log enabling set to false. Should return with error and nil bytes.",
+			formatter:                  &logrus.TextFormatter{},
+			appInitialized:             false,
+			logForwardingEnabled:       false,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: false,
+			e:                          &logrus.Entry{},
+			want:                       nil,
+			wantErr:                    true,
+			wantCallSpy:                false,
+		},
+		{
+			name:                       "Couldn't retrieve app config and some log enabling set to true. Should return with error and nil bytes.",
+			formatter:                  &logrus.TextFormatter{},
+			appInitialized:             false,
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: false,
+			e:                          &logrus.Entry{},
+			want:                       nil,
+			wantErr:                    true,
+			wantCallSpy:                false,
+		},
+		{
+			name:                       "Log decorating within message set to true but enrich log returns error. Should return with error and nil bytes.",
+			formatter:                  &logrus.TextFormatter{},
+			appInitialized:             true,
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: true,
+			enricher:                   &testEnricher{err: fmt.Errorf("test error")},
+			e:                          &logrus.Entry{},
+			want:                       nil,
+			wantErr:                    true,
+			wantCallSpy:                false,
+		},
+		{
+			name:                       "Log decorating within message set to true but others set to false but enrich log returns error. Should return with nil bytes.",
+			formatter:                  &logrus.TextFormatter{},
+			appInitialized:             true,
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: true,
+			enricher:                   &testEnricher{err: fmt.Errorf("test error")},
+			e:                          &logrus.Entry{},
+			want:                       nil,
+			wantErr:                    true,
+			wantCallSpy:                false,
+		},
+		{
+			name:                       "Log decorating within message set to true and enrich log returns nil. Format returns an error (JSON only). Should return with nil bytes but should enrich.",
+			formatter:                  &logrus.JSONFormatter{},
+			appInitialized:             true,
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: true,
+			enricher:                   &testEnricher{},
+			e: &logrus.Entry{
+				Data: logrus.Fields{"fn": func() {}}, // json encode won't work in JSONFormatter.Format()
+			},
+			want:        nil,
+			wantErr:     true,
+			wantCallSpy: true,
+		},
+		{
+			name:                       "Log decorating within message set to false and enrich log returns nil. Format returns an error (JSON only). Should return with nil bytes and should call enrich.",
+			formatter:                  &logrus.JSONFormatter{},
+			appInitialized:             true,
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: false,
+			enricher:                   &testEnricher{},
+			e: &logrus.Entry{
+				Data: logrus.Fields{"fn": func() {}}, // json encode won't work in JSONFormatter.Format()
+			},
+			want:        nil,
+			wantErr:     true,
+			wantCallSpy: true,
+		},
+		{
+			name:                       "Log decorating within message set to false and enrich log returns err. Format returns an error (JSON only). Should return with nil bytes and should call enrich.",
+			formatter:                  &logrus.JSONFormatter{},
+			appInitialized:             true,
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: false,
+			enricher:                   &testEnricher{err: fmt.Errorf("test error")},
+			e: &logrus.Entry{
+				Data: logrus.Fields{"fn": func() {}}, // json encode won't work in JSONFormatter.Format()
+			},
+			want:        nil,
+			wantErr:     true,
+			wantCallSpy: true,
+		},
+		{
+			name:                       "Log decorating within message set to false and enrich log returns err. Should return with nil bytes and should call enrich.",
+			formatter:                  &logrus.JSONFormatter{},
+			appInitialized:             true,
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: false,
+			enricher:                   &testEnricher{err: fmt.Errorf("test error")},
+			e:                          &logrus.Entry{},
+			want:                       nil,
+			wantErr:                    true,
+			wantCallSpy:                true,
+		},
+		{
+			name:                       "Log decorating within message set to false and enrich log returns nil. Should return with bytes and should call enrich.",
+			formatter:                  &logrus.JSONFormatter{},
+			appInitialized:             true,
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: false,
+			enricher:                   &testEnricher{},
+			e:                          &logrus.Entry{},
+			want:                       []byte{},
+			wantErr:                    false,
+			wantCallSpy:                true,
+		},
+		{
+			name:                       "Log decorating within message set to true and enrich log returns nil. Should return with bytes and should call enrich.",
+			formatter:                  &logrus.JSONFormatter{},
+			appInitialized:             true,
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: true,
+			enricher:                   &testEnricher{},
+			e:                          &logrus.Entry{},
+			want:                       []byte{},
+			wantErr:                    false,
+			wantCallSpy:                true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := buildApp(tt.appInitialized, tt.logForwardingEnabled, tt.localDecoratingEnabled, tt.logDecoratingWithinMessage)
+			f := &ContextFormatter{
+				app:       app.Application,
+				formatter: tt.formatter,
+				enricher:  tt.enricher,
+			}
+			got, gotErr := f.Format(tt.e)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("Format() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("Format() succeeded unexpectedly")
+			}
+			if tt.want != nil {
+				if len(got) == 0 {
+					t.Errorf("Unexpected nil return -> Format() = %v, want %v", got, tt.want)
+				}
+				return
+			}
+			if len(got) > 0 {
+				t.Errorf("Unexpected non-nil return -> Format() = %v, want %v", got, tt.want)
+			}
+			if checker, ok := tt.enricher.(calledChecker); ok {
+				if tt.wantCallSpy {
+					if !checker.WasCalled() {
+						t.Errorf("Unexpected non-call of Enrich()")
+					}
+					return
+				}
+				if checker.WasCalled() {
+					t.Errorf("Unexpected call of Enrich()")
+				}
+			}
+		})
+	}
+}
+
+func buildApp(appInitialized bool, logForwardingEnabled, localDecoratingEnabled, logDecoratingWithinMessage bool) integrationsupport.ExpectApp {
+	if !appInitialized {
+		return integrationsupport.ExpectApp{
+			Application: &newrelic.Application{},
+		}
+	}
+	return integrationsupport.NewTestApp(integrationsupport.SampleEverythingReplyFn,
+		newrelic.ConfigAppLogDecoratingEnabled(localDecoratingEnabled),
+		newrelic.ConfigAppLogForwardingEnabled(logForwardingEnabled),
+		newrelic.ConfigAppLogDecoratingWithinMessage(logDecoratingWithinMessage),
+	)
 }

--- a/v3/integrations/logcontext-v2/nrlogrus/formatter_test.go
+++ b/v3/integrations/logcontext-v2/nrlogrus/formatter_test.go
@@ -281,19 +281,14 @@ func TestContextFormatter_enrichLog(t *testing.T) {
 	// do I need to test different types of formatters? Probably should
 	tests := []struct {
 		name string // description of this test case
-		// Named input parameters for receiver constructor.
-		formatter logrus.Formatter
 		// Named input parameters for target function.
-		txn *newrelic.Transaction
-
+		txn                    *newrelic.Transaction
 		enabled                bool
 		localDecoratingEnabled bool
-
-		wantCallSpy bool
+		wantCallSpy            bool
 	}{
 		{
 			name:                   "Logging and Local Decorating Disabled and existing txn. Should not call Enrich Log",
-			formatter:              &logrus.TextFormatter{},
 			txn:                    &newrelic.Transaction{},
 			enabled:                false,
 			localDecoratingEnabled: false,
@@ -301,7 +296,6 @@ func TestContextFormatter_enrichLog(t *testing.T) {
 		},
 		{
 			name:                   "Logging and Local Decorating Disabled and no existing txn. Should not call Enrich Log",
-			formatter:              &logrus.TextFormatter{},
 			txn:                    nil,
 			enabled:                false,
 			localDecoratingEnabled: false,
@@ -309,7 +303,6 @@ func TestContextFormatter_enrichLog(t *testing.T) {
 		},
 		{
 			name:                   "Logging Enabled and Local Decorating Disabled and existing txn. Should not call Enrich Log",
-			formatter:              &logrus.TextFormatter{},
 			txn:                    &newrelic.Transaction{},
 			enabled:                true,
 			localDecoratingEnabled: false,
@@ -317,7 +310,6 @@ func TestContextFormatter_enrichLog(t *testing.T) {
 		},
 		{
 			name:                   "Logging Enabled and Local Decorating Disabled and no existing txn. Should not call Enrich Log",
-			formatter:              &logrus.TextFormatter{},
 			txn:                    nil,
 			enabled:                true,
 			localDecoratingEnabled: false,
@@ -325,7 +317,6 @@ func TestContextFormatter_enrichLog(t *testing.T) {
 		},
 		{
 			name:                   "Logging Disabled and Local Decorating Enabled and existing txn. Should not call Enrich Log",
-			formatter:              &logrus.TextFormatter{},
 			txn:                    &newrelic.Transaction{},
 			enabled:                false,
 			localDecoratingEnabled: true,
@@ -333,7 +324,6 @@ func TestContextFormatter_enrichLog(t *testing.T) {
 		},
 		{
 			name:                   "Logging Disabled and Local Decorating Enabled and no existing txn. Should not call Enrich Log",
-			formatter:              &logrus.TextFormatter{},
 			txn:                    nil,
 			enabled:                false,
 			localDecoratingEnabled: true,
@@ -341,7 +331,6 @@ func TestContextFormatter_enrichLog(t *testing.T) {
 		},
 		{
 			name:                   "Logging and Local Decorating Enabled and no existing txn. Should call enrich log",
-			formatter:              &logrus.TextFormatter{},
 			txn:                    nil,
 			enabled:                true,
 			localDecoratingEnabled: true,
@@ -349,37 +338,43 @@ func TestContextFormatter_enrichLog(t *testing.T) {
 		},
 		{
 			name:                   "Logging and Local Decorating Enabled and existing txn. Should call enrich log",
-			formatter:              &logrus.TextFormatter{},
 			txn:                    &newrelic.Transaction{},
 			enabled:                true,
 			localDecoratingEnabled: true,
 			wantCallSpy:            true,
 		},
 	}
+	formatters := map[string]logrus.Formatter{
+		"Text": &logrus.TextFormatter{},
+		"JSON": &logrus.JSONFormatter{},
+	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			enricherSpy := &testEnricher{}
-			f := ContextFormatter{
-				formatter: tt.formatter,
-				enricher:  enricherSpy,
-			} // not testing any app functionality so we can set it to nil in this case
-			f.enrichLog(nil, tt.txn, newrelic.Config{
-				ApplicationLogging: newrelic.ApplicationLogging{
-					Enabled: tt.enabled,
-					LocalDecorating: struct {
-						Enabled            bool
-						WithinMessageField bool
-					}{
-						Enabled: tt.localDecoratingEnabled,
+		for key, formatter := range formatters {
+			testName := fmt.Sprintf("%s: tt.name", key)
+			t.Run(testName, func(t *testing.T) {
+				enricherSpy := &testEnricher{}
+				f := ContextFormatter{
+					formatter: formatter,
+					enricher:  enricherSpy,
+				} // not testing any app functionality so we can set it to nil in this case
+				f.enrichLog(nil, tt.txn, newrelic.Config{
+					ApplicationLogging: newrelic.ApplicationLogging{
+						Enabled: tt.enabled,
+						LocalDecorating: struct {
+							Enabled            bool
+							WithinMessageField bool
+						}{
+							Enabled: tt.localDecoratingEnabled,
+						},
 					},
-				},
+				})
+
+				if enricherSpy.called != tt.wantCallSpy {
+					t.Errorf("enrichLog() failed with calling newrelic.Enrich(), Got: %v want: %v", enricherSpy.called, tt.wantCallSpy)
+				}
+
 			})
-
-			if enricherSpy.called != tt.wantCallSpy {
-				t.Errorf("enrichLog() failed with calling newrelic.Enrich(), Got: %v want: %v", enricherSpy.called, tt.wantCallSpy)
-			}
-
-		})
+		}
 	}
 }
 
@@ -387,7 +382,7 @@ func TestContextFormatter_Format(t *testing.T) {
 	tests := []struct {
 		name string // description of this test case
 		// Named input parameters for receiver constructor.
-		formatter                  logrus.Formatter
+		jsonOnly                   bool
 		enricher                   logEnricher
 		appInitialized             bool
 		logForwardingEnabled       bool
@@ -401,11 +396,11 @@ func TestContextFormatter_Format(t *testing.T) {
 	}{
 		{
 			name:                       "Couldn't retrieve app config and all log enabling set to true. Should return with error and nil bytes.",
-			formatter:                  &logrus.TextFormatter{},
 			appInitialized:             false,
 			logForwardingEnabled:       true,
 			localDecoratingEnabled:     true,
 			logDecoratingWithinMessage: true,
+			enricher:                   &testEnricher{},
 			e:                          &logrus.Entry{},
 			want:                       nil,
 			wantErr:                    true,
@@ -413,35 +408,37 @@ func TestContextFormatter_Format(t *testing.T) {
 		},
 		{
 			name:                       "Couldn't retrieve app config and all log enabling set to false. Should return with error and nil bytes.",
-			formatter:                  &logrus.TextFormatter{},
 			appInitialized:             false,
 			logForwardingEnabled:       false,
 			localDecoratingEnabled:     false,
 			logDecoratingWithinMessage: false,
-			e:                          &logrus.Entry{},
-			want:                       nil,
-			wantErr:                    true,
-			wantCallSpy:                false,
+			enricher:                   &testEnricher{},
+
+			e:           &logrus.Entry{},
+			want:        nil,
+			wantErr:     true,
+			wantCallSpy: false,
 		},
 		{
 			name:                       "Couldn't retrieve app config and some log enabling set to false. Should return with error and nil bytes.",
-			formatter:                  &logrus.TextFormatter{},
 			appInitialized:             false,
 			logForwardingEnabled:       false,
 			localDecoratingEnabled:     true,
 			logDecoratingWithinMessage: false,
-			e:                          &logrus.Entry{},
-			want:                       nil,
-			wantErr:                    true,
-			wantCallSpy:                false,
+			enricher:                   &testEnricher{},
+
+			e:           &logrus.Entry{},
+			want:        nil,
+			wantErr:     true,
+			wantCallSpy: false,
 		},
 		{
 			name:                       "Couldn't retrieve app config and some log enabling set to true. Should return with error and nil bytes.",
-			formatter:                  &logrus.TextFormatter{},
 			appInitialized:             false,
 			logForwardingEnabled:       true,
 			localDecoratingEnabled:     true,
 			logDecoratingWithinMessage: false,
+			enricher:                   &testEnricher{},
 			e:                          &logrus.Entry{},
 			want:                       nil,
 			wantErr:                    true,
@@ -449,7 +446,6 @@ func TestContextFormatter_Format(t *testing.T) {
 		},
 		{
 			name:                       "Log decorating within message set to true but enrich log returns error. Should return with error and nil bytes.",
-			formatter:                  &logrus.TextFormatter{},
 			appInitialized:             true,
 			logForwardingEnabled:       true,
 			localDecoratingEnabled:     true,
@@ -458,11 +454,10 @@ func TestContextFormatter_Format(t *testing.T) {
 			e:                          &logrus.Entry{},
 			want:                       nil,
 			wantErr:                    true,
-			wantCallSpy:                false,
+			wantCallSpy:                true,
 		},
 		{
 			name:                       "Log decorating within message set to true but others set to false but enrich log returns error. Should return with nil bytes.",
-			formatter:                  &logrus.TextFormatter{},
 			appInitialized:             true,
 			logForwardingEnabled:       true,
 			localDecoratingEnabled:     true,
@@ -471,11 +466,11 @@ func TestContextFormatter_Format(t *testing.T) {
 			e:                          &logrus.Entry{},
 			want:                       nil,
 			wantErr:                    true,
-			wantCallSpy:                false,
+			wantCallSpy:                true,
 		},
 		{
 			name:                       "Log decorating within message set to true and enrich log returns nil. Format returns an error (JSON only). Should return with nil bytes but should enrich.",
-			formatter:                  &logrus.JSONFormatter{},
+			jsonOnly:                   true,
 			appInitialized:             true,
 			logForwardingEnabled:       true,
 			localDecoratingEnabled:     true,
@@ -489,8 +484,23 @@ func TestContextFormatter_Format(t *testing.T) {
 			wantCallSpy: true,
 		},
 		{
-			name:                       "Log decorating within message set to false and enrich log returns nil. Format returns an error (JSON only). Should return with nil bytes and should call enrich.",
-			formatter:                  &logrus.JSONFormatter{},
+			name:                       "Log decorating within message set to true and enrich log returns err. Format returns an error (JSON only). Should return with nil bytes but should enrich.",
+			jsonOnly:                   true,
+			appInitialized:             true,
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: true,
+			enricher:                   &testEnricher{err: fmt.Errorf("test error")},
+			e: &logrus.Entry{
+				Data: logrus.Fields{"fn": func() {}}, // json encode won't work in JSONFormatter.Format()
+			},
+			want:        nil,
+			wantErr:     true,
+			wantCallSpy: true,
+		},
+		{
+			name:                       "Log decorating within message set to false and enrich log returns nil. Format returns an error (JSON only). Should return with nil bytes.",
+			jsonOnly:                   true,
 			appInitialized:             true,
 			logForwardingEnabled:       true,
 			localDecoratingEnabled:     true,
@@ -501,11 +511,11 @@ func TestContextFormatter_Format(t *testing.T) {
 			},
 			want:        nil,
 			wantErr:     true,
-			wantCallSpy: true,
+			wantCallSpy: false,
 		},
 		{
-			name:                       "Log decorating within message set to false and enrich log returns err. Format returns an error (JSON only). Should return with nil bytes and should call enrich.",
-			formatter:                  &logrus.JSONFormatter{},
+			name:                       "Log decorating within message set to false and enrich log returns err. Format returns an error (JSON only). Should return with nil bytes.",
+			jsonOnly:                   true,
 			appInitialized:             true,
 			logForwardingEnabled:       true,
 			localDecoratingEnabled:     true,
@@ -516,11 +526,10 @@ func TestContextFormatter_Format(t *testing.T) {
 			},
 			want:        nil,
 			wantErr:     true,
-			wantCallSpy: true,
+			wantCallSpy: false,
 		},
 		{
 			name:                       "Log decorating within message set to false and enrich log returns err. Should return with nil bytes and should call enrich.",
-			formatter:                  &logrus.JSONFormatter{},
 			appInitialized:             true,
 			logForwardingEnabled:       true,
 			localDecoratingEnabled:     true,
@@ -533,7 +542,6 @@ func TestContextFormatter_Format(t *testing.T) {
 		},
 		{
 			name:                       "Log decorating within message set to false and enrich log returns nil. Should return with bytes and should call enrich.",
-			formatter:                  &logrus.JSONFormatter{},
 			appInitialized:             true,
 			logForwardingEnabled:       true,
 			localDecoratingEnabled:     true,
@@ -546,7 +554,6 @@ func TestContextFormatter_Format(t *testing.T) {
 		},
 		{
 			name:                       "Log decorating within message set to true and enrich log returns nil. Should return with bytes and should call enrich.",
-			formatter:                  &logrus.JSONFormatter{},
 			appInitialized:             true,
 			logForwardingEnabled:       true,
 			localDecoratingEnabled:     true,
@@ -557,46 +564,62 @@ func TestContextFormatter_Format(t *testing.T) {
 			wantErr:                    false,
 			wantCallSpy:                true,
 		},
+		{
+			name:                       "App initialized with local decorating disabled. Should return with bytes and should not call enrich.",
+			appInitialized:             true,
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     false,
+			logDecoratingWithinMessage: false,
+			enricher:                   &testEnricher{},
+			e:                          &logrus.Entry{},
+			want:                       []byte{},
+			wantErr:                    false,
+			wantCallSpy:                false,
+		},
+	}
+	formatters := map[string]logrus.Formatter{
+		"Text": &logrus.TextFormatter{},
+		"JSON": &logrus.JSONFormatter{},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			app := buildApp(tt.appInitialized, tt.logForwardingEnabled, tt.localDecoratingEnabled, tt.logDecoratingWithinMessage)
-			f := &ContextFormatter{
-				app:       app.Application,
-				formatter: tt.formatter,
-				enricher:  tt.enricher,
+		for key, formatter := range formatters {
+			if tt.jsonOnly && key == "Text" {
+				continue
 			}
-			got, gotErr := f.Format(tt.e)
-			if gotErr != nil {
-				if !tt.wantErr {
-					t.Errorf("Format() failed: %v", gotErr)
+			testName := fmt.Sprintf("%s: %s", key, tt.name)
+			t.Run(testName, func(t *testing.T) {
+				app := buildApp(tt.appInitialized, tt.logForwardingEnabled, tt.localDecoratingEnabled, tt.logDecoratingWithinMessage)
+				f := &ContextFormatter{
+					app:       app.Application,
+					formatter: formatter,
+					enricher:  tt.enricher,
 				}
-				return
-			}
-			if tt.wantErr {
-				t.Fatal("Format() succeeded unexpectedly")
-			}
-			if tt.want != nil {
-				if len(got) == 0 {
-					t.Errorf("Unexpected nil return -> Format() = %v, want %v", got, tt.want)
-				}
-				return
-			}
-			if len(got) > 0 {
-				t.Errorf("Unexpected non-nil return -> Format() = %v, want %v", got, tt.want)
-			}
-			if checker, ok := tt.enricher.(calledChecker); ok {
-				if tt.wantCallSpy {
-					if !checker.WasCalled() {
-						t.Errorf("Unexpected non-call of Enrich()")
+				got, gotErr := f.Format(tt.e)
+				if gotErr != nil {
+					if !tt.wantErr {
+						t.Errorf("Format() failed: %v", gotErr)
 					}
-					return
+				} else if tt.wantErr {
+					t.Errorf("Format() succeeded unexpectedly: %v", key)
 				}
-				if checker.WasCalled() {
-					t.Errorf("Unexpected call of Enrich()")
+				if tt.want != nil {
+					if len(got) == 0 {
+						t.Errorf("Unexpected nil return -> Format() = %v, want %v", got, tt.want)
+					}
+				} else if len(got) > 0 {
+					t.Errorf("Unexpected non-nil return -> Format() = %v, want %v", got, tt.want)
 				}
-			}
-		})
+				if checker, ok := tt.enricher.(calledChecker); ok {
+					if tt.wantCallSpy {
+						if !checker.WasCalled() {
+							t.Errorf("Unexpected non-call of Enrich()")
+						}
+					} else if checker.WasCalled() {
+						t.Errorf("Unexpected call of Enrich()")
+					}
+				}
+			})
+		}
 	}
 }
 

--- a/v3/integrations/logcontext-v2/nrlogrus/formatter_test.go
+++ b/v3/integrations/logcontext-v2/nrlogrus/formatter_test.go
@@ -3,6 +3,7 @@ package nrlogrus
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"testing"
@@ -350,7 +351,7 @@ func TestContextFormatter_enrichLog(t *testing.T) {
 	}
 	for _, tt := range tests {
 		for key, formatter := range formatters {
-			testName := fmt.Sprintf("%s: tt.name", key)
+			testName := fmt.Sprintf("%s: %s", key, tt.name)
 			t.Run(testName, func(t *testing.T) {
 				enricherSpy := &testEnricher{}
 				f := ContextFormatter{
@@ -584,7 +585,7 @@ func TestContextFormatter_Format(t *testing.T) {
 	for _, tt := range tests {
 		for key, formatter := range formatters {
 			if tt.jsonOnly && key == "Text" {
-				continue
+				continue // skip TextFormatter if we are expecting a JSON error
 			}
 			testName := fmt.Sprintf("%s: %s", key, tt.name)
 			t.Run(testName, func(t *testing.T) {
@@ -634,4 +635,40 @@ func buildApp(appInitialized bool, logForwardingEnabled, localDecoratingEnabled,
 		newrelic.ConfigAppLogForwardingEnabled(logForwardingEnabled),
 		newrelic.ConfigAppLogDecoratingWithinMessage(logDecoratingWithinMessage),
 	)
+}
+
+func TestLogInfoWithMessage(t *testing.T) {
+	tests := []struct {
+		name                       string
+		logForwardingEnabled       bool
+		localDecoratingEnabled     bool
+		logDecoratingWithinMessage bool
+	}{
+		{
+			name:                       "TEST TEST",
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: true,
+		},
+	}
+
+	for _, tt := range tests {
+		app := buildApp(true, tt.logForwardingEnabled, tt.localDecoratingEnabled, tt.logDecoratingWithinMessage)
+		out := bytes.NewBuffer([]byte{})
+		log := newJSONLogger(out, app.Application)
+		message := "Hello World"
+		log.Info(message)
+
+		var entry any
+		s := out.String()
+		if err := json.Unmarshal(out.Bytes(), &entry); err != nil {
+			t.Fatalf("Failed to unmarshal logger entry: %v", err)
+		}
+		t.Logf("ENTRY: %v\n%v", entry, s)
+		logcontext.ValidateDecoratedOutput(t, out, &logcontext.DecorationExpect{
+			EntityGUID: integrationsupport.TestEntityGUID,
+			Hostname:   host,
+			EntityName: "integrationsupport.SampleAppName",
+		})
+	}
 }

--- a/v3/integrations/logcontext-v2/nrlogrus/formatter_test.go
+++ b/v3/integrations/logcontext-v2/nrlogrus/formatter_test.go
@@ -18,6 +18,14 @@ var (
 	host, _ = sysinfo.Hostname()
 )
 
+type testEnricher struct {
+	called bool
+}
+
+func (e *testEnricher) Enrich(buf *bytes.Buffer, opts newrelic.EnricherOption) error {
+	e.called = true
+	return nil
+}
 func newTextLogger(out io.Writer, app *newrelic.Application) *logrus.Logger {
 	l := logrus.New()
 	l.Formatter = NewFormatter(app, &logrus.TextFormatter{
@@ -253,4 +261,110 @@ func TestLogInContextWithFields(t *testing.T) {
 	})
 
 	txn.End()
+}
+
+func TestContextFormatter_enrichLog(t *testing.T) {
+	// do I need to test different types of formatters? Probably should
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for receiver constructor.
+		formatter logrus.Formatter
+		// Named input parameters for target function.
+		txn *newrelic.Transaction
+
+		enabled                bool
+		localDecoratingEnabled bool
+
+		wantCallSpy bool
+	}{
+		{
+			name:                   "Logging and Local Decorating Disabled and existing txn. Should not call Enrich Log",
+			formatter:              &logrus.TextFormatter{},
+			txn:                    &newrelic.Transaction{},
+			enabled:                false,
+			localDecoratingEnabled: false,
+			wantCallSpy:            false,
+		},
+		{
+			name:                   "Logging and Local Decorating Disabled and no existing txn. Should not call Enrich Log",
+			formatter:              &logrus.TextFormatter{},
+			txn:                    nil,
+			enabled:                false,
+			localDecoratingEnabled: false,
+			wantCallSpy:            false,
+		},
+		{
+			name:                   "Logging Enabled and Local Decorating Disabled and existing txn. Should not call Enrich Log",
+			formatter:              &logrus.TextFormatter{},
+			txn:                    &newrelic.Transaction{},
+			enabled:                true,
+			localDecoratingEnabled: false,
+			wantCallSpy:            false,
+		},
+		{
+			name:                   "Logging Enabled and Local Decorating Disabled and no existing txn. Should not call Enrich Log",
+			formatter:              &logrus.TextFormatter{},
+			txn:                    nil,
+			enabled:                true,
+			localDecoratingEnabled: false,
+			wantCallSpy:            false,
+		},
+		{
+			name:                   "Logging Disabled and Local Decorating Enabled and existing txn. Should not call Enrich Log",
+			formatter:              &logrus.TextFormatter{},
+			txn:                    &newrelic.Transaction{},
+			enabled:                false,
+			localDecoratingEnabled: true,
+			wantCallSpy:            false,
+		},
+		{
+			name:                   "Logging Disabled and Local Decorating Enabled and no existing txn. Should not call Enrich Log",
+			formatter:              &logrus.TextFormatter{},
+			txn:                    nil,
+			enabled:                false,
+			localDecoratingEnabled: true,
+			wantCallSpy:            false,
+		},
+		{
+			name:                   "Logging and Local Decorating Enabled and no existing txn. Should call enrich log",
+			formatter:              &logrus.TextFormatter{},
+			txn:                    nil,
+			enabled:                true,
+			localDecoratingEnabled: true,
+			wantCallSpy:            true,
+		},
+		{
+			name:                   "Logging and Local Decorating Enabled and existing txn. Should call enrich log",
+			formatter:              &logrus.TextFormatter{},
+			txn:                    &newrelic.Transaction{},
+			enabled:                true,
+			localDecoratingEnabled: true,
+			wantCallSpy:            true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enricherSpy := &testEnricher{}
+			f := ContextFormatter{
+				formatter: tt.formatter,
+				enricher:  enricherSpy,
+			} // not testing any app functionality so we can set it to nil in this case
+			f.enrichLog(nil, tt.txn, newrelic.Config{
+				ApplicationLogging: newrelic.ApplicationLogging{
+					Enabled: tt.enabled,
+					LocalDecorating: struct {
+						Enabled            bool
+						WithinMessageField bool
+					}{
+						Enabled: tt.localDecoratingEnabled,
+					},
+				},
+			})
+
+			if enricherSpy.called != tt.wantCallSpy {
+				t.Errorf("enrichLog() failed with calling newrelic.Enrich(), Got: %v want: %v", enricherSpy.called, tt.wantCallSpy)
+			}
+
+		})
+	}
 }

--- a/v3/integrations/logcontext-v2/nrlogrus/formatter_test.go
+++ b/v3/integrations/logcontext-v2/nrlogrus/formatter_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/newrelic/go-agent/v3/internal"
@@ -645,30 +646,86 @@ func TestLogInfoWithMessage(t *testing.T) {
 		logDecoratingWithinMessage bool
 	}{
 		{
-			name:                       "TEST TEST",
+			name:                       "Within message field",
 			logForwardingEnabled:       true,
 			localDecoratingEnabled:     true,
 			logDecoratingWithinMessage: true,
 		},
+		{
+			name:                       "Not within message field",
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: false,
+		},
 	}
 
+	buildLoggers := map[string]func(out io.Writer, app *newrelic.Application) *logrus.Logger{
+		"Text": newTextLogger,
+		"JSON": newJSONLogger,
+	}
 	for _, tt := range tests {
-		app := buildApp(true, tt.logForwardingEnabled, tt.localDecoratingEnabled, tt.logDecoratingWithinMessage)
-		out := bytes.NewBuffer([]byte{})
-		log := newJSONLogger(out, app.Application)
-		message := "Hello World"
-		log.Info(message)
+		for key, buildLog := range buildLoggers {
+			testName := fmt.Sprintf("%s: %s", key, tt.name)
+			t.Run(testName, func(t *testing.T) {
+				app := buildApp(true, tt.logForwardingEnabled, tt.localDecoratingEnabled, tt.logDecoratingWithinMessage)
+				out := bytes.NewBuffer([]byte{})
+				log := buildLog(out, app.Application)
+				message := "Hello World"
+				log.Info(message)
 
-		var entry any
-		s := out.String()
-		if err := json.Unmarshal(out.Bytes(), &entry); err != nil {
-			t.Fatalf("Failed to unmarshal logger entry: %v", err)
+				if tt.logDecoratingWithinMessage {
+					if key == "Text" {
+						// do something diff
+					} else {
+						var entry map[string]string
+						if err := json.Unmarshal(out.Bytes(), &entry); err != nil {
+							t.Fatalf("Failed to unmarshal logger entry: %v", err)
+						}
+						s, ok := entry["msg"]
+						if !ok {
+							t.Fatal("No message field found")
+						}
+						logcontext.ValidateNRLinkingString(t, bytes.NewBufferString(s), &logcontext.DecorationExpect{
+							EntityGUID:         integrationsupport.TestEntityGUID,
+							Hostname:           host,
+							EntityName:         integrationsupport.SampleAppName,
+							DecorationDisabled: false, // we expect the NR-LINKING string to be within the message field
+						})
+					}
+				} else {
+					// NR-LINKING STRING SHOULD BE AT THE END so breaks JSON formatting
+					if key == "Text" {
+						// do something diff
+					} else {
+						var entry map[string]string
+						split := strings.Split(out.String(), "NR-LINKING")
+						if len(split) != 2 {
+							t.Fatalf("expected log decoration, but NR-LINKING data was missing: %s", out.String())
+						}
+
+						// test if first portion of split (non NR-LINKING) msg has no nr linking
+						if err := json.Unmarshal([]byte(split[0]), &entry); err != nil {
+							t.Fatalf("Failed to unmarshal logger entry: %v", err)
+						}
+						s, ok := entry["msg"]
+						if !ok {
+							t.Fatal("No message field found")
+						}
+						logcontext.ValidateNRLinkingString(t, bytes.NewBufferString(s), &logcontext.DecorationExpect{
+							EntityGUID:         integrationsupport.TestEntityGUID,
+							Hostname:           host,
+							EntityName:         integrationsupport.SampleAppName,
+							DecorationDisabled: true, // we don't expect to find a NR-LINKING string within a message field
+						})
+					}
+				}
+
+				logcontext.ValidateDecoratedOutput(t, out, &logcontext.DecorationExpect{
+					EntityGUID: integrationsupport.TestEntityGUID,
+					Hostname:   host,
+					EntityName: integrationsupport.SampleAppName,
+				})
+			})
 		}
-		t.Logf("ENTRY: %v\n%v", entry, s)
-		logcontext.ValidateDecoratedOutput(t, out, &logcontext.DecorationExpect{
-			EntityGUID: integrationsupport.TestEntityGUID,
-			Hostname:   host,
-			EntityName: "integrationsupport.SampleAppName",
-		})
 	}
 }

--- a/v3/integrations/logcontext-v2/nrlogrus/formatter_test.go
+++ b/v3/integrations/logcontext-v2/nrlogrus/formatter_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -638,21 +639,38 @@ func buildApp(appInitialized bool, logForwardingEnabled, localDecoratingEnabled,
 	)
 }
 
-func TestLogInfoWithMessage(t *testing.T) {
+func TestLogWithMessageLogDecorating(t *testing.T) {
 	tests := []struct {
 		name                       string
+		message                    string
 		logForwardingEnabled       bool
 		localDecoratingEnabled     bool
 		logDecoratingWithinMessage bool
 	}{
 		{
 			name:                       "Within message field",
+			message:                    "Hello World",
 			logForwardingEnabled:       true,
 			localDecoratingEnabled:     true,
 			logDecoratingWithinMessage: true,
 		},
 		{
 			name:                       "Not within message field",
+			message:                    "Hello World",
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: false,
+		},
+		{
+			name:                       "Empty string logged. Decorator should be within message field.",
+			message:                    "",
+			logForwardingEnabled:       true,
+			localDecoratingEnabled:     true,
+			logDecoratingWithinMessage: true,
+		},
+		{
+			name:                       "Empty string logged. Decorater should not be within empty message field.",
+			message:                    "",
 			logForwardingEnabled:       true,
 			localDecoratingEnabled:     true,
 			logDecoratingWithinMessage: false,
@@ -663,6 +681,34 @@ func TestLogInfoWithMessage(t *testing.T) {
 		"Text": newTextLogger,
 		"JSON": newJSONLogger,
 	}
+
+	validateMessageField := func(t *testing.T, byts []byte, decorationDisabled bool) {
+		var entry map[string]string
+		if err := json.Unmarshal(byts, &entry); err != nil {
+			t.Fatalf("Failed to unmarshal logger entry: %v", err)
+		}
+		s, ok := entry["msg"]
+		if !ok {
+			t.Fatal("No message field found")
+		}
+		logcontext.ValidateNRLinkingString(t, bytes.NewBufferString(s), &logcontext.DecorationExpect{
+			EntityGUID:         integrationsupport.TestEntityGUID,
+			Hostname:           host,
+			EntityName:         integrationsupport.SampleAppName,
+			DecorationDisabled: decorationDisabled, // we expect the NR-LINKING string to be within the message field
+		})
+	}
+
+	validateMessageFieldStr := func(t *testing.T, str string, decorationDisabled bool) {
+		logcontext.ValidateNRLinkingString(t, bytes.NewBufferString(str), &logcontext.DecorationExpect{
+			EntityGUID:         integrationsupport.TestEntityGUID,
+			Hostname:           host,
+			EntityName:         integrationsupport.SampleAppName,
+			DecorationDisabled: decorationDisabled, // we expect the NR-LINKING string to be within the message field
+		})
+	}
+
+	var re = regexp.MustCompile(`(?m)msg="[^"]*"`)
 	for _, tt := range tests {
 		for key, buildLog := range buildLoggers {
 			testName := fmt.Sprintf("%s: %s", key, tt.name)
@@ -670,56 +716,47 @@ func TestLogInfoWithMessage(t *testing.T) {
 				app := buildApp(true, tt.logForwardingEnabled, tt.localDecoratingEnabled, tt.logDecoratingWithinMessage)
 				out := bytes.NewBuffer([]byte{})
 				log := buildLog(out, app.Application)
-				message := "Hello World"
+				message := tt.message
 				log.Info(message)
 
+				// if we expect the log decorating to be within the message check if its there
 				if tt.logDecoratingWithinMessage {
 					if key == "Text" {
-						// do something diff
+						s := out.String()
+						sl := re.FindStringSubmatch(s)
+						if len(sl) == 0 {
+							if tt.message != "" {
+								t.Fatal("couldn't find msg field in string")
+							}
+						}
+						validateMessageFieldStr(t, sl[0], false)
+
 					} else {
-						var entry map[string]string
-						if err := json.Unmarshal(out.Bytes(), &entry); err != nil {
-							t.Fatalf("Failed to unmarshal logger entry: %v", err)
-						}
-						s, ok := entry["msg"]
-						if !ok {
-							t.Fatal("No message field found")
-						}
-						logcontext.ValidateNRLinkingString(t, bytes.NewBufferString(s), &logcontext.DecorationExpect{
-							EntityGUID:         integrationsupport.TestEntityGUID,
-							Hostname:           host,
-							EntityName:         integrationsupport.SampleAppName,
-							DecorationDisabled: false, // we expect the NR-LINKING string to be within the message field
-						})
+						validateMessageField(t, out.Bytes(), false)
 					}
 				} else {
 					// NR-LINKING STRING SHOULD BE AT THE END so breaks JSON formatting
 					if key == "Text" {
-						// do something diff
+						s := out.String()
+						sl := re.FindStringSubmatch(s)
+						if len(sl) == 0 {
+							if tt.message != "" {
+								t.Fatal("couldn't find msg field in string")
+							}
+							// empty message case means there is nothing to check
+						} else {
+							validateMessageFieldStr(t, sl[0], true)
+						}
 					} else {
-						var entry map[string]string
 						split := strings.Split(out.String(), "NR-LINKING")
 						if len(split) != 2 {
 							t.Fatalf("expected log decoration, but NR-LINKING data was missing: %s", out.String())
 						}
-
-						// test if first portion of split (non NR-LINKING) msg has no nr linking
-						if err := json.Unmarshal([]byte(split[0]), &entry); err != nil {
-							t.Fatalf("Failed to unmarshal logger entry: %v", err)
-						}
-						s, ok := entry["msg"]
-						if !ok {
-							t.Fatal("No message field found")
-						}
-						logcontext.ValidateNRLinkingString(t, bytes.NewBufferString(s), &logcontext.DecorationExpect{
-							EntityGUID:         integrationsupport.TestEntityGUID,
-							Hostname:           host,
-							EntityName:         integrationsupport.SampleAppName,
-							DecorationDisabled: true, // we don't expect to find a NR-LINKING string within a message field
-						})
+						validateMessageField(t, []byte(split[0]), true)
 					}
 				}
 
+				// still validate log as a whole not mattering where NR-LINKING string is
 				logcontext.ValidateDecoratedOutput(t, out, &logcontext.DecorationExpect{
 					EntityGUID: integrationsupport.TestEntityGUID,
 					Hostname:   host,

--- a/v3/internal/logcontext/decoratorTesting.go
+++ b/v3/internal/logcontext/decoratorTesting.go
@@ -101,3 +101,34 @@ func ValidateDecoratedOutput(t *testing.T, out *bytes.Buffer, expect *Decoration
 		}
 	}
 }
+
+func ValidateNRLinkingString(t *testing.T, out *bytes.Buffer, expect *DecorationExpect) {
+	actual := out.String()
+
+	if expect.DecorationDisabled {
+		if strings.Contains(actual, "NR-LINKING") {
+			t.Fatal("log decoration was expected to be disabled, but were decorated anyway")
+		} else {
+			return
+		}
+	}
+
+	if expect.DecoratorError != nil {
+		if strings.Contains(actual, "NR-LINKING") {
+			t.Fatal("logs should not be decorated when a decorator error occurs")
+		}
+
+		msg := expect.DecoratorError.Error()
+		if !strings.Contains(actual, msg) {
+			t.Fatalf("an error message debug log was expected, \"%s\", but was not found: %s", msg, actual)
+		} else {
+			return
+		}
+	}
+
+	split := strings.Split(actual, "NR-LINKING")
+
+	if len(split) != 2 {
+		t.Fatalf("expected log decoration, but NR-LINKING data was missing: %s", actual)
+	}
+}

--- a/v3/newrelic/config.go
+++ b/v3/newrelic/config.go
@@ -624,6 +624,8 @@ type ApplicationLogging struct {
 	LocalDecorating struct {
 		// Toggles whether the agent enriches local logs printed to console so they can be sent to new relic for ingestion
 		Enabled bool
+		// Toggles whether the agent enriches local logs in the message field or appends to the end of the message (default)
+		WithinMessageField bool
 	}
 	// We want to enable this when your app collects fewer logs, or if your app can afford to compile the json
 	// during log collection, slowing down the execution of the line of code that will write the log. If your

--- a/v3/newrelic/config_options.go
+++ b/v3/newrelic/config_options.go
@@ -345,6 +345,24 @@ func ConfigAppLogDecoratingEnabled(enabled bool) ConfigOption {
 	}
 }
 
+// ConfigAppLogDecoratingWithinMessage enables or disables the location of the
+// local log decorating string within a log. If local log decorating or application
+// logging is not enabled, no string will be added.  Example:
+// If set to true:
+//
+//	ConfigAppLogDecoratingWithinMessage(true)
+//	"{"message": "...NR-LINKING|...|..."}"
+//
+// If set to false (Default):
+//
+//	ConfigAppLogDecoratingWithinMessage(false)
+//	"{"message": "..."} NR-LINKING|...|..."
+func ConfigAppLogDecoratingWithinMessage(withinMessage bool) ConfigOption {
+	return func(cfg *Config) {
+		cfg.ApplicationLogging.LocalDecorating.WithinMessageField = withinMessage
+	}
+}
+
 // ConfigAIMonitoringEnabled enables or disables the collection of AI Monitoring event data.
 func ConfigAIMonitoringEnabled(enabled bool) ConfigOption {
 	return func(cfg *Config) {

--- a/v3/newrelic/config_options.go
+++ b/v3/newrelic/config_options.go
@@ -345,6 +345,7 @@ func ConfigAppLogDecoratingEnabled(enabled bool) ConfigOption {
 	}
 }
 
+// EXPERIMENTAL 4/27/2026.  Use with caution.
 // ConfigAppLogDecoratingWithinMessage enables or disables the location of the
 // local log decorating string within a log. If local log decorating or application
 // logging is not enabled, no string will be added.  Example:

--- a/v3/newrelic/config_test.go
+++ b/v3/newrelic/config_test.go
@@ -153,7 +153,8 @@ func TestCopyConfigReferenceFieldsPresent(t *testing.T) {
 					"MaxSamplesStored": %d
 				},
 				"LocalDecorating":{
-					"Enabled": false
+					"Enabled": false,
+					"WithinMessageField": false
 				},
 				"Metrics": {
 					"Enabled": true
@@ -374,7 +375,8 @@ func TestCopyConfigReferenceFieldsAbsent(t *testing.T) {
 					"MaxSamplesStored": %d
 				},
 				"LocalDecorating":{
-					"Enabled": false
+					"Enabled": false,
+					"WithinMessageField": false
 				},
 				"Metrics": {
 					"Enabled": true


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

<!--
Any relevant links that will help reviewers.
-->

## Details
Experimental Fix for Log Decorating: Log Decorator can be enabled or disabled through Config Option.

NOTE: This only applies to the `nrlogrus` integration.

<!--
In-depth description of changes, other technical notes, etc.
-->
