### PR TITLE
feat(nrgocqlx): Batch Observer

### DIFF
--- a/v3/integrations/nrgocqlx/nrgocqlx.go
+++ b/v3/integrations/nrgocqlx/nrgocqlx.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"reflect"
 	"strconv"
+	"strings"
 
 	gocql "github.com/gocql/gocql"
 	"github.com/newrelic/go-agent/v3/internal"
@@ -25,6 +26,17 @@ call it
 type queryObserver struct {
 	original interface {
 		ObserveQuery(ctx context.Context, query gocql.ObservedQuery)
+	}
+}
+
+/*
+queryObserver contains the implementation for ObserveQuery
+and a field for the original ObserveQuery if the user chooses to
+call it
+*/
+type batchObserver struct {
+	original interface {
+		ObserveBatch(ctx context.Context, batch gocql.ObservedBatch)
 	}
 }
 
@@ -333,4 +345,37 @@ func (o *queryObserver) ObserveQuery(ctx context.Context, query gocql.ObservedQu
 	segment.DatabaseName = keyspace
 
 	// security agent?
+}
+
+func (o *batchObserver) ObserveBatch(ctx context.Context, batch gocql.ObservedBatch) {
+	if o.original != nil {
+		o.original.ObserveBatch(ctx, batch)
+	}
+
+	txn := newrelic.FromContext(ctx)
+	if txn == nil {
+		return
+	}
+
+	var host, keyspace string
+	var statements []string
+	var port int
+
+	if batch.Host != nil {
+		host = batch.Host.HostID()
+		port = batch.Host.Port()
+	}
+	statements = batch.Statements // copy or set each individual element
+	keyspace = batch.Keyspace
+
+	segment, ok := ctx.Value("nrGocqlxBatchSegment").(*newrelic.DatastoreSegment)
+	if !ok {
+		return
+	}
+	segment.ParameterizedQuery = strings.Join(statements, ",") // join statements together?
+	segment.Host = host
+	segment.Collection = "tableNameExample"
+	segment.PortPathOrID = strconv.Itoa(port)
+	segment.DatabaseName = keyspace
+	// enrich segment below
 }

