### PR TITLE
fix(sqlparser): Optional INTO for INSERT

### DIFF
--- a/v3/newrelic/sqlparse/sqlparse.go
+++ b/v3/newrelic/sqlparse/sqlparse.go
@@ -24,11 +24,12 @@ var (
 	tablePattern      = `(` + `\s+` + basicTable + `|` + `\s*` + enclosedTable + `)`
 	extractTableRegex = regexp.MustCompile(`[\s` + "`" + `"'\(\)\{\}\[\]]*`)
 	updateRegex       = regexp.MustCompile(`(?is)^update(?:\s+(?:low_priority|ignore|or|rollback|abort|replace|fail|only))*` + tablePattern)
+	insertRegex       = regexp.MustCompile(`(?is)^insert(?:\s+(?:low_priority|delayed|high_priority|ignore))*(?:\s+into)?` + tablePattern)
 	withRegex         = regexp.MustCompile(`(?is)^with(?:\s+recursive)?.*\)\s*select.*?\sfrom` + tablePattern)
 	sqlOperations     = map[string]*regexp.Regexp{
 		"select":   regexp.MustCompile(`(?is)^.*\sfrom` + tablePattern),
 		"delete":   regexp.MustCompile(`(?is)^.*\sfrom` + tablePattern),
-		"insert":   regexp.MustCompile(`(?is)^.*\sinto?` + tablePattern),
+		"insert":   insertRegex,
 		"update":   updateRegex,
 		"call":     nil,
 		"create":   nil,

--- a/v3/newrelic/sqlparse/sqlparse_test.go
+++ b/v3/newrelic/sqlparse/sqlparse_test.go
@@ -218,6 +218,10 @@ func TestInsertSQL(t *testing.T) {
 		{Input: "INSERT DELAYED employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
 		{Input: "INSERT HIGH_PRIORITY employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
 		{Input: "INSERT LOW_PRIORITY IGNORE employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
+		//modifiers with INTO
+		{Input: "INSERT DELAYED INTO employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
+		{Input: "INSERT HIGH_PRIORITY INTO employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
+		{Input: "INSERT LOW_PRIORITY IGNORE INTO employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
 	} {
 		tc.test(t)
 	}

--- a/v3/newrelic/sqlparse/sqlparse_test.go
+++ b/v3/newrelic/sqlparse/sqlparse_test.go
@@ -207,3 +207,18 @@ func TestParseSQLWith(t *testing.T) {
 		tc.test(t)
 	}
 }
+
+func TestInsertSQL(t *testing.T) {
+	for _, tc := range []sqlTestcase{
+		// standard form
+		{Input: "INSERT INTO employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
+		// INTO is optional
+		{Input: "INSERT employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
+		// modifiers without INTO
+		{Input: "INSERT DELAYED employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
+		{Input: "INSERT HIGH_PRIORITY employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
+		{Input: "INSERT LOW_PRIORITY IGNORE employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
+	} {
+		tc.test(t)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links
[SQL Lite Insert](https://sqlite.org/lang_insert.html) (required INTO after INSERT)
[Postgres Insert](https://www.postgresql.org/docs/current/sql-insert.html) (required INTO after INSERT)
[MySQL Insert](https://dev.mysql.com/doc/refman/9.7/en/insert.html) (contains optional INTO and modifiers)
<!--
Any relevant links that will help reviewers.
-->

## Details

<!--
In-depth description of changes, other technical notes, etc.
-->

### Issue
- `insertRegex` captures only `o` as optional at the end of `into` meaning any `INSERT` queries without `into` are not properly captured with collection
### Goals
- Make `INTO` optional for `INSERT` queries
### Implementation
- `insertRegex` follows the same pattern as `updateRegex` with optional keywords followed by an optional `into`
- Simple adding `(?:into)?` would not have worked because the regex would expect two spaces (one before and after `INTO`).  `INSERT table_name` was never properly captured

