### PR TITLE
feat(nrgocqlx): CQL Parser

### DIFF
--- a/v3/integrations/nrgocqlx/nrgocqlx.go
+++ b/v3/integrations/nrgocqlx/nrgocqlx.go
@@ -14,6 +14,7 @@ import (
 	gocql "github.com/gocql/gocql"
 	"github.com/newrelic/go-agent/v3/internal"
 	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v3/newrelic/cqlparse"
 	"github.com/scylladb/gocqlx/v3"
 )
 
@@ -552,9 +553,9 @@ func (o *queryObserver) ObserveQuery(ctx context.Context, query gocql.ObservedQu
 	if !ok {
 		return
 	}
+	cqlparse.ParseQuery(segment, statement)
 	segment.ParameterizedQuery = statement
 	segment.Host = host
-	segment.Collection = "tableNameExample"
 	segment.PortPathOrID = strconv.Itoa(port)
 	segment.DatabaseName = keyspace
 
@@ -592,9 +593,9 @@ func (o *batchObserver) ObserveBatch(ctx context.Context, batch gocql.ObservedBa
 	if !ok {
 		return
 	}
+	segment.Operation = "batch"
 	segment.ParameterizedQuery = strings.Join(statements, "; ") // join statements together
 	segment.Host = host
-	segment.Collection = "tableNameExample"
 	segment.PortPathOrID = strconv.Itoa(port)
 	segment.DatabaseName = keyspace
 	// enrich segment below

--- a/v3/newrelic/cqlparse/cqlparse.go
+++ b/v3/newrelic/cqlparse/cqlparse.go
@@ -1,0 +1,63 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cqlparse
+
+import (
+	"regexp"
+	"strings"
+
+	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+)
+
+func extractTable(s string) string {
+	s = extractTableRegex.ReplaceAllString(s, "")
+	if idx := strings.Index(s, "."); idx > 0 {
+		s = s[idx+1:]
+	}
+	return s
+}
+
+var (
+	basicTable        = `[^)(\]\[\}\{\s,;]+`
+	enclosedTable     = `[\[\(\{]` + `\s*` + basicTable + `\s*` + `[\]\)\}]`
+	tablePattern      = `(` + `\s+` + basicTable + `|` + `\s*` + enclosedTable + `)`
+	extractTableRegex = regexp.MustCompile(`[\s` + "`" + `"'\(\)\{\}\[\]]*`)
+	updateRegex       = regexp.MustCompile(`(?is)^update` + tablePattern)
+	truncateRegex     = regexp.MustCompile(`(?is)^truncate(?:\s+table)?` + tablePattern)
+	cqlOperations     = map[string]*regexp.Regexp{
+		"select":   regexp.MustCompile(`(?is)^.*\sfrom` + tablePattern),
+		"delete":   regexp.MustCompile(`(?is)^.*\sfrom` + tablePattern),
+		"insert":   regexp.MustCompile(`(?is)^.*\sinto` + tablePattern),
+		"update":   updateRegex,
+		"create":   nil,
+		"drop":     nil,
+		"alter":    nil,
+		"truncate": truncateRegex,
+		"use":      nil,
+		"begin":    nil, // BEGIN [UNLOGGED|COUNTER] BATCH
+		"apply":    nil, // APPLY BATCH
+	}
+	firstWordRegex   = regexp.MustCompile(`^\w+`)
+	cCommentRegex    = regexp.MustCompile(`(?is)/\*.*?\*/`)
+	lineCommentRegex = regexp.MustCompile(`(?im)--.*?$`)
+	cqlPrefixRegex   = regexp.MustCompile(`^[\s;]*`)
+)
+
+// ParseQuery parses table and operation from a CQL query string. It is a
+// helper meant to be used when writing Cassandra driver instrumentation.
+func ParseQuery(segment *newrelic.DatastoreSegment, query string) {
+	s := cCommentRegex.ReplaceAllString(query, "")
+	s = lineCommentRegex.ReplaceAllString(s, "")
+	s = cqlPrefixRegex.ReplaceAllString(s, "")
+	op := strings.ToLower(firstWordRegex.FindString(s))
+	if rg, ok := cqlOperations[op]; ok {
+		segment.Operation = op
+		segment.RawQuery = query
+		if nil != rg {
+			if m := rg.FindStringSubmatch(s); len(m) > 1 {
+				segment.Collection = extractTable(m[1])
+			}
+		}
+	}
+}

--- a/v3/newrelic/cqlparse/cqlparse.go
+++ b/v3/newrelic/cqlparse/cqlparse.go
@@ -18,6 +18,13 @@ func extractTable(s string) string {
 	return s
 }
 
+/*
+CQL is similar to SQL in syntax with a few key differences.  There are no Common Table Expressions (CTE),
+so the WITH keyword is not captured with regular expressions below.  Additionally, there are no
+sub-queries in CQL.  In some SQL queries, INTO may be an optional keyword to use with INSERT.  However, in
+CQL is required.  We only capture the DatastoreSegmemt.Collection (table in CQL) for DML queries (SELECT, UPDATE,
+INSERT, DELETE) and TRUNCATE.
+*/
 var (
 	basicTable        = `[^)(\]\[\}\{\s,;]+`
 	enclosedTable     = `[\[\(\{]` + `\s*` + basicTable + `\s*` + `[\]\)\}]`
@@ -28,14 +35,14 @@ var (
 	cqlOperations     = map[string]*regexp.Regexp{
 		"select":   regexp.MustCompile(`(?is)^.*\sfrom` + tablePattern),
 		"delete":   regexp.MustCompile(`(?is)^.*\sfrom` + tablePattern),
-		"insert":   regexp.MustCompile(`(?is)^.*\sinto` + tablePattern),
+		"insert":   regexp.MustCompile(`(?is)^.*\sinto` + tablePattern), // INTO is a required keyword after INSERT
 		"update":   updateRegex,
 		"create":   nil,
 		"drop":     nil,
 		"alter":    nil,
-		"truncate": truncateRegex,
+		"truncate": truncateRegex, // drops all rows from table
 		"use":      nil,
-		"begin":    nil, // BEGIN [UNLOGGED|COUNTER] BATCH
+		"begin":    nil, // BEGIN BATCH
 		"apply":    nil, // APPLY BATCH
 	}
 	firstWordRegex   = regexp.MustCompile(`^\w+`)
@@ -44,8 +51,11 @@ var (
 	cqlPrefixRegex   = regexp.MustCompile(`^[\s;]*`)
 )
 
-// ParseQuery parses table and operation from a CQL query string. It is a
-// helper meant to be used when writing Cassandra driver instrumentation.
+/*
+ParseQuery parses table and operation from a CQL query string. It is a
+helper meant to be used when writing Cassandra driver instrumentation.
+This is not meant to be used to parse SQL.
+*/
 func ParseQuery(segment *newrelic.DatastoreSegment, query string) {
 	s := cCommentRegex.ReplaceAllString(query, "")
 	s = lineCommentRegex.ReplaceAllString(s, "")

--- a/v3/newrelic/cqlparse/cqlparse_test.go
+++ b/v3/newrelic/cqlparse/cqlparse_test.go
@@ -1,0 +1,461 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cqlparse
+
+import (
+	"testing"
+
+	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+)
+
+func TestParseQuery(t *testing.T) {
+	tests := []struct {
+		// Named input parameters for target function.
+		query string
+
+		expectedCollection string
+		expectedOperation  string
+	}{
+		{
+			query:              "SELECT * FROM table",
+			expectedCollection: "table",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "SELECT name, occupation FROM users;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "SELECT name, occupation FROM users",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "SELECT name, occupation FROM users WHERE userid IN (199, 200, 207);",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "SELECT JSON name, occupation FROM users WHERE userid IN (199, 200, 207);",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "SELECT name AS user_name, occupation AS user_occupation FROM users;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		// SELECT — additional cases from https://cassandra.apache.org/doc/4.0/cassandra/cql/dml.html
+		{
+			query:              "SELECT COUNT(*) AS user_count FROM users;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "SELECT intAsBlob(4) AS four FROM t;",
+			expectedCollection: "t",
+			expectedOperation:  "select",
+		},
+		{
+			query: `SELECT time, value
+FROM events
+WHERE event_type = 'myEvent'
+  AND time > '2011-02-03'
+  AND time <= '2012-01-01';`,
+			expectedCollection: "events",
+			expectedOperation:  "select",
+		},
+		{
+			query: `SELECT entry_title, content FROM posts
+ WHERE userid = 'john doe'
+   AND blog_title = 'John''s Blog'
+   AND posted_at >= '2012-01-01' AND posted_at < '2012-01-31';`,
+			expectedCollection: "posts",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "SELECT * FROM posts WHERE token(userid) > token('tom') AND token(userid) < token('bob');",
+			expectedCollection: "posts",
+			expectedOperation:  "select",
+		},
+		{
+			query: `SELECT * FROM posts
+ WHERE userid = 'john doe'
+   AND (blog_title, posted_at) > ('John''s Blog', '2012-01-01');`,
+			expectedCollection: "posts",
+			expectedOperation:  "select",
+		},
+		{
+			query: `SELECT * FROM posts
+ WHERE userid = 'john doe'
+   AND (blog_title, posted_at) IN (('John''s Blog', '2012-01-01'), ('Extreme Chess', '2014-06-01'));`,
+			expectedCollection: "posts",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "SELECT * FROM users WHERE birth_year = 1981 AND country = 'FR' ALLOW FILTERING;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		// SELECT — mixed case
+		{
+			query:              "select name, occupation from users;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "Select * From users;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		// SELECT — line comments
+		{
+			query: `SELECT -- * FROM tricky
+* FROM users`,
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query: `    -- SELECT * FROM tricky
+SELECT * FROM users`,
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query: `SELECT * FROM -- tricky
+users`,
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		// SELECT — block comments
+		{
+			query:              `/* find all users */ SELECT * FROM users;`,
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query: `SELECT /* columns */ name, occupation
+FROM /* table */ users;`,
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query: `/* multi
+line
+comment */
+SELECT * FROM users;`,
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		// SELECT — semicolon/whitespace prefixes
+		{
+			query:              ";SELECT * FROM users;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "  ;;  ; SELECT * FROM users;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query: ` ;
+SELECT * FROM users`,
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		// SELECT — keyspace-qualified
+		{
+			query:              "SELECT * FROM mykeyspace.users;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		// INSERT — from https://cassandra.apache.org/doc/4.0/cassandra/cql/dml.html
+		{
+			query: `INSERT INTO NerdMovies (movie, director, main_actor, year)
+   VALUES ('Serenity', 'Joss Whedon', 'Nathan Fillion', 2005)
+   USING TTL 86400;`,
+			expectedCollection: "NerdMovies",
+			expectedOperation:  "insert",
+		},
+		{
+			query:              `INSERT INTO NerdMovies JSON '{"movie": "Serenity", "director": "Joss Whedon", "year": 2005}';`,
+			expectedCollection: "NerdMovies",
+			expectedOperation:  "insert",
+		},
+		{
+			query:              "INSERT INTO users (userid, password, name) VALUES ('user2', 'ch@ngem3b', 'second user') IF NOT EXISTS;",
+			expectedCollection: "users",
+			expectedOperation:  "insert",
+		},
+		{
+			query:              "INSERT INTO users (userid, password) VALUES ('user4', 'ch@ngem3c');",
+			expectedCollection: "users",
+			expectedOperation:  "insert",
+		},
+		// INSERT — mixed case
+		{
+			query:              "insert into users (userid) values ('u1');",
+			expectedCollection: "users",
+			expectedOperation:  "insert",
+		},
+		{
+			query:              "Insert Into users (userid) Values ('u1');",
+			expectedCollection: "users",
+			expectedOperation:  "insert",
+		},
+		// INSERT — line comment
+		{
+			query: `-- INSERT INTO tricky (x) VALUES (1)
+INSERT INTO users (userid) VALUES ('u1')`,
+			expectedCollection: "users",
+			expectedOperation:  "insert",
+		},
+		// INSERT — block comment
+		{
+			query:              `/* INSERT INTO tricky */ INSERT INTO users (userid) VALUES ('u1');`,
+			expectedCollection: "users",
+			expectedOperation:  "insert",
+		},
+		// INSERT — semicolon prefix
+		{
+			query:              "   INSERT INTO users (userid) VALUES ('u1');",
+			expectedCollection: "users",
+			expectedOperation:  "insert",
+		},
+		// INSERT — keyspace-qualified
+		{
+			query:              "INSERT INTO mykeyspace.NerdMovies (movie) VALUES ('Serenity');",
+			expectedCollection: "NerdMovies",
+			expectedOperation:  "insert",
+		},
+		// UPDATE — from https://cassandra.apache.org/doc/4.0/cassandra/cql/dml.html
+		{
+			query: `UPDATE NerdMovies USING TTL 400
+   SET director   = 'Joss Whedon',
+       main_actor = 'Nathan Fillion',
+       year       = 2005
+ WHERE movie = 'Serenity';`,
+			expectedCollection: "NerdMovies",
+			expectedOperation:  "update",
+		},
+		{
+			query: `UPDATE UserActions
+   SET total = total + 2
+   WHERE user = B70DE1D0-9908-4AE3-BE34-5573E5B09F14
+     AND action = 'click';`,
+			expectedCollection: "UserActions",
+			expectedOperation:  "update",
+		},
+		{
+			query:              "UPDATE users SET password = 'ps22dhds' WHERE userid = 'user3';",
+			expectedCollection: "users",
+			expectedOperation:  "update",
+		},
+		// UPDATE — mixed case
+		{
+			query:              "update users set name = 'foo' where userid = 'u1';",
+			expectedCollection: "users",
+			expectedOperation:  "update",
+		},
+		// UPDATE — line comment
+		{
+			query: `UPDATE -- NerdMovies
+users SET name = 'foo' WHERE userid = 'u1';`,
+			expectedCollection: "users",
+			expectedOperation:  "update",
+		},
+		// UPDATE — block comment
+		{
+			query: `UPDATE users /* USING TTL 400 */
+SET name = 'foo'
+WHERE userid = 'u1';`,
+			expectedCollection: "users",
+			expectedOperation:  "update",
+		},
+		// UPDATE — keyspace-qualified
+		{
+			query:              "UPDATE mykeyspace.users SET name = 'foo' WHERE userid = 'u1';",
+			expectedCollection: "users",
+			expectedOperation:  "update",
+		},
+		// DELETE — from https://cassandra.apache.org/doc/4.0/cassandra/cql/dml.html
+		{
+			query: `DELETE FROM NerdMovies USING TIMESTAMP 1240003134
+ WHERE movie = 'Serenity';`,
+			expectedCollection: "NerdMovies",
+			expectedOperation:  "delete",
+		},
+		{
+			query: `DELETE phone FROM Users
+ WHERE userid IN (C73DE1D3-AF08-40F3-B124-3FF3E5109F22, B70DE1D0-9908-4AE3-BE34-5573E5B09F14);`,
+			expectedCollection: "Users",
+			expectedOperation:  "delete",
+		},
+		{
+			query:              "DELETE name FROM users WHERE userid = 'user1';",
+			expectedCollection: "users",
+			expectedOperation:  "delete",
+		},
+		// DELETE — mixed case
+		{
+			query:              "delete from users where userid = 'u1';",
+			expectedCollection: "users",
+			expectedOperation:  "delete",
+		},
+		// DELETE — line comment
+		{
+			query: `DELETE -- phone
+FROM users WHERE userid = 'u1';`,
+			expectedCollection: "users",
+			expectedOperation:  "delete",
+		},
+		// DELETE — block comment
+		{
+			query:              `/* comment */ DELETE FROM users WHERE userid = 'u1';`,
+			expectedCollection: "users",
+			expectedOperation:  "delete",
+		},
+		// DELETE — keyspace-qualified
+		{
+			query:              "DELETE FROM mykeyspace.users WHERE userid = 'u1';",
+			expectedCollection: "users",
+			expectedOperation:  "delete",
+		},
+		// TRUNCATE
+		{
+			query:              "TRUNCATE users;",
+			expectedCollection: "users",
+			expectedOperation:  "truncate",
+		},
+		{
+			query:              "TRUNCATE TABLE users;",
+			expectedCollection: "users",
+			expectedOperation:  "truncate",
+		},
+		{
+			query:              "truncate table NerdMovies;",
+			expectedCollection: "NerdMovies",
+			expectedOperation:  "truncate",
+		},
+		{
+			query:              "TRUNCATE TABLE mykeyspace.users;",
+			expectedCollection: "users",
+			expectedOperation:  "truncate",
+		},
+		// BATCH — from https://cassandra.apache.org/doc/4.0/cassandra/cql/dml.html
+		{
+			query: `BEGIN BATCH
+   INSERT INTO users (userid, password, name) VALUES ('user2', 'ch@ngem3b', 'second user');
+   UPDATE users SET password = 'ps22dhds' WHERE userid = 'user3';
+   INSERT INTO users (userid, password) VALUES ('user4', 'ch@ngem3c');
+   DELETE name FROM users WHERE userid = 'user1';
+APPLY BATCH;`,
+			expectedCollection: "",
+			expectedOperation:  "begin",
+		},
+		{
+			query:              "BEGIN UNLOGGED BATCH",
+			expectedCollection: "",
+			expectedOperation:  "begin",
+		},
+		{
+			query:              "BEGIN COUNTER BATCH",
+			expectedCollection: "",
+			expectedOperation:  "begin",
+		},
+		{
+			query:              "begin batch",
+			expectedCollection: "",
+			expectedOperation:  "begin",
+		},
+		{
+			query:              "APPLY BATCH;",
+			expectedCollection: "",
+			expectedOperation:  "apply",
+		},
+		{
+			query:              "apply batch;",
+			expectedCollection: "",
+			expectedOperation:  "apply",
+		},
+		// DDL — operation detected, no collection extracted
+		{
+			query:              "CREATE TABLE users (userid text PRIMARY KEY, name text);",
+			expectedCollection: "",
+			expectedOperation:  "create",
+		},
+		{
+			query:              "CREATE KEYSPACE mykeyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};",
+			expectedCollection: "",
+			expectedOperation:  "create",
+		},
+		{
+			query:              "CREATE INDEX ON users(birth_year);",
+			expectedCollection: "",
+			expectedOperation:  "create",
+		},
+		{
+			query:              "DROP TABLE users;",
+			expectedCollection: "",
+			expectedOperation:  "drop",
+		},
+		{
+			query:              "DROP KEYSPACE mykeyspace;",
+			expectedCollection: "",
+			expectedOperation:  "drop",
+		},
+		{
+			query:              "ALTER TABLE users ADD email text;",
+			expectedCollection: "",
+			expectedOperation:  "alter",
+		},
+		{
+			query:              "ALTER TABLE users DROP email;",
+			expectedCollection: "",
+			expectedOperation:  "alter",
+		},
+		{
+			query:              "USE mykeyspace;",
+			expectedCollection: "",
+			expectedOperation:  "use",
+		},
+		// Unknown operations
+		{
+			query:              "",
+			expectedCollection: "",
+			expectedOperation:  "other",
+		},
+		{
+			query:              "EXPLAIN SELECT * FROM users;",
+			expectedCollection: "",
+			expectedOperation:  "other",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			seg := &newrelic.DatastoreSegment{}
+			ParseQuery(seg, tt.query)
+			if tt.expectedOperation == "other" {
+				// Allow for matching of Operation "other" to ""
+				if seg.Operation != "" {
+					t.Errorf("operation mismatch query='%s' wanted='%s' got='%s'",
+						tt.query, tt.expectedOperation, seg.Operation)
+				}
+			} else if seg.Operation != tt.expectedOperation {
+				t.Errorf("operation mismatch query='%s' wanted='%s' got='%s'",
+					tt.query, tt.expectedOperation, seg.Operation)
+			}
+			// The Go agent subquery behavior does not matth the PHP Agent.
+			if tt.expectedCollection == "(subquery)" {
+				return
+			}
+			if tt.expectedCollection != seg.Collection {
+				t.Errorf("table mismatch query='%s' wanted='%s' got='%s'",
+					tt.query, tt.expectedCollection, seg.Collection)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

<!--
Any relevant links that will help reviewers.
-->

[Cassandra Syntax DML](https://cassandra.apache.org/doc/4.0/cassandra/cql/dml.html)
[Cassandra Syntax DDL](https://cassandra.apache.org/doc/4.0/cassandra/cql/ddl.html)

## Details

<!--
In-depth description of changes, other technical notes, etc.
-->

### Issue
- Needed a specific parser for CQL syntax
### Goals
- Build a CQL parser for the gocqlx integration (and for the future gocql integration)
### Implementation
Essentially and copy/paste of the SQL parser that already exists, but there are a few key differences between CQL and SQL syntax:
- No Common Table Expressions in CQL so no `WITH` statements
- No sub-queries
- `INTO` is required after `INSERT` so the regex does not contain an optional identifier 