--- a/v3/integrations/nrgocqlx/nrgocqlx.go
+++ b/v3/integrations/nrgocqlx/nrgocqlx.go
@@ -30,8 +30,8 @@ type queryObserver struct {
 }
 
 /*
-queryObserver contains the implementation for ObserveQuery
-and a field for the original ObserveQuery if the user chooses to
+batchObserver contains the implementation for ObserveBatch
+and a field for the original ObserveBatch if the user chooses to
 call it
 */
 type batchObserver struct {
@@ -307,6 +307,21 @@ func NewQueryObserver(original interface {
 }
 
 /*
+NewBatchObserver returns a gocql.BatchObserver that creates newrelic.DatastoreSegment for each database batch query. If provided,
+the original gocql.BatchObserver will be called as well.
+*/
+func NewBatchObserver(original interface {
+	ObserveBatch(ctx context.Context, batch gocql.ObservedBatch)
+}) *batchObserver {
+	if original != nil && reflect.ValueOf(original).IsNil() {
+		original = nil
+	}
+	return &batchObserver{
+		original: original,
+	}
+}
+
+/*
 ObserveQuery is the implementation for the gocql.QueryObserver.  This will run after the
 query is executed.  It will execute the original implementation of ObserveQuery if it is
 passed in.  If there is no new relic transaction in context, it will return early.  Otherwise,
@@ -365,14 +380,14 @@ func (o *batchObserver) ObserveBatch(ctx context.Context, batch gocql.ObservedBa
 		host = batch.Host.HostID()
 		port = batch.Host.Port()
 	}
-	statements = batch.Statements // copy or set each individual element
+	statements = batch.Statements
 	keyspace = batch.Keyspace
 
 	segment, ok := ctx.Value("nrGocqlxBatchSegment").(*newrelic.DatastoreSegment)
 	if !ok {
 		return
 	}
-	segment.ParameterizedQuery = strings.Join(statements, ",") // join statements together?
+	segment.ParameterizedQuery = strings.Join(statements, "; ") // join statements together
 	segment.Host = host
 	segment.Collection = "tableNameExample"
 	segment.PortPathOrID = strconv.Itoa(port)

--- a/v3/integrations/nrgocqlx/nrgocqlx_test.go
+++ b/v3/integrations/nrgocqlx/nrgocqlx_test.go
@@ -21,7 +21,18 @@ type mockObserver struct {
 	}
 }
 
+type mockBatchObserver struct {
+	called   bool
+	original interface {
+		ObserveBatch(ctx context.Context, batch gocql.ObservedBatch)
+	}
+}
+
 func (m *mockObserver) ObserveQuery(ctx context.Context, q gocql.ObservedQuery) {
+	m.called = true
+}
+
+func (m *mockBatchObserver) ObserveBatch(ctx context.Context, batch gocql.ObservedBatch) {
 	m.called = true
 }
 
@@ -109,7 +120,7 @@ func TestObserveQuery(t *testing.T) {
 				ctx = newrelic.NewContext(ctx, txn)
 
 				if tt.storeSegment {
-					seg = &newrelic.DatastoreSegment{StartTime: txn.StartSegmentNow()}
+					seg = &newrelic.DatastoreSegment{StartTime: newrelic.SegmentStartTime{}}
 					defer seg.End()
 					ctx = context.WithValue(ctx, "nrGocqlxSegment", seg)
 
@@ -443,6 +454,130 @@ func TestNewQueryObserver(t *testing.T) {
 			}
 			if tt.want.original != nil && got.original == nil {
 				t.Errorf("NewQueryObserver() = %v, want %v", got.original, tt.want.original)
+			}
+		})
+	}
+}
+
+func TestObserveBatch(t *testing.T) {
+	app := integrationsupport.NewTestApp(
+		integrationsupport.SampleEverythingReplyFn,
+		integrationsupport.ConfigFullTraces,
+	)
+
+	hostWithID := new(gocql.HostInfo)
+	hostWithID.SetHostID("test-host-id")
+
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		batch            gocql.ObservedBatch
+		startTransaction bool
+		storeSegment     bool
+		original         *mockBatchObserver
+		wantOrigCalled   bool
+		wantBatch        string
+		wantKeyspace     string
+		wantHost         string
+	}{
+		{
+			name:             "nil transaction returns early",
+			startTransaction: false,
+			storeSegment:     false,
+			original:         nil,
+			batch:            gocql.ObservedBatch{Statements: []string{}},
+		},
+		{
+			name:             "original observer is called",
+			startTransaction: true,
+			storeSegment:     true,
+			original:         &mockBatchObserver{},
+			batch:            gocql.ObservedBatch{Statements: []string{"SELECT * FROM USERS", "INSERT INTO t"}, Keyspace: "mykeyspace"},
+			wantOrigCalled:   true,
+			wantBatch:        "SELECT * FROM USERS; INSERT INTO t",
+			wantKeyspace:     "mykeyspace",
+		},
+		{
+			name:             "segment is enriched",
+			startTransaction: true,
+			storeSegment:     true,
+			batch:            gocql.ObservedBatch{Statements: []string{"INSERT INTO t", "DELETE FROM t"}, Keyspace: "mykeyspace"},
+			wantBatch:        "INSERT INTO t; DELETE FROM t",
+			wantKeyspace:     "mykeyspace",
+		},
+		{
+			name:             "host info is captured",
+			startTransaction: true,
+			storeSegment:     true,
+			batch: gocql.ObservedBatch{
+				Statements: []string{"SELECT * FROM t"},
+				Keyspace:   "ks",
+				Host:       hostWithID,
+			},
+			wantBatch:    "SELECT * FROM t",
+			wantKeyspace: "ks",
+			wantHost:     "test-host-id",
+		},
+		{
+			name:             "early return no segment",
+			startTransaction: true,
+			storeSegment:     false,
+			batch: gocql.ObservedBatch{
+				Statements: []string{"SELECT * FROM t"},
+				Keyspace:   "ks",
+				Host:       hostWithID,
+			},
+		},
+		{
+			name:             "more than two statements joined",
+			startTransaction: true,
+			storeSegment:     true,
+			batch: gocql.ObservedBatch{
+				Statements: []string{"SELECT * FROM a", "INSERT INTO b", "DELETE FROM c"},
+				Keyspace:   "ks",
+			},
+			wantBatch:    "SELECT * FROM a; INSERT INTO b; DELETE FROM c",
+			wantKeyspace: "ks",
+		},
+		{
+			name:             "empty statements",
+			startTransaction: true,
+			storeSegment:     true,
+			batch:            gocql.ObservedBatch{Statements: []string{}, Keyspace: "ks"},
+			wantBatch:        "",
+			wantKeyspace:     "ks",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			var seg *newrelic.DatastoreSegment
+
+			if tt.startTransaction {
+				txn := app.StartTransaction("test-txn")
+				defer txn.End()
+				ctx = newrelic.NewContext(ctx, txn)
+				if tt.storeSegment {
+					seg = &newrelic.DatastoreSegment{StartTime: newrelic.SegmentStartTime{}}
+					defer seg.End()
+					ctx = context.WithValue(ctx, "nrGocqlxBatchSegment", seg)
+				}
+			}
+			NewBatchObserver(tt.original).ObserveBatch(ctx, tt.batch)
+
+			if tt.original != nil && tt.original.called != tt.wantOrigCalled {
+				t.Errorf("original.called = %v, want %v", tt.original.called, tt.wantOrigCalled)
+			}
+			if seg != nil {
+				if seg.ParameterizedQuery != tt.wantBatch {
+					t.Errorf("ParameterizedQuery = %q, want %q", seg.ParameterizedQuery, tt.wantBatch)
+				}
+				if seg.DatabaseName != tt.wantKeyspace {
+					t.Errorf("DatabaseName = %q, want %q", seg.DatabaseName, tt.wantKeyspace)
+				}
+				if seg.Host != tt.wantHost {
+					t.Errorf("Host = %q, want %q", seg.Host, tt.wantHost)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

<!--
Any relevant links that will help reviewers.
-->

## Details
Implementation for Implementation for BatchObserver used in gocqlx. Almost the same implementation as: [QueryObserver](https://github.com/newrelic/go-agent/pull/1132). Key differences is how statements are handled.

ObserveBatch is a function of the struct batchObserver which implements the original interface. This allows the user to pass in an original ObserveBatch function if they still want that to execute.

ObserveBatch does not begin or end a segment, it only enriches the segment. It does so by pulling the segment out of context. Putting the segment into context will be added in a later PR when executing the query.

Note: Collection has a temporary value so that the values will show up in the Database section in the UI. Will add others such as Operation when a CQL parser is implemented.. 
<!--
In-depth description of changes, other technical notes, etc.
-->
