### PR TITLE
Go Agent Release v3.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 3.44.0
+### Added
+  * Added Support for Anthropic SDK `nranthropic`
+  * Added Support for GocqlX `nrgocqlx`
+### Fixed
+  * Export Internal Test Types via `integrationsupport` to unblock external test consumers
+    * Thank you to community member @nitinprajwal for contributing to this solution
+  * Fixed a bug in sqlparse to support optional `INTO` statements in sql integrations
+  * Fixed a bug in `nrnats` that caused flaky testing
+### Security
+  * Dependabot Security Bumps
+    * `nrfiber`
+
+
+### Support statement
+We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
+See the [Go agent EOL Policy](https://docs.newrelic.com/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.
+
 ## 3.43.3
 ### Feature
   * EXPERIMENTAL: Added a config option `ConfigAppLogDecoratingWithinMessage` to allow Local Log Decorator to appear within a message field.  This can only be applied to the `logcontext-v2/nrlogrus` integration. The `logcontext-v2/nrlogrus` integration will be bumped to v1.1.4.

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ integration-test:
 	WD=$(shell pwd); \
 	$(GO) mod edit -replace github.com/newrelic/go-agent/v3="$${WD}/${MODULE_DIR}";\
 	if [ "$(TEST)" == "nrnats" ]; then \
-		GOPROXY=direct $(GO) mod tidy; \
+		GOPROXY=https://proxy.golang.org,direct $(GO) mod tidy; \
 	else \
 		$(GO) mod tidy; \
 	fi; \

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ integration-test:
 	WD=$(shell pwd); \
 	$(GO) mod edit -replace github.com/newrelic/go-agent/v3="$${WD}/${MODULE_DIR}";\
 	if [ "$(TEST)" == "nrnats" ]; then \
-		GOPROXY=https://proxy.golang.org,direct $(GO) mod tidy; \
+		GOPROXY=direct $(GO) mod tidy; \
 	else \
 		$(GO) mod tidy; \
 	fi; \

--- a/Makefile
+++ b/Makefile
@@ -56,11 +56,7 @@ integration-test:
 	cd $(MODULE_DIR)/integrations/$(TEST); \
 	WD=$(shell pwd); \
 	$(GO) mod edit -replace github.com/newrelic/go-agent/v3="$${WD}/${MODULE_DIR}";\
-	if [ "$(TEST)" == "nrnats" ]; then \
-		GOPROXY=direct $(GO) mod tidy; \
-	else \
-		$(GO) mod tidy; \
-	fi; \
+	$(GO) mod tidy; \
 	if [ "$(COVERAGE)" == "1" ]; then \
 		$(GO) test -coverprofile=coverage.txt -race -benchtime=$(BENCHTIME) -bench=. ./ || exit 1; \
 	else \

--- a/integration-tests.mk
+++ b/integration-tests.mk
@@ -55,4 +55,5 @@ GO_INTEGRATION_TESTS=$${INTEGRATION_TESTS:-\
 	nrsqlite3 \
 	nrzap \
 	nrzerolog \
+	nranthropic \
 }

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -7,12 +7,6 @@ require (
 	google.golang.org/protobuf v1.36.11
 )
 
-require (
-	golang.org/x/net v0.49.0 // indirect
-	golang.org/x/sys v0.40.0 // indirect
-	golang.org/x/text v0.33.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 // indirect
-)
 
 retract v3.22.0 // release process error corrected in v3.22.1
 

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -7,6 +7,13 @@ require (
 	google.golang.org/protobuf v1.36.11
 )
 
+require (
+	golang.org/x/net v0.49.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
+	golang.org/x/text v0.33.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 // indirect
+)
+
 retract v3.22.0 // release process error corrected in v3.22.1
 
 retract v3.25.0 // release process error corrected in v3.25.1

--- a/v3/integrations/logcontext-v2/logWriter/go.mod
+++ b/v3/integrations/logcontext-v2/logWriter/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/logWriter
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter v1.0.0
 )
 

--- a/v3/integrations/logcontext-v2/nrlogrus/go.mod
+++ b/v3/integrations/logcontext-v2/nrlogrus/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrlogrus
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/sirupsen/logrus v1.8.3
 )
 

--- a/v3/integrations/logcontext-v2/nrslog/go.mod
+++ b/v3/integrations/logcontext-v2/nrslog/go.mod
@@ -2,7 +2,7 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrslog
 
 go 1.25
 
-require github.com/newrelic/go-agent/v3 v3.43.3
+require github.com/newrelic/go-agent/v3 v3.44.0
 
 
 replace github.com/newrelic/go-agent/v3 => ../../..

--- a/v3/integrations/logcontext-v2/nrwriter/go.mod
+++ b/v3/integrations/logcontext-v2/nrwriter/go.mod
@@ -2,7 +2,7 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter
 
 go 1.25
 
-require github.com/newrelic/go-agent/v3 v3.43.3
+require github.com/newrelic/go-agent/v3 v3.44.0
 
 
 replace github.com/newrelic/go-agent/v3 => ../../..

--- a/v3/integrations/logcontext-v2/nrzap/go.mod
+++ b/v3/integrations/logcontext-v2/nrzap/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrzap
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	go.uber.org/zap v1.24.0
 )
 

--- a/v3/integrations/logcontext-v2/nrzerolog/go.mod
+++ b/v3/integrations/logcontext-v2/nrzerolog/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrzerolog
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/rs/zerolog v1.26.1
 )
 

--- a/v3/integrations/logcontext-v2/zerologWriter/go.mod
+++ b/v3/integrations/logcontext-v2/zerologWriter/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext-v2/zerologWriter
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrwriter v1.0.2
 	github.com/rs/zerolog v1.27.0
 )

--- a/v3/integrations/logcontext/nrlogrusplugin/go.mod
+++ b/v3/integrations/logcontext/nrlogrusplugin/go.mod
@@ -5,7 +5,7 @@ module github.com/newrelic/go-agent/v3/integrations/logcontext/nrlogrusplugin
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	// v1.4.0 is required for for the log.WithContext.
 	github.com/sirupsen/logrus v1.8.3
 )

--- a/v3/integrations/nramqp/go.mod
+++ b/v3/integrations/nramqp/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/nramqp
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/rabbitmq/amqp091-go v1.9.0
 )
 replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nranthropic/LICENSE.txt
+++ b/v3/integrations/nranthropic/LICENSE.txt
@@ -1,0 +1,206 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+Versions 3.8.0 and above for this project are licensed under Apache 2.0. For
+prior versions of this project, please see the LICENCE.txt file in the root
+directory of that version for more information.

--- a/v3/integrations/nranthropic/examples/conversation/main.go
+++ b/v3/integrations/nranthropic/examples/conversation/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/newrelic/go-agent/v3/newrelic"
+)
+
+func main() {
+	// Initialize New Relic
+	app, err := newrelic.NewApplication(
+		newrelic.ConfigAppName("Anthropic Conversation Example"),
+		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+		newrelic.ConfigDebugLogger(os.Stdout),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Start a transaction
+	txn := app.StartTransaction("multi-turn-conversation")
+	defer txn.End()
+
+	ctx := newrelic.NewContext(context.Background(), txn)
+
+	// Create Anthropic client pointed at the NR proxy.
+	// Set NR_ANTHROPIC_BASE_URL to override (defaults to the NR staging proxy).
+	baseURL := os.Getenv("NR_ANTHROPIC_BASE_URL_NR")
+	// The NR proxy uses its own model slugs (see GET /v1/models).
+	// Set NR_ANTHROPIC_MODEL to override.
+	model := os.Getenv("NR_ANTHROPIC_MODEL")
+	if model == "" {
+		model = "claude-3-5-sonnet"
+	}
+	client := anthropic.NewClient(
+		option.WithAPIKey(os.Getenv("ANTHROPIC_API_KEY")),
+		option.WithBaseURL(baseURL),
+	)
+
+	fmt.Println("=== Multi-turn Conversation Example ===")
+	fmt.Println()
+
+	// Build conversation history across turns
+	var history []anthropic.MessageParam
+
+	turns := []string{
+		"What is a goroutine in Go?",
+		"Can you give me a simple example?",
+		"What are the main differences between goroutines and threads?",
+	}
+
+	for _, userText := range turns {
+		fmt.Printf("User: %s\n", userText)
+
+		// Append the new user message to history
+		history = append(history, anthropic.NewUserMessage(anthropic.NewTextBlock(userText)))
+
+		// Send the full conversation history
+		message, err := client.Messages.New(ctx, anthropic.MessageNewParams{
+			Model:     anthropic.Model(model),
+			MaxTokens: 1024,
+			Messages:  history,
+		})
+		if err != nil {
+			log.Fatalf("Error creating message: %v", err)
+		}
+
+		// Extract and print the assistant reply
+		var replyText string
+		if len(message.Content) > 0 {
+			replyText = message.Content[0].Text
+		}
+		fmt.Printf("Assistant: %s\n\n", replyText)
+
+		// Add the assistant reply to history for the next turn
+		history = append(history, anthropic.NewAssistantMessage(anthropic.NewTextBlock(replyText)))
+	}
+
+	fmt.Printf("Total conversation turns: %d\n", len(history))
+}

--- a/v3/integrations/nranthropic/examples/simple/main.go
+++ b/v3/integrations/nranthropic/examples/simple/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/newrelic/go-agent/v3/integrations/nranthropic"
+	"github.com/newrelic/go-agent/v3/newrelic"
+)
+
+func main() {
+	// Initialize New Relic
+	app, err := newrelic.NewApplication(
+		newrelic.ConfigAppName("Anthropic Simple Example"),
+		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+		newrelic.ConfigDebugLogger(os.Stdout),
+		newrelic.ConfigAIMonitoringEnabled(true),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := app.WaitForConnection(5 * time.Second); err != nil {
+		log.Fatalf("New Relic failed to connect: %v", err)
+	}
+	defer app.Shutdown(10 * time.Second)
+
+	// Set NR_ANTHROPIC_BASE_URL_NR to override (defaults to the NR staging proxy).
+	baseURL := os.Getenv("NR_ANTHROPIC_BASE_URL_NR")
+	// The NR proxy uses its own model slugs (see GET /v1/models).
+	// Set NR_ANTHROPIC_MODEL to override.
+	model := os.Getenv("NR_ANTHROPIC_MODEL")
+	if model == "" {
+		model = "claude-sonnet-4-6"
+	}
+	client := anthropic.NewClient(
+		option.WithAPIKey(os.Getenv("ANTHROPIC_API_KEY_AIR")),
+		option.WithBaseURL(baseURL),
+	)
+
+	nrClient := nranthropic.NewClient(app, &client)
+
+	// Send a message
+	prompt := "Write a haiku about programming in Go"
+	message, err := nrClient.Messages.New(context.TODO(), anthropic.MessageNewParams{
+		Model:     anthropic.Model(model),
+		MaxTokens: 1024,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(prompt)),
+		},
+	})
+	if err != nil {
+		log.Fatalf("Error creating message: %v", err)
+	}
+
+	fmt.Println("=== Simple Message Example ===")
+	fmt.Printf("Prompt: %s\n\n", prompt)
+	if len(message.Content) > 0 {
+		fmt.Printf("Response: %s\n", message.Content[0].Text)
+	}
+	fmt.Printf("\nInput tokens:  %d\n", message.Usage.InputTokens)
+	fmt.Printf("Output tokens: %d\n", message.Usage.OutputTokens)
+}

--- a/v3/integrations/nranthropic/examples/simple/main.go
+++ b/v3/integrations/nranthropic/examples/simple/main.go
@@ -37,12 +37,10 @@ func main() {
 	if model == "" {
 		model = "claude-sonnet-4-6"
 	}
-	client := anthropic.NewClient(
+	nrClient := nranthropic.NewClient(app,
 		option.WithAPIKey(os.Getenv("ANTHROPIC_API_KEY_AIR")),
 		option.WithBaseURL(baseURL),
 	)
-
-	nrClient := nranthropic.NewClient(app, &client)
 
 	// Send a message
 	prompt := "Write a haiku about programming in Go"

--- a/v3/integrations/nranthropic/examples/streaming/main.go
+++ b/v3/integrations/nranthropic/examples/streaming/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/newrelic/go-agent/v3/newrelic"
+)
+
+func main() {
+	// Initialize New Relic
+	app, err := newrelic.NewApplication(
+		newrelic.ConfigAppName("Anthropic Streaming Example"),
+		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+		newrelic.ConfigDebugLogger(os.Stdout),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Start a transaction
+	txn := app.StartTransaction("streaming-message")
+	defer txn.End()
+
+	ctx := newrelic.NewContext(context.Background(), txn)
+
+	// Create Anthropic client pointed at the NR proxy.
+	// Set NR_ANTHROPIC_BASE_URL to override (defaults to the NR staging proxy).
+	baseURL := os.Getenv("NR_ANTHROPIC_BASE_URL_NR")
+	// The NR proxy uses its own model slugs (see GET /v1/models).
+	// Set NR_ANTHROPIC_MODEL to override.
+	model := os.Getenv("NR_ANTHROPIC_MODEL")
+	if model == "" {
+		model = "claude-3-5-sonnet"
+	}
+	client := anthropic.NewClient(
+		option.WithAPIKey(os.Getenv("ANTHROPIC_API_KEY")),
+		option.WithBaseURL(baseURL),
+	)
+
+	prompt := "Explain the benefits of using Go for backend services in 3 points"
+	fmt.Println("=== Streaming Message Example ===")
+	fmt.Printf("Prompt: %s\n\n", prompt)
+	fmt.Print("Response: ")
+
+	// Create a streaming message
+	stream := client.Messages.NewStreaming(ctx, anthropic.MessageNewParams{
+		Model:     anthropic.Model(model),
+		MaxTokens: 1024,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(prompt)),
+		},
+	})
+
+	// Process stream events as they arrive
+	for stream.Next() {
+		event := stream.Current()
+		switch v := event.AsAny().(type) {
+		case anthropic.ContentBlockDeltaEvent:
+			switch delta := v.Delta.AsAny().(type) {
+			case anthropic.TextDelta:
+				fmt.Print(delta.Text)
+			}
+		}
+	}
+
+	if err := stream.Err(); err != nil {
+		log.Fatalf("Stream error: %v", err)
+	}
+
+}

--- a/v3/integrations/nranthropic/examples/streaming/main.go
+++ b/v3/integrations/nranthropic/examples/streaming/main.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/newrelic/go-agent/v3/integrations/nranthropic"
 	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
@@ -17,30 +19,35 @@ func main() {
 		newrelic.ConfigAppName("Anthropic Streaming Example"),
 		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
 		newrelic.ConfigDebugLogger(os.Stdout),
+		newrelic.ConfigAIMonitoringEnabled(true),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
+	if err := app.WaitForConnection(5 * time.Second); err != nil {
+		log.Fatalf("New Relic failed to connect: %v", err)
+	}
+	defer app.Shutdown(10 * time.Second)
 
 	// Start a transaction
 	txn := app.StartTransaction("streaming-message")
 	defer txn.End()
 
 	ctx := newrelic.NewContext(context.Background(), txn)
-
-	// Create Anthropic client pointed at the NR proxy.
-	// Set NR_ANTHROPIC_BASE_URL to override (defaults to the NR staging proxy).
+	// Set NR_ANTHROPIC_BASE_URL_NR to override (defaults to the NR staging proxy).
 	baseURL := os.Getenv("NR_ANTHROPIC_BASE_URL_NR")
 	// The NR proxy uses its own model slugs (see GET /v1/models).
 	// Set NR_ANTHROPIC_MODEL to override.
 	model := os.Getenv("NR_ANTHROPIC_MODEL")
 	if model == "" {
-		model = "claude-3-5-sonnet"
+		model = "claude-sonnet-4-6"
 	}
 	client := anthropic.NewClient(
-		option.WithAPIKey(os.Getenv("ANTHROPIC_API_KEY")),
+		option.WithAPIKey(os.Getenv("ANTHROPIC_API_KEY_AIR")),
 		option.WithBaseURL(baseURL),
 	)
+
+	nrClient := nranthropic.NewClient(app, &client)
 
 	prompt := "Explain the benefits of using Go for backend services in 3 points"
 	fmt.Println("=== Streaming Message Example ===")
@@ -48,7 +55,7 @@ func main() {
 	fmt.Print("Response: ")
 
 	// Create a streaming message
-	stream := client.Messages.NewStreaming(ctx, anthropic.MessageNewParams{
+	stream := nrClient.Messages.NewStreaming(ctx, anthropic.MessageNewParams{
 		Model:     anthropic.Model(model),
 		MaxTokens: 1024,
 		Messages: []anthropic.MessageParam{
@@ -72,4 +79,9 @@ func main() {
 		log.Fatalf("Stream error: %v", err)
 	}
 
+	if err := stream.Close(); err != nil {
+		log.Fatalf("Stream close error: %v", err)
+	}
+
+	fmt.Println()
 }

--- a/v3/integrations/nranthropic/examples/streaming/main.go
+++ b/v3/integrations/nranthropic/examples/streaming/main.go
@@ -42,12 +42,10 @@ func main() {
 	if model == "" {
 		model = "claude-sonnet-4-6"
 	}
-	client := anthropic.NewClient(
+	nrClient := nranthropic.NewClient(app,
 		option.WithAPIKey(os.Getenv("ANTHROPIC_API_KEY_AIR")),
 		option.WithBaseURL(baseURL),
 	)
-
-	nrClient := nranthropic.NewClient(app, &client)
 
 	prompt := "Explain the benefits of using Go for backend services in 3 points"
 	fmt.Println("=== Streaming Message Example ===")

--- a/v3/integrations/nranthropic/go.mod
+++ b/v3/integrations/nranthropic/go.mod
@@ -1,0 +1,24 @@
+module github.com/newrelic/go-agent/v3/integrations/nranthropic
+
+go 1.25
+
+require (
+	github.com/anthropics/anthropic-sdk-go v1.2.0
+	github.com/google/uuid v1.6.0
+	github.com/newrelic/go-agent/v3 v3.43.3
+)
+
+replace github.com/newrelic/go-agent/v3 => ../..
+
+require (
+	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
+	golang.org/x/net v0.49.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
+	golang.org/x/text v0.33.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 // indirect
+	google.golang.org/grpc v1.80.0 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
+)

--- a/v3/integrations/nranthropic/go.mod
+++ b/v3/integrations/nranthropic/go.mod
@@ -5,20 +5,8 @@ go 1.25
 require (
 	github.com/anthropics/anthropic-sdk-go v1.2.0
 	github.com/google/uuid v1.6.0
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
+
 
 replace github.com/newrelic/go-agent/v3 => ../..
-
-require (
-	github.com/tidwall/gjson v1.14.4 // indirect
-	github.com/tidwall/match v1.1.1 // indirect
-	github.com/tidwall/pretty v1.2.1 // indirect
-	github.com/tidwall/sjson v1.2.5 // indirect
-	golang.org/x/net v0.49.0 // indirect
-	golang.org/x/sys v0.40.0 // indirect
-	golang.org/x/text v0.33.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 // indirect
-	google.golang.org/grpc v1.80.0 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
-)

--- a/v3/integrations/nranthropic/nranthropic.go
+++ b/v3/integrations/nranthropic/nranthropic.go
@@ -1,0 +1,241 @@
+// Package nranthropic provides New Relic instrumentation for the Anthropic Go
+// SDK (github.com/anthropics/anthropic-sdk-go).
+//
+// Wrap your Anthropic client with NewClient, then use nrClient.Messages.New in
+// place of client.Messages.New to automatically record LlmChatCompletionSummary
+// and LlmChatCompletionMessage custom events and a segment under the active
+// transaction — mirroring the Python agent's mlmodel_anthropic instrumentation.
+//
+// The New Relic transaction must be present in the context (via
+// newrelic.NewContext) for instrumentation to activate. AI monitoring must also
+// be enabled on the application (newrelic.ConfigAIMonitoringEnabled(true)).
+package nranthropic
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/google/uuid"
+	"github.com/newrelic/go-agent/v3/internal"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v3/newrelic/integrationsupport"
+)
+
+// Version is the current version of the nranthropic integration.
+const Version = "0.1.0"
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if info != nil && ok {
+		for _, module := range info.Deps {
+			if module != nil && strings.Contains(module.Path, "anthropic-sdk-go") {
+				internal.TrackUsage("Go", "ML", "Anthropic", module.Version)
+				return
+			}
+		}
+	}
+	internal.TrackUsage("Go", "ML", "Anthropic", "unknown")
+}
+
+// NRClient wraps an Anthropic client with New Relic instrumentation.
+type NRClient struct {
+	Client           *anthropic.Client
+	Messages         NRMessageService
+	customAttributes map[string]interface{}
+}
+
+// NRMessageService wraps the Anthropic MessageService with instrumentation.
+type NRMessageService struct {
+	client *anthropic.Client
+	app    *newrelic.Application
+	nrc    *NRClient
+}
+
+// NewClient creates an NRClient wrapping the given Anthropic client.
+func NewClient(app *newrelic.Application, client *anthropic.Client) *NRClient {
+	nrc := &NRClient{Client: client}
+	nrc.Messages = NRMessageService{client: client, app: app, nrc: nrc}
+	return nrc
+}
+
+// AddCustomAttributes attaches llm.* prefixed key-value pairs to all LLM events
+// recorded by this client.
+func (c *NRClient) AddCustomAttributes(attrs map[string]interface{}) {
+	if c.customAttributes == nil {
+		c.customAttributes = make(map[string]interface{})
+	}
+	for k, v := range attrs {
+		if strings.HasPrefix(k, "llm.") {
+			c.customAttributes[k] = v
+		}
+	}
+}
+
+// New wraps client.Messages.New with New Relic instrumentation.
+//
+// If ctx carries a New Relic transaction (via newrelic.NewContext) that
+// transaction is used and its lifecycle is left to the caller. If no
+// transaction is present a new one named "AnthropicMessageNew" is started and
+// ended automatically. AI monitoring must be enabled on the application
+// (newrelic.ConfigAIMonitoringEnabled(true)); otherwise the call is forwarded
+// to the underlying SDK without instrumentation.
+func (s *NRMessageService) New(ctx context.Context, params anthropic.MessageNewParams, opts ...option.RequestOption) (*anthropic.Message, error) {
+	cfg, _ := s.app.Config()
+	if !cfg.AIMonitoring.Enabled {
+		return s.client.Messages.New(ctx, params, opts...)
+	}
+
+	txn := newrelic.FromContext(ctx)
+	if txn == nil {
+		txn = s.app.StartTransaction("AnthropicMessageNew")
+		defer txn.End()
+		ctx = newrelic.NewContext(ctx, txn)
+	}
+
+	integrationsupport.AddAgentAttribute(txn, "llm", "", true)
+
+	completionID := uuid.New().String()
+	spanID := txn.GetTraceMetadata().SpanID
+	traceID := txn.GetTraceMetadata().TraceID
+
+	seg := txn.StartSegment("Llm/completion/Anthropic/MessageNew")
+	start := time.Now()
+	resp, err := s.client.Messages.New(ctx, params, opts...)
+	duration := time.Since(start).Milliseconds()
+	seg.End()
+
+	if err != nil {
+		txn.NoticeError(newrelic.Error{
+			Message: err.Error(),
+			Class:   "AnthropicError",
+			Attributes: map[string]interface{}{
+				"completion_id": completionID,
+			},
+		})
+		s.recordSummary(completionID, spanID, traceID, params, nil, duration, true)
+		s.recordMessages(completionID, spanID, traceID, params, nil)
+		return resp, err
+	}
+
+	s.recordSummary(completionID, spanID, traceID, params, resp, duration, false)
+	s.recordMessages(completionID, spanID, traceID, params, resp)
+	return resp, nil
+}
+
+func (s *NRMessageService) recordSummary(completionID, spanID, traceID string, params anthropic.MessageNewParams, resp *anthropic.Message, duration int64, isError bool) {
+	data := map[string]interface{}{
+		"id":                 completionID,
+		"span_id":            spanID,
+		"trace_id":           traceID,
+		"request.model":      string(params.Model),
+		"request.max_tokens": params.MaxTokens,
+		"vendor":             "anthropic",
+		"ingest_source":      "Go",
+		"duration":           duration,
+	}
+
+	if params.Temperature.Valid() {
+		data["request.temperature"] = params.Temperature.Value
+	}
+
+	if isError {
+		data["error"] = true
+		data["response.number_of_messages"] = len(params.Messages)
+	} else if resp != nil {
+		data["response.model"] = string(resp.Model)
+		data["response.choices.finish_reason"] = string(resp.StopReason)
+		data["response.number_of_messages"] = len(params.Messages) + 1
+	}
+
+	s.appendCustomAttrs(data)
+	s.app.RecordCustomEvent("LlmChatCompletionSummary", data)
+}
+
+func (s *NRMessageService) recordMessages(completionID, spanID, traceID string, params anthropic.MessageNewParams, resp *anthropic.Message) {
+	cfg, _ := s.app.Config()
+	model := string(params.Model)
+	if resp != nil {
+		model = string(resp.Model)
+	}
+
+	for i, msg := range params.Messages {
+		text := extractParamText(msg.Content)
+		data := map[string]interface{}{
+			"id":             uuid.New().String(),
+			"span_id":        spanID,
+			"trace_id":       traceID,
+			"role":           string(msg.Role),
+			"completion_id":  completionID,
+			"sequence":       i,
+			"response.model": model,
+			"vendor":         "anthropic",
+			"ingest_source":  "Go",
+		}
+		if cfg.AIMonitoring.RecordContent.Enabled && text != "" {
+			data["content"] = text
+		}
+		if tokens, ok := s.app.InvokeLLMTokenCountCallback(model, text); ok {
+			data["token_count"] = tokens
+		}
+		s.appendCustomAttrs(data)
+		s.app.RecordCustomEvent("LlmChatCompletionMessage", data)
+	}
+
+	if resp == nil {
+		return
+	}
+
+	responseText := extractResponseText(resp.Content)
+	responseSeq := len(params.Messages)
+	data := map[string]interface{}{
+		"id":             fmt.Sprintf("%s-%d", resp.ID, responseSeq),
+		"span_id":        spanID,
+		"trace_id":       traceID,
+		"role":           "assistant",
+		"completion_id":  completionID,
+		"sequence":       responseSeq,
+		"response.model": model,
+		"vendor":         "anthropic",
+		"ingest_source":  "Go",
+		"is_response":    true,
+	}
+	if cfg.AIMonitoring.RecordContent.Enabled && responseText != "" {
+		data["content"] = responseText
+	}
+	if tokens, ok := s.app.InvokeLLMTokenCountCallback(model, responseText); ok {
+		data["token_count"] = tokens
+	}
+	s.appendCustomAttrs(data)
+	s.app.RecordCustomEvent("LlmChatCompletionMessage", data)
+}
+
+func (s *NRMessageService) appendCustomAttrs(data map[string]interface{}) {
+	for k, v := range s.nrc.customAttributes {
+		data[k] = v
+	}
+}
+
+func extractParamText(blocks []anthropic.ContentBlockParamUnion) string {
+	var parts []string
+	for _, b := range blocks {
+		if b.OfText != nil {
+			parts = append(parts, b.OfText.Text)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func extractResponseText(blocks []anthropic.ContentBlockUnion) string {
+	var parts []string
+	for _, b := range blocks {
+		if b.Type == "text" {
+			parts = append(parts, b.Text)
+		}
+	}
+	return strings.Join(parts, " ")
+}

--- a/v3/integrations/nranthropic/nranthropic.go
+++ b/v3/integrations/nranthropic/nranthropic.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"time"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
@@ -30,7 +31,12 @@ import (
 // Version is the current version of the nranthropic integration.
 const Version = "0.1.0"
 
+var reportStreamingDisabled func()
+
 func init() {
+	reportStreamingDisabled = sync.OnceFunc(func() {
+		internal.TrackUsage("Go", "ML", "Streaming", "Disabled")
+	})
 	info, ok := debug.ReadBuildInfo()
 	if info != nil && ok {
 		for _, module := range info.Deps {
@@ -45,34 +51,34 @@ func init() {
 
 // NRClient wraps an Anthropic client with New Relic instrumentation.
 type NRClient struct {
-	Client           *anthropic.Client
-	Messages         NRMessageService
-	customAttributes map[string]interface{}
+	Client   anthropic.Client
+	Messages NRMessageService
 }
 
 // NRMessageService wraps the Anthropic MessageService with instrumentation.
 type NRMessageService struct {
-	client *anthropic.Client
-	app    *newrelic.Application
-	nrc    *NRClient
+	messages         *anthropic.MessageService
+	app              *newrelic.Application
+	customAttributes map[string]interface{}
 }
 
-// NewClient creates an NRClient wrapping the given Anthropic client.
-func NewClient(app *newrelic.Application, client *anthropic.Client) *NRClient {
-	nrc := &NRClient{Client: client}
-	nrc.Messages = NRMessageService{client: client, app: app, nrc: nrc}
+// NewClient creates an NRClient wrapping a new Anthropic client initialized with opts.
+func NewClient(app *newrelic.Application, opts ...option.RequestOption) *NRClient {
+	nrc := &NRClient{Client: anthropic.NewClient(opts...)}
+	nrc.Messages = NRMessageService{
+		messages:         &nrc.Client.Messages,
+		app:              app,
+		customAttributes: make(map[string]interface{}),
+	}
 	return nrc
 }
 
 // AddCustomAttributes attaches llm.* prefixed key-value pairs to all LLM events
 // recorded by this client.
 func (c *NRClient) AddCustomAttributes(attrs map[string]interface{}) {
-	if c.customAttributes == nil {
-		c.customAttributes = make(map[string]interface{})
-	}
 	for k, v := range attrs {
 		if strings.HasPrefix(k, "llm.") {
-			c.customAttributes[k] = v
+			c.Messages.customAttributes[k] = v
 		}
 	}
 }
@@ -88,7 +94,7 @@ func (c *NRClient) AddCustomAttributes(attrs map[string]interface{}) {
 func (s *NRMessageService) New(ctx context.Context, params anthropic.MessageNewParams, opts ...option.RequestOption) (*anthropic.Message, error) {
 	cfg, _ := s.app.Config()
 	if !cfg.AIMonitoring.Enabled {
-		return s.client.Messages.New(ctx, params, opts...)
+		return s.messages.New(ctx, params, opts...)
 	}
 
 	txn := newrelic.FromContext(ctx)
@@ -106,7 +112,7 @@ func (s *NRMessageService) New(ctx context.Context, params anthropic.MessageNewP
 
 	seg := txn.StartSegment("Llm/completion/Anthropic/MessageNew")
 	start := time.Now()
-	resp, err := s.client.Messages.New(ctx, params, opts...)
+	resp, err := s.messages.New(ctx, params, opts...)
 	duration := time.Since(start).Milliseconds()
 	seg.End()
 
@@ -216,7 +222,7 @@ func (s *NRMessageService) recordMessages(completionID, spanID, traceID string, 
 }
 
 func (s *NRMessageService) appendCustomAttrs(data map[string]interface{}) {
-	for k, v := range s.nrc.customAttributes {
+	for k, v := range s.customAttributes {
 		data[k] = v
 	}
 }
@@ -245,21 +251,21 @@ func extractResponseText(blocks []anthropic.ContentBlockUnion) string {
 // Call Next() to advance the stream, Current() to read the current event, Err() to
 // check for errors, and Close() to flush NR events and release resources.
 type NRMessageStreamWrapper struct {
-	stream       *ssestream.Stream[anthropic.MessageStreamEventUnion]
-	app          *newrelic.Application
-	txn          *newrelic.Transaction
-	txnOwned     bool
-	seg          *newrelic.Segment
-	nrc          *NRClient
-	params       anthropic.MessageNewParams
-	completionID string
-	spanID       string
-	traceID      string
-	responseText strings.Builder
-	responseID   string
-	responseModel string
-	stopReason   string
-	start        time.Time
+	stream           *ssestream.Stream[anthropic.MessageStreamEventUnion]
+	app              *newrelic.Application
+	txn              *newrelic.Transaction
+	txnOwned         bool
+	seg              *newrelic.Segment
+	customAttributes map[string]interface{}
+	params           anthropic.MessageNewParams
+	completionID     string
+	spanID           string
+	traceID          string
+	responseText     strings.Builder
+	responseID       string
+	responseModel    string
+	stopReason       string
+	start            time.Time
 }
 
 // NewStreaming wraps client.Messages.NewStreaming with New Relic instrumentation.
@@ -269,9 +275,10 @@ func (s *NRMessageService) NewStreaming(ctx context.Context, params anthropic.Me
 	cfg, _ := s.app.Config()
 
 	if !cfg.AIMonitoring.Streaming.Enabled {
-		internal.TrackUsage("Go", "ML", "Streaming", "Disabled")
+		if reportStreamingDisabled != nil {
+			reportStreamingDisabled()
+		}
 	}
-
 	txn := newrelic.FromContext(ctx)
 	txnOwned := false
 	if txn == nil {
@@ -281,26 +288,26 @@ func (s *NRMessageService) NewStreaming(ctx context.Context, params anthropic.Me
 	}
 
 	w := &NRMessageStreamWrapper{
-		app:          s.app,
-		txn:          txn,
-		txnOwned:     txnOwned,
-		nrc:          s.nrc,
-		params:       params,
-		completionID: uuid.New().String(),
-		spanID:       txn.GetTraceMetadata().SpanID,
-		traceID:      txn.GetTraceMetadata().TraceID,
-		start:        time.Now(),
+		app:              s.app,
+		txn:              txn,
+		txnOwned:         txnOwned,
+		customAttributes: s.customAttributes,
+		params:           params,
+		completionID:     uuid.New().String(),
+		spanID:           txn.GetTraceMetadata().SpanID,
+		traceID:          txn.GetTraceMetadata().TraceID,
+		start:            time.Now(),
 	}
 
 	if !cfg.AIMonitoring.Enabled || !cfg.AIMonitoring.Streaming.Enabled {
-		w.stream = s.client.Messages.NewStreaming(ctx, params, opts...)
+		w.stream = s.messages.NewStreaming(ctx, params, opts...)
 		return w
 	}
 
 	integrationsupport.AddAgentAttribute(txn, "llm", "", true)
 	seg := txn.StartSegment("Llm/completion/Anthropic/MessageNewStreaming")
 	w.seg = seg
-	w.stream = s.client.Messages.NewStreaming(ctx, params, opts...)
+	w.stream = s.messages.NewStreaming(ctx, params, opts...)
 	return w
 }
 
@@ -451,7 +458,7 @@ func (w *NRMessageStreamWrapper) Close() error {
 }
 
 func (w *NRMessageStreamWrapper) appendCustomAttrs(data map[string]interface{}) {
-	for k, v := range w.nrc.customAttributes {
+	for k, v := range w.customAttributes {
 		data[k] = v
 	}
 }

--- a/v3/integrations/nranthropic/nranthropic.go
+++ b/v3/integrations/nranthropic/nranthropic.go
@@ -20,6 +20,7 @@ import (
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/anthropics/anthropic-sdk-go/packages/ssestream"
 	"github.com/google/uuid"
 	"github.com/newrelic/go-agent/v3/internal"
 	"github.com/newrelic/go-agent/v3/newrelic"
@@ -238,4 +239,219 @@ func extractResponseText(blocks []anthropic.ContentBlockUnion) string {
 		}
 	}
 	return strings.Join(parts, " ")
+}
+
+// NRMessageStreamWrapper wraps an Anthropic SSE stream with New Relic instrumentation.
+// Call Next() to advance the stream, Current() to read the current event, Err() to
+// check for errors, and Close() to flush NR events and release resources.
+type NRMessageStreamWrapper struct {
+	stream       *ssestream.Stream[anthropic.MessageStreamEventUnion]
+	app          *newrelic.Application
+	txn          *newrelic.Transaction
+	txnOwned     bool
+	seg          *newrelic.Segment
+	nrc          *NRClient
+	params       anthropic.MessageNewParams
+	completionID string
+	spanID       string
+	traceID      string
+	responseText strings.Builder
+	responseID   string
+	responseModel string
+	stopReason   string
+	start        time.Time
+}
+
+// NewStreaming wraps client.Messages.NewStreaming with New Relic instrumentation.
+// The returned wrapper exposes Next/Current/Err/Close matching the underlying
+// ssestream.Stream API. Call Close() after the stream is consumed to record NR events.
+func (s *NRMessageService) NewStreaming(ctx context.Context, params anthropic.MessageNewParams, opts ...option.RequestOption) *NRMessageStreamWrapper {
+	cfg, _ := s.app.Config()
+
+	if !cfg.AIMonitoring.Streaming.Enabled {
+		internal.TrackUsage("Go", "ML", "Streaming", "Disabled")
+	}
+
+	txn := newrelic.FromContext(ctx)
+	txnOwned := false
+	if txn == nil {
+		txn = s.app.StartTransaction("AnthropicMessageNewStreaming")
+		txnOwned = true
+		ctx = newrelic.NewContext(ctx, txn)
+	}
+
+	w := &NRMessageStreamWrapper{
+		app:          s.app,
+		txn:          txn,
+		txnOwned:     txnOwned,
+		nrc:          s.nrc,
+		params:       params,
+		completionID: uuid.New().String(),
+		spanID:       txn.GetTraceMetadata().SpanID,
+		traceID:      txn.GetTraceMetadata().TraceID,
+		start:        time.Now(),
+	}
+
+	if !cfg.AIMonitoring.Enabled || !cfg.AIMonitoring.Streaming.Enabled {
+		w.stream = s.client.Messages.NewStreaming(ctx, params, opts...)
+		return w
+	}
+
+	integrationsupport.AddAgentAttribute(txn, "llm", "", true)
+	seg := txn.StartSegment("Llm/completion/Anthropic/MessageNewStreaming")
+	w.seg = seg
+	w.stream = s.client.Messages.NewStreaming(ctx, params, opts...)
+	return w
+}
+
+// Next advances the stream to the next event and accumulates response state.
+func (w *NRMessageStreamWrapper) Next() bool {
+	if !w.stream.Next() {
+		return false
+	}
+	event := w.stream.Current()
+	switch v := event.AsAny().(type) {
+	case anthropic.MessageStartEvent:
+		w.responseID = v.Message.ID
+		w.responseModel = string(v.Message.Model)
+	case anthropic.ContentBlockDeltaEvent:
+		if delta, ok := v.Delta.AsAny().(anthropic.TextDelta); ok {
+			w.responseText.WriteString(delta.Text)
+		}
+	case anthropic.MessageDeltaEvent:
+		w.stopReason = string(v.Delta.StopReason)
+	}
+	return true
+}
+
+// Current returns the most recent stream event.
+func (w *NRMessageStreamWrapper) Current() anthropic.MessageStreamEventUnion {
+	return w.stream.Current()
+}
+
+// Err returns any error encountered during streaming.
+func (w *NRMessageStreamWrapper) Err() error {
+	return w.stream.Err()
+}
+
+// Close records LlmChatCompletionSummary and LlmChatCompletionMessage events,
+// ends the segment, ends the transaction if it was started by this wrapper,
+// and closes the underlying stream.
+func (w *NRMessageStreamWrapper) Close() error {
+	err := w.stream.Close()
+
+	cfg, _ := w.app.Config()
+	if !cfg.AIMonitoring.Enabled || !cfg.AIMonitoring.Streaming.Enabled {
+		if w.txnOwned {
+			w.txn.End()
+		}
+		return err
+	}
+
+	if w.seg != nil {
+		w.seg.End()
+	}
+
+	duration := time.Since(w.start).Milliseconds()
+	isError := w.stream.Err() != nil
+
+	if isError {
+		w.txn.NoticeError(newrelic.Error{
+			Message: w.stream.Err().Error(),
+			Class:   "AnthropicError",
+			Attributes: map[string]interface{}{
+				"completion_id": w.completionID,
+			},
+		})
+	}
+
+	model := string(w.params.Model)
+	if w.responseModel != "" {
+		model = w.responseModel
+	}
+
+	summaryData := map[string]interface{}{
+		"id":                 w.completionID,
+		"span_id":            w.spanID,
+		"trace_id":           w.traceID,
+		"request.model":      string(w.params.Model),
+		"request.max_tokens": w.params.MaxTokens,
+		"vendor":             "anthropic",
+		"ingest_source":      "Go",
+		"duration":           duration,
+	}
+	if w.params.Temperature.Valid() {
+		summaryData["request.temperature"] = w.params.Temperature.Value
+	}
+	if isError {
+		summaryData["error"] = true
+		summaryData["response.number_of_messages"] = len(w.params.Messages)
+	} else {
+		summaryData["response.model"] = model
+		if w.stopReason != "" {
+			summaryData["response.choices.finish_reason"] = w.stopReason
+		}
+		summaryData["response.number_of_messages"] = len(w.params.Messages) + 1
+	}
+	w.appendCustomAttrs(summaryData)
+	w.app.RecordCustomEvent("LlmChatCompletionSummary", summaryData)
+
+	for i, msg := range w.params.Messages {
+		text := extractParamText(msg.Content)
+		msgData := map[string]interface{}{
+			"id":             uuid.New().String(),
+			"span_id":        w.spanID,
+			"trace_id":       w.traceID,
+			"role":           string(msg.Role),
+			"completion_id":  w.completionID,
+			"sequence":       i,
+			"response.model": model,
+			"vendor":         "anthropic",
+			"ingest_source":  "Go",
+		}
+		if cfg.AIMonitoring.RecordContent.Enabled && text != "" {
+			msgData["content"] = text
+		}
+		if tokens, ok := w.app.InvokeLLMTokenCountCallback(model, text); ok {
+			msgData["token_count"] = tokens
+		}
+		w.appendCustomAttrs(msgData)
+		w.app.RecordCustomEvent("LlmChatCompletionMessage", msgData)
+	}
+
+	if !isError {
+		responseText := w.responseText.String()
+		responseSeq := len(w.params.Messages)
+		respData := map[string]interface{}{
+			"id":             fmt.Sprintf("%s-%d", w.responseID, responseSeq),
+			"span_id":        w.spanID,
+			"trace_id":       w.traceID,
+			"role":           "assistant",
+			"completion_id":  w.completionID,
+			"sequence":       responseSeq,
+			"response.model": model,
+			"vendor":         "anthropic",
+			"ingest_source":  "Go",
+			"is_response":    true,
+		}
+		if cfg.AIMonitoring.RecordContent.Enabled && responseText != "" {
+			respData["content"] = responseText
+		}
+		if tokens, ok := w.app.InvokeLLMTokenCountCallback(model, responseText); ok {
+			respData["token_count"] = tokens
+		}
+		w.appendCustomAttrs(respData)
+		w.app.RecordCustomEvent("LlmChatCompletionMessage", respData)
+	}
+
+	if w.txnOwned {
+		w.txn.End()
+	}
+	return err
+}
+
+func (w *NRMessageStreamWrapper) appendCustomAttrs(data map[string]interface{}) {
+	for k, v := range w.nrc.customAttributes {
+		data[k] = v
+	}
 }

--- a/v3/integrations/nranthropic/nranthropic.go
+++ b/v3/integrations/nranthropic/nranthropic.go
@@ -110,7 +110,7 @@ func (s *NRMessageService) New(ctx context.Context, params anthropic.MessageNewP
 	spanID := txn.GetTraceMetadata().SpanID
 	traceID := txn.GetTraceMetadata().TraceID
 
-	seg := txn.StartSegment("Llm/completion/Anthropic/MessageNew")
+	seg := txn.StartSegment("Llm/completion/Anthropic/New")
 	start := time.Now()
 	resp, err := s.messages.New(ctx, params, opts...)
 	duration := time.Since(start).Milliseconds()
@@ -305,7 +305,7 @@ func (s *NRMessageService) NewStreaming(ctx context.Context, params anthropic.Me
 	}
 
 	integrationsupport.AddAgentAttribute(txn, "llm", "", true)
-	seg := txn.StartSegment("Llm/completion/Anthropic/MessageNewStreaming")
+	seg := txn.StartSegment("Llm/completion/Anthropic/NewStreaming")
 	w.seg = seg
 	w.stream = s.messages.NewStreaming(ctx, params, opts...)
 	return w
@@ -345,14 +345,17 @@ func (w *NRMessageStreamWrapper) Err() error {
 // ends the segment, ends the transaction if it was started by this wrapper,
 // and closes the underlying stream.
 func (w *NRMessageStreamWrapper) Close() error {
-	err := w.stream.Close()
+	w.recordCustomEvent()
+	if w.txnOwned {
+		w.txn.End()
+	}
+	return w.stream.Close()
+}
 
+func (w *NRMessageStreamWrapper) recordCustomEvent() {
 	cfg, _ := w.app.Config()
 	if !cfg.AIMonitoring.Enabled || !cfg.AIMonitoring.Streaming.Enabled {
-		if w.txnOwned {
-			w.txn.End()
-		}
-		return err
+		return
 	}
 
 	if w.seg != nil {
@@ -426,35 +429,32 @@ func (w *NRMessageStreamWrapper) Close() error {
 		w.app.RecordCustomEvent("LlmChatCompletionMessage", msgData)
 	}
 
-	if !isError {
-		responseText := w.responseText.String()
-		responseSeq := len(w.params.Messages)
-		respData := map[string]interface{}{
-			"id":             fmt.Sprintf("%s-%d", w.responseID, responseSeq),
-			"span_id":        w.spanID,
-			"trace_id":       w.traceID,
-			"role":           "assistant",
-			"completion_id":  w.completionID,
-			"sequence":       responseSeq,
-			"response.model": model,
-			"vendor":         "anthropic",
-			"ingest_source":  "Go",
-			"is_response":    true,
-		}
-		if cfg.AIMonitoring.RecordContent.Enabled && responseText != "" {
-			respData["content"] = responseText
-		}
-		if tokens, ok := w.app.InvokeLLMTokenCountCallback(model, responseText); ok {
-			respData["token_count"] = tokens
-		}
-		w.appendCustomAttrs(respData)
-		w.app.RecordCustomEvent("LlmChatCompletionMessage", respData)
+	if isError {
+		return
 	}
 
-	if w.txnOwned {
-		w.txn.End()
+	responseText := w.responseText.String()
+	responseSeq := len(w.params.Messages)
+	respData := map[string]interface{}{
+		"id":             fmt.Sprintf("%s-%d", w.responseID, responseSeq),
+		"span_id":        w.spanID,
+		"trace_id":       w.traceID,
+		"role":           "assistant",
+		"completion_id":  w.completionID,
+		"sequence":       responseSeq,
+		"response.model": model,
+		"vendor":         "anthropic",
+		"ingest_source":  "Go",
+		"is_response":    true,
 	}
-	return err
+	if cfg.AIMonitoring.RecordContent.Enabled && responseText != "" {
+		respData["content"] = responseText
+	}
+	if tokens, ok := w.app.InvokeLLMTokenCountCallback(model, responseText); ok {
+		respData["token_count"] = tokens
+	}
+	w.appendCustomAttrs(respData)
+	w.app.RecordCustomEvent("LlmChatCompletionMessage", respData)
 }
 
 func (w *NRMessageStreamWrapper) appendCustomAttrs(data map[string]interface{}) {

--- a/v3/integrations/nranthropic/nranthropic.go
+++ b/v3/integrations/nranthropic/nranthropic.go
@@ -279,6 +279,16 @@ func (s *NRMessageService) NewStreaming(ctx context.Context, params anthropic.Me
 			reportStreamingDisabled()
 		}
 	}
+
+	if !cfg.AIMonitoring.Enabled || !cfg.AIMonitoring.Streaming.Enabled {
+		return &NRMessageStreamWrapper{
+			app:    s.app,
+			params: params,
+			stream: s.messages.NewStreaming(ctx, params, opts...),
+			start:  time.Now(),
+		}
+	}
+
 	txn := newrelic.FromContext(ctx)
 	txnOwned := false
 	if txn == nil {
@@ -287,28 +297,22 @@ func (s *NRMessageService) NewStreaming(ctx context.Context, params anthropic.Me
 		ctx = newrelic.NewContext(ctx, txn)
 	}
 
-	w := &NRMessageStreamWrapper{
+	integrationsupport.AddAgentAttribute(txn, "llm", "", true)
+	seg := txn.StartSegment("Llm/completion/Anthropic/NewStreaming")
+
+	return &NRMessageStreamWrapper{
 		app:              s.app,
 		txn:              txn,
 		txnOwned:         txnOwned,
+		seg:              seg,
 		customAttributes: s.customAttributes,
 		params:           params,
 		completionID:     uuid.New().String(),
 		spanID:           txn.GetTraceMetadata().SpanID,
 		traceID:          txn.GetTraceMetadata().TraceID,
 		start:            time.Now(),
+		stream:           s.messages.NewStreaming(ctx, params, opts...),
 	}
-
-	if !cfg.AIMonitoring.Enabled || !cfg.AIMonitoring.Streaming.Enabled {
-		w.stream = s.messages.NewStreaming(ctx, params, opts...)
-		return w
-	}
-
-	integrationsupport.AddAgentAttribute(txn, "llm", "", true)
-	seg := txn.StartSegment("Llm/completion/Anthropic/NewStreaming")
-	w.seg = seg
-	w.stream = s.messages.NewStreaming(ctx, params, opts...)
-	return w
 }
 
 // Next advances the stream to the next event and accumulates response state.

--- a/v3/integrations/nranthropic/nranthropic_test.go
+++ b/v3/integrations/nranthropic/nranthropic_test.go
@@ -1,0 +1,322 @@
+package nranthropic
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/newrelic/go-agent/v3/internal"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v3/newrelic/integrationsupport"
+)
+
+const (
+	testModel     = "claude-3-5-sonnet-20241022"
+	testPrompt    = "What is 8*5"
+	testResponse  = "Hello there, how may I assist you today?"
+	testMessageID = "msg_abc123"
+)
+
+// noCodeLevelMetrics disables CLM so code.* agent attributes don't appear in
+// test assertions and cause spurious length mismatches.
+func noCodeLevelMetrics(cfg *newrelic.Config) {
+	cfg.CodeLevelMetrics.Enabled = false
+}
+
+// mockAnthropicServer returns a test server and an Anthropic client pointing at it.
+// The handler is called for every request.
+func mockAnthropicServer(t *testing.T, handler http.HandlerFunc) *anthropic.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	client := anthropic.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithBaseURL(srv.URL),
+	)
+	return &client
+}
+
+func successHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":            testMessageID,
+		"type":          "message",
+		"role":          "assistant",
+		"model":         testModel,
+		"stop_reason":   "end_turn",
+		"stop_sequence": nil,
+		"content": []map[string]interface{}{
+			{"type": "text", "text": testResponse},
+		},
+		"usage": map[string]interface{}{
+			"input_tokens":  9,
+			"output_tokens": 12,
+		},
+	})
+}
+
+func errorHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"type": "error",
+		"error": map[string]interface{}{
+			"type":    "invalid_request_error",
+			"message": "test error",
+		},
+	})
+}
+
+func TestAddCustomAttributes(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	client := mockAnthropicServer(t, successHandler)
+	nrClient := NewClient(app.Application, client)
+
+	nrClient.AddCustomAttributes(map[string]interface{}{
+		"llm.foo": "bar",
+	})
+	if nrClient.customAttributes["llm.foo"] != "bar" {
+		t.Errorf("expected llm.foo=bar, got %v", nrClient.customAttributes["llm.foo"])
+	}
+}
+
+func TestAddCustomAttributesIncorrectPrefix(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	client := mockAnthropicServer(t, successHandler)
+	nrClient := NewClient(app.Application, client)
+
+	nrClient.AddCustomAttributes(map[string]interface{}{
+		"notllm.foo": "bar",
+	})
+	if len(nrClient.customAttributes) != 0 {
+		t.Errorf("expected no custom attributes, got %d", len(nrClient.customAttributes))
+	}
+}
+
+func TestNRMessagesNew(t *testing.T) {
+	client := mockAnthropicServer(t, successHandler)
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := NewClient(app.Application, client)
+
+	resp, err := nrClient.Messages.New(context.Background(), anthropic.MessageNewParams{
+		Model:     anthropic.Model(testModel),
+		MaxTokens: 150,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(testPrompt)),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Content) == 0 || resp.Content[0].Text != testResponse {
+		t.Errorf("unexpected response content: %v", resp.Content)
+	}
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                             internal.MatchAnything,
+				"span_id":                        internal.MatchAnything,
+				"trace_id":                       internal.MatchAnything,
+				"request.model":                  testModel,
+				"request.max_tokens":             int64(150),
+				"vendor":                         "anthropic",
+				"ingest_source":                  "Go",
+				"duration":                       internal.MatchAnything,
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "end_turn",
+				"response.number_of_messages":    2,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       0,
+				"role":           "user",
+				"content":        testPrompt,
+				"vendor":         "anthropic",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       1,
+				"role":           "assistant",
+				"content":        testResponse,
+				"vendor":         "anthropic",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+				"is_response":    true,
+			},
+		},
+	})
+}
+
+func TestNRMessagesNewAIMonitoringNotEnabled(t *testing.T) {
+	client := mockAnthropicServer(t, successHandler)
+	app := integrationsupport.NewTestApp(nil) // AI monitoring NOT enabled
+	nrClient := NewClient(app.Application, client)
+
+	resp, err := nrClient.Messages.New(context.Background(), anthropic.MessageNewParams{
+		Model:     anthropic.Model(testModel),
+		MaxTokens: 150,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(testPrompt)),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Call still succeeds, just with no instrumentation
+	if len(resp.Content) == 0 || resp.Content[0].Text != testResponse {
+		t.Errorf("unexpected response content: %v", resp.Content)
+	}
+	app.ExpectCustomEvents(t, []internal.WantEvent{})
+}
+
+func TestNRMessagesNewError(t *testing.T) {
+	client := mockAnthropicServer(t, errorHandler)
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := NewClient(app.Application, client)
+
+	_, err := nrClient.Messages.New(context.Background(), anthropic.MessageNewParams{
+		Model:     anthropic.Model(testModel),
+		MaxTokens: 150,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(testPrompt)),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                          internal.MatchAnything,
+				"span_id":                     internal.MatchAnything,
+				"trace_id":                    internal.MatchAnything,
+				"request.model":               testModel,
+				"request.max_tokens":          int64(150),
+				"vendor":                      "anthropic",
+				"ingest_source":               "Go",
+				"duration":                    internal.MatchAnything,
+				"error":                       true,
+				"response.number_of_messages": 1,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       0,
+				"role":           "user",
+				"content":        testPrompt,
+				"vendor":         "anthropic",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+			},
+		},
+	})
+
+	app.ExpectErrorEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":            "TransactionError",
+				"transactionName": "OtherTransaction/Go/AnthropicMessageNew",
+				"guid":            internal.MatchAnything,
+				"priority":        internal.MatchAnything,
+				"sampled":         internal.MatchAnything,
+				"traceId":         internal.MatchAnything,
+				"error.class":     "AnthropicError",
+				"error.message":   internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"completion_id": internal.MatchAnything,
+			},
+			AgentAttributes: map[string]interface{}{
+				"llm": true,
+			},
+		},
+	})
+}
+
+func TestNRMessagesNewWithExistingTxn(t *testing.T) {
+	client := mockAnthropicServer(t, successHandler)
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := NewClient(app.Application, client)
+
+	txn := app.StartTransaction("my-existing-txn")
+	ctx := newrelic.NewContext(context.Background(), txn)
+
+	resp, err := nrClient.Messages.New(ctx, anthropic.MessageNewParams{
+		Model:     anthropic.Model(testModel),
+		MaxTokens: 150,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(testPrompt)),
+		},
+	})
+	txn.End()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Content) == 0 || resp.Content[0].Text != testResponse {
+		t.Errorf("unexpected response content: %v", resp.Content)
+	}
+
+	// Events should be recorded under the caller's transaction
+	app.ExpectTxnEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "Transaction",
+				"name":      "OtherTransaction/Go/my-existing-txn",
+				"guid":      internal.MatchAnything,
+				"priority":  internal.MatchAnything,
+				"sampled":   internal.MatchAnything,
+				"traceId":   internal.MatchAnything,
+				"timestamp": internal.MatchAnything,
+				"duration":  internal.MatchAnything,
+				"totalTime": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{},
+			AgentAttributes: map[string]interface{}{
+				"llm": true,
+			},
+		},
+	})
+}

--- a/v3/integrations/nranthropic/nranthropic_test.go
+++ b/v3/integrations/nranthropic/nranthropic_test.go
@@ -28,17 +28,16 @@ func noCodeLevelMetrics(cfg *newrelic.Config) {
 	cfg.CodeLevelMetrics.Enabled = false
 }
 
-// mockAnthropicServer returns a test server and an Anthropic client pointing at it.
+// mockAnthropicServer returns request options pointing at a test server.
 // The handler is called for every request.
-func mockAnthropicServer(t *testing.T, handler http.HandlerFunc) *anthropic.Client {
+func mockAnthropicServer(t *testing.T, handler http.HandlerFunc) []option.RequestOption {
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
-	client := anthropic.NewClient(
+	return []option.RequestOption{
 		option.WithAPIKey("test-key"),
 		option.WithBaseURL(srv.URL),
-	)
-	return &client
+	}
 }
 
 func successHandler(w http.ResponseWriter, r *http.Request) {
@@ -74,34 +73,31 @@ func errorHandler(w http.ResponseWriter, r *http.Request) {
 
 func TestAddCustomAttributes(t *testing.T) {
 	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	client := mockAnthropicServer(t, successHandler)
-	nrClient := NewClient(app.Application, client)
+	nrClient := NewClient(app.Application, mockAnthropicServer(t, successHandler)...)
 
 	nrClient.AddCustomAttributes(map[string]interface{}{
 		"llm.foo": "bar",
 	})
-	if nrClient.customAttributes["llm.foo"] != "bar" {
-		t.Errorf("expected llm.foo=bar, got %v", nrClient.customAttributes["llm.foo"])
+	if nrClient.Messages.customAttributes["llm.foo"] != "bar" {
+		t.Errorf("expected llm.foo=bar, got %v", nrClient.Messages.customAttributes["llm.foo"])
 	}
 }
 
 func TestAddCustomAttributesIncorrectPrefix(t *testing.T) {
 	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	client := mockAnthropicServer(t, successHandler)
-	nrClient := NewClient(app.Application, client)
+	nrClient := NewClient(app.Application, mockAnthropicServer(t, successHandler)...)
 
 	nrClient.AddCustomAttributes(map[string]interface{}{
 		"notllm.foo": "bar",
 	})
-	if len(nrClient.customAttributes) != 0 {
-		t.Errorf("expected no custom attributes, got %d", len(nrClient.customAttributes))
+	if len(nrClient.Messages.customAttributes) != 0 {
+		t.Errorf("expected no custom attributes, got %d", len(nrClient.Messages.customAttributes))
 	}
 }
 
 func TestNRMessagesNew(t *testing.T) {
-	client := mockAnthropicServer(t, successHandler)
 	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	nrClient := NewClient(app.Application, client)
+	nrClient := NewClient(app.Application, mockAnthropicServer(t, successHandler)...)
 
 	resp, err := nrClient.Messages.New(context.Background(), anthropic.MessageNewParams{
 		Model:     anthropic.Model(testModel),
@@ -178,9 +174,8 @@ func TestNRMessagesNew(t *testing.T) {
 }
 
 func TestNRMessagesNewAIMonitoringNotEnabled(t *testing.T) {
-	client := mockAnthropicServer(t, successHandler)
 	app := integrationsupport.NewTestApp(nil) // AI monitoring NOT enabled
-	nrClient := NewClient(app.Application, client)
+	nrClient := NewClient(app.Application, mockAnthropicServer(t, successHandler)...)
 
 	resp, err := nrClient.Messages.New(context.Background(), anthropic.MessageNewParams{
 		Model:     anthropic.Model(testModel),
@@ -200,9 +195,8 @@ func TestNRMessagesNewAIMonitoringNotEnabled(t *testing.T) {
 }
 
 func TestNRMessagesNewError(t *testing.T) {
-	client := mockAnthropicServer(t, errorHandler)
 	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	nrClient := NewClient(app.Application, client)
+	nrClient := NewClient(app.Application, mockAnthropicServer(t, errorHandler)...)
 
 	_, err := nrClient.Messages.New(context.Background(), anthropic.MessageNewParams{
 		Model:     anthropic.Model(testModel),
@@ -319,9 +313,8 @@ func streamingHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestNRMessagesNewWithExistingTxn(t *testing.T) {
-	client := mockAnthropicServer(t, successHandler)
 	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	nrClient := NewClient(app.Application, client)
+	nrClient := NewClient(app.Application, mockAnthropicServer(t, successHandler)...)
 
 	txn := app.StartTransaction("my-existing-txn")
 	ctx := newrelic.NewContext(context.Background(), txn)
@@ -365,9 +358,8 @@ func TestNRMessagesNewWithExistingTxn(t *testing.T) {
 }
 
 func TestNRMessagesNewStreaming(t *testing.T) {
-	client := mockAnthropicServer(t, streamingHandler)
 	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	nrClient := NewClient(app.Application, client)
+	nrClient := NewClient(app.Application, mockAnthropicServer(t, streamingHandler)...)
 
 	stream := nrClient.Messages.NewStreaming(context.Background(), anthropic.MessageNewParams{
 		Model:     anthropic.Model(testModel),
@@ -447,9 +439,8 @@ func TestNRMessagesNewStreaming(t *testing.T) {
 }
 
 func TestNRMessagesNewStreamingAIMonitoringNotEnabled(t *testing.T) {
-	client := mockAnthropicServer(t, streamingHandler)
 	app := integrationsupport.NewTestApp(nil) // AI monitoring NOT enabled
-	nrClient := NewClient(app.Application, client)
+	nrClient := NewClient(app.Application, mockAnthropicServer(t, streamingHandler)...)
 
 	stream := nrClient.Messages.NewStreaming(context.Background(), anthropic.MessageNewParams{
 		Model:     anthropic.Model(testModel),
@@ -467,9 +458,8 @@ func TestNRMessagesNewStreamingAIMonitoringNotEnabled(t *testing.T) {
 }
 
 func TestNRMessagesNewStreamingWithExistingTxn(t *testing.T) {
-	client := mockAnthropicServer(t, streamingHandler)
 	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	nrClient := NewClient(app.Application, client)
+	nrClient := NewClient(app.Application, mockAnthropicServer(t, streamingHandler)...)
 
 	txn := app.StartTransaction("my-existing-streaming-txn")
 	ctx := newrelic.NewContext(context.Background(), txn)

--- a/v3/integrations/nranthropic/nranthropic_test.go
+++ b/v3/integrations/nranthropic/nranthropic_test.go
@@ -455,6 +455,40 @@ func TestNRMessagesNewStreamingAIMonitoringNotEnabled(t *testing.T) {
 		t.Fatal(err)
 	}
 	app.ExpectCustomEvents(t, []internal.WantEvent{})
+	app.ExpectTxnEvents(t, []internal.WantEvent{})
+}
+
+func TestNRMessagesNewStreamingDisabled(t *testing.T) {
+	// AI monitoring enabled but streaming specifically disabled — no txn should be started.
+	app := integrationsupport.NewTestApp(nil,
+		newrelic.ConfigAIMonitoringEnabled(true),
+		func(cfg *newrelic.Config) { cfg.AIMonitoring.Streaming.Enabled = false },
+		noCodeLevelMetrics,
+	)
+	nrClient := NewClient(app.Application, mockAnthropicServer(t, streamingHandler)...)
+
+	stream := nrClient.Messages.NewStreaming(context.Background(), anthropic.MessageNewParams{
+		Model:     anthropic.Model(testModel),
+		MaxTokens: 150,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(testPrompt)),
+		},
+	})
+
+	if stream.txn != nil {
+		t.Error("expected txn to be nil when streaming is disabled, but it was set")
+	}
+	if stream.txnOwned {
+		t.Error("expected txnOwned=false when streaming is disabled")
+	}
+
+	for stream.Next() {
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+	app.ExpectCustomEvents(t, []internal.WantEvent{})
+	app.ExpectTxnEvents(t, []internal.WantEvent{})
 }
 
 func TestNRMessagesNewStreamingWithExistingTxn(t *testing.T) {
@@ -493,6 +527,571 @@ func TestNRMessagesNewStreamingWithExistingTxn(t *testing.T) {
 			AgentAttributes: map[string]interface{}{
 				"llm": true,
 			},
+		},
+	})
+}
+
+// --- Pure helper function tests ---
+
+func TestExtractParamText(t *testing.T) {
+	tests := []struct {
+		name   string
+		blocks []anthropic.ContentBlockParamUnion
+		want   string
+	}{
+		{name: "nil", blocks: nil, want: ""},
+		{name: "empty", blocks: []anthropic.ContentBlockParamUnion{}, want: ""},
+		{
+			name:   "single text",
+			blocks: []anthropic.ContentBlockParamUnion{anthropic.NewTextBlock("hello")},
+			want:   "hello",
+		},
+		{
+			name: "multiple text",
+			blocks: []anthropic.ContentBlockParamUnion{
+				anthropic.NewTextBlock("hello"),
+				anthropic.NewTextBlock("world"),
+			},
+			want: "hello world",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractParamText(tc.blocks); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractResponseText(t *testing.T) {
+	tests := []struct {
+		name   string
+		blocks []anthropic.ContentBlockUnion
+		want   string
+	}{
+		{name: "nil", blocks: nil, want: ""},
+		{name: "empty", blocks: []anthropic.ContentBlockUnion{}, want: ""},
+		{
+			name:   "single text",
+			blocks: []anthropic.ContentBlockUnion{{Type: "text", Text: "hello"}},
+			want:   "hello",
+		},
+		{
+			name: "multiple text",
+			blocks: []anthropic.ContentBlockUnion{
+				{Type: "text", Text: "hello"},
+				{Type: "text", Text: "world"},
+			},
+			want: "hello world",
+		},
+		{
+			name:   "non-text block ignored",
+			blocks: []anthropic.ContentBlockUnion{{Type: "tool_use", Text: "ignored"}},
+			want:   "",
+		},
+		{
+			name: "mixed text and non-text",
+			blocks: []anthropic.ContentBlockUnion{
+				{Type: "text", Text: "hello"},
+				{Type: "tool_use", Text: "ignored"},
+				{Type: "text", Text: "world"},
+			},
+			want: "hello world",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractResponseText(tc.blocks); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// --- NRMessageStreamWrapper.appendCustomAttrs tests ---
+
+func TestStreamWrapperAppendCustomAttrs(t *testing.T) {
+	w := &NRMessageStreamWrapper{
+		customAttributes: map[string]interface{}{
+			"llm.key1": "val1",
+			"llm.key2": 42,
+		},
+	}
+	data := map[string]interface{}{"existing": "preserved"}
+	w.appendCustomAttrs(data)
+
+	if data["llm.key1"] != "val1" {
+		t.Errorf("llm.key1: got %v, want val1", data["llm.key1"])
+	}
+	if data["llm.key2"] != 42 {
+		t.Errorf("llm.key2: got %v, want 42", data["llm.key2"])
+	}
+	if data["existing"] != "preserved" {
+		t.Errorf("existing key was overwritten, got %v", data["existing"])
+	}
+}
+
+func TestStreamWrapperAppendCustomAttrsEmpty(t *testing.T) {
+	w := &NRMessageStreamWrapper{customAttributes: map[string]interface{}{}}
+	data := map[string]interface{}{"k": "v"}
+	w.appendCustomAttrs(data)
+	if len(data) != 1 || data["k"] != "v" {
+		t.Errorf("data should be unchanged, got %v", data)
+	}
+}
+
+// --- NRClient.AddCustomAttributes additional tests ---
+
+func TestAddCustomAttributesMixed(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := NewClient(app.Application)
+
+	nrClient.AddCustomAttributes(map[string]interface{}{
+		"llm.valid":   "yes",
+		"notllm.skip": "no",
+		"also.skip":   "no",
+	})
+
+	if len(nrClient.Messages.customAttributes) != 1 {
+		t.Fatalf("expected 1 attribute, got %d: %v", len(nrClient.Messages.customAttributes), nrClient.Messages.customAttributes)
+	}
+	if nrClient.Messages.customAttributes["llm.valid"] != "yes" {
+		t.Errorf("llm.valid: got %v, want yes", nrClient.Messages.customAttributes["llm.valid"])
+	}
+}
+
+func TestAddCustomAttributesEmpty(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil)
+	nrClient := NewClient(app.Application)
+	nrClient.AddCustomAttributes(map[string]interface{}{})
+	if len(nrClient.Messages.customAttributes) != 0 {
+		t.Errorf("expected no attributes, got %d", len(nrClient.Messages.customAttributes))
+	}
+}
+
+// --- NRMessageService.recordSummary tests ---
+
+func newTestService(t *testing.T) (*NRMessageService, integrationsupport.ExpectApp) {
+	t.Helper()
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	svc := &NRMessageService{
+		app:              app.Application,
+		customAttributes: make(map[string]interface{}),
+	}
+	return svc, app
+}
+
+func baseParams() anthropic.MessageNewParams {
+	return anthropic.MessageNewParams{
+		Model:     anthropic.Model(testModel),
+		MaxTokens: 150,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(testPrompt)),
+		},
+	}
+}
+
+func TestRecordSummarySuccess(t *testing.T) {
+	svc, app := newTestService(t)
+	resp := &anthropic.Message{
+		ID:         testMessageID,
+		Model:      anthropic.Model(testModel),
+		StopReason: anthropic.StopReasonEndTurn,
+	}
+
+	svc.recordSummary("cid", "sid", "tid", baseParams(), resp, 100, false)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                             "cid",
+				"span_id":                        "sid",
+				"trace_id":                       "tid",
+				"request.model":                  testModel,
+				"request.max_tokens":             int64(150),
+				"vendor":                         "anthropic",
+				"ingest_source":                  "Go",
+				"duration":                       int64(100),
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "end_turn",
+				"response.number_of_messages":    2,
+			},
+		},
+	})
+}
+
+func TestRecordSummaryError(t *testing.T) {
+	svc, app := newTestService(t)
+
+	svc.recordSummary("cid", "sid", "tid", baseParams(), nil, 50, true)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                          "cid",
+				"span_id":                     "sid",
+				"trace_id":                    "tid",
+				"request.model":               testModel,
+				"request.max_tokens":          int64(150),
+				"vendor":                      "anthropic",
+				"ingest_source":               "Go",
+				"duration":                    int64(50),
+				"error":                       true,
+				"response.number_of_messages": 1,
+			},
+		},
+	})
+}
+
+func TestRecordSummaryWithTemperature(t *testing.T) {
+	svc, app := newTestService(t)
+	params := baseParams()
+	params.Temperature = anthropic.Float(0.7)
+	resp := &anthropic.Message{
+		ID:         testMessageID,
+		Model:      anthropic.Model(testModel),
+		StopReason: anthropic.StopReasonEndTurn,
+	}
+
+	svc.recordSummary("cid", "sid", "tid", params, resp, 10, false)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                             "cid",
+				"span_id":                        "sid",
+				"trace_id":                       "tid",
+				"request.model":                  testModel,
+				"request.max_tokens":             int64(150),
+				"request.temperature":            0.7,
+				"vendor":                         "anthropic",
+				"ingest_source":                  "Go",
+				"duration":                       int64(10),
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "end_turn",
+				"response.number_of_messages":    2,
+			},
+		},
+	})
+}
+
+func TestRecordSummaryCustomAttrs(t *testing.T) {
+	svc, app := newTestService(t)
+	svc.customAttributes["llm.env"] = "prod"
+	resp := &anthropic.Message{
+		Model:      anthropic.Model(testModel),
+		StopReason: anthropic.StopReasonEndTurn,
+	}
+
+	svc.recordSummary("cid", "sid", "tid", baseParams(), resp, 10, false)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                             "cid",
+				"span_id":                        "sid",
+				"trace_id":                       "tid",
+				"request.model":                  testModel,
+				"request.max_tokens":             int64(150),
+				"vendor":                         "anthropic",
+				"ingest_source":                  "Go",
+				"duration":                       int64(10),
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "end_turn",
+				"response.number_of_messages":    2,
+				"llm.env":                        "prod",
+			},
+		},
+	})
+}
+
+// --- NRMessageService.recordMessages tests ---
+
+func TestRecordMessagesWithResp(t *testing.T) {
+	svc, app := newTestService(t)
+	resp := &anthropic.Message{
+		ID:    testMessageID,
+		Model: anthropic.Model(testModel),
+		Content: []anthropic.ContentBlockUnion{
+			{Type: "text", Text: testResponse},
+		},
+	}
+
+	svc.recordMessages("cid", "sid", "tid", baseParams(), resp)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "user",
+				"completion_id":  "cid",
+				"sequence":       0,
+				"response.model": testModel,
+				"vendor":         "anthropic",
+				"ingest_source":  "Go",
+				"content":        testPrompt,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             fmt.Sprintf("%s-%d", testMessageID, 1),
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "assistant",
+				"completion_id":  "cid",
+				"sequence":       1,
+				"response.model": testModel,
+				"vendor":         "anthropic",
+				"ingest_source":  "Go",
+				"content":        testResponse,
+				"is_response":    true,
+			},
+		},
+	})
+}
+
+func TestRecordMessagesNilResp(t *testing.T) {
+	svc, app := newTestService(t)
+
+	svc.recordMessages("cid", "sid", "tid", baseParams(), nil)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "user",
+				"completion_id":  "cid",
+				"sequence":       0,
+				"response.model": testModel,
+				"vendor":         "anthropic",
+				"ingest_source":  "Go",
+				"content":        testPrompt,
+			},
+		},
+	})
+}
+
+func TestRecordMessagesContentDisabled(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil,
+		newrelic.ConfigAIMonitoringEnabled(true),
+		func(cfg *newrelic.Config) { cfg.AIMonitoring.RecordContent.Enabled = false },
+		noCodeLevelMetrics,
+	)
+	svc := &NRMessageService{
+		app:              app.Application,
+		customAttributes: make(map[string]interface{}),
+	}
+	resp := &anthropic.Message{
+		ID:    testMessageID,
+		Model: anthropic.Model(testModel),
+		Content: []anthropic.ContentBlockUnion{
+			{Type: "text", Text: testResponse},
+		},
+	}
+
+	svc.recordMessages("cid", "sid", "tid", baseParams(), resp)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "user",
+				"completion_id":  "cid",
+				"sequence":       0,
+				"response.model": testModel,
+				"vendor":         "anthropic",
+				"ingest_source":  "Go",
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             fmt.Sprintf("%s-%d", testMessageID, 1),
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "assistant",
+				"completion_id":  "cid",
+				"sequence":       1,
+				"response.model": testModel,
+				"vendor":         "anthropic",
+				"ingest_source":  "Go",
+				"is_response":    true,
+			},
+		},
+	})
+}
+
+// --- NRMessageStreamWrapper.Next state accumulation ---
+
+func TestStreamWrapperNextAccumulatesState(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := NewClient(app.Application, mockAnthropicServer(t, streamingHandler)...)
+
+	stream := nrClient.Messages.NewStreaming(context.Background(), anthropic.MessageNewParams{
+		Model:     anthropic.Model(testModel),
+		MaxTokens: 150,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(testPrompt)),
+		},
+	})
+
+	for stream.Next() {
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if stream.responseID != testMessageID {
+		t.Errorf("responseID: got %q, want %q", stream.responseID, testMessageID)
+	}
+	if stream.responseModel != testModel {
+		t.Errorf("responseModel: got %q, want %q", stream.responseModel, testModel)
+	}
+	if got := stream.responseText.String(); got != testResponse {
+		t.Errorf("responseText: got %q, want %q", got, testResponse)
+	}
+	if stream.stopReason != "end_turn" {
+		t.Errorf("stopReason: got %q, want %q", stream.stopReason, "end_turn")
+	}
+
+	stream.Close()
+}
+
+// --- NRMessageStreamWrapper.Close tests (post-refactor) ---
+
+func TestStreamWrapperCloseReturnsNilOnSuccess(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := NewClient(app.Application, mockAnthropicServer(t, streamingHandler)...)
+
+	stream := nrClient.Messages.NewStreaming(context.Background(), anthropic.MessageNewParams{
+		Model:     anthropic.Model(testModel),
+		MaxTokens: 150,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(testPrompt)),
+		},
+	})
+	for stream.Next() {
+	}
+
+	if err := stream.Close(); err != nil {
+		t.Errorf("Close() returned unexpected error: %v", err)
+	}
+}
+
+func TestStreamWrapperCloseEndsTxnWhenOwned(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := NewClient(app.Application, mockAnthropicServer(t, streamingHandler)...)
+
+	// No txn in context — wrapper creates and owns the transaction.
+	stream := nrClient.Messages.NewStreaming(context.Background(), anthropic.MessageNewParams{
+		Model:     anthropic.Model(testModel),
+		MaxTokens: 150,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(testPrompt)),
+		},
+	})
+	for stream.Next() {
+	}
+	stream.Close()
+
+	app.ExpectTxnEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "Transaction",
+				"name":      "OtherTransaction/Go/AnthropicMessageNewStreaming",
+				"guid":      internal.MatchAnything,
+				"priority":  internal.MatchAnything,
+				"sampled":   internal.MatchAnything,
+				"traceId":   internal.MatchAnything,
+				"timestamp": internal.MatchAnything,
+				"duration":  internal.MatchAnything,
+				"totalTime": internal.MatchAnything,
+			},
+			UserAttributes:  map[string]interface{}{},
+			AgentAttributes: map[string]interface{}{"llm": true},
+		},
+	})
+}
+
+func TestStreamWrapperCloseNoTxnEndWhenNotOwned(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := NewClient(app.Application, mockAnthropicServer(t, streamingHandler)...)
+
+	// Inject an existing txn — wrapper must NOT end it.
+	txn := app.StartTransaction("caller-txn")
+	ctx := newrelic.NewContext(context.Background(), txn)
+
+	stream := nrClient.Messages.NewStreaming(ctx, anthropic.MessageNewParams{
+		Model:     anthropic.Model(testModel),
+		MaxTokens: 150,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(testPrompt)),
+		},
+	})
+	for stream.Next() {
+	}
+	stream.Close()
+
+	// Txn is still open; end it explicitly and verify the name is caller-txn, not the wrapper name.
+	txn.End()
+
+	app.ExpectTxnEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "Transaction",
+				"name":      "OtherTransaction/Go/caller-txn",
+				"guid":      internal.MatchAnything,
+				"priority":  internal.MatchAnything,
+				"sampled":   internal.MatchAnything,
+				"traceId":   internal.MatchAnything,
+				"timestamp": internal.MatchAnything,
+				"duration":  internal.MatchAnything,
+				"totalTime": internal.MatchAnything,
+			},
+			UserAttributes:  map[string]interface{}{},
+			AgentAttributes: map[string]interface{}{"llm": true},
 		},
 	})
 }

--- a/v3/integrations/nranthropic/nranthropic_test.go
+++ b/v3/integrations/nranthropic/nranthropic_test.go
@@ -3,6 +3,7 @@ package nranthropic
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -275,6 +276,48 @@ func TestNRMessagesNewError(t *testing.T) {
 	})
 }
 
+func streamingHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+
+	writeSSE := func(eventType, data string) {
+		fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, data)
+	}
+
+	startMsg, _ := json.Marshal(map[string]interface{}{
+		"type": "message_start",
+		"message": map[string]interface{}{
+			"id":    testMessageID,
+			"type":  "message",
+			"role":  "assistant",
+			"model": testModel,
+			"usage": map[string]interface{}{"input_tokens": 9, "output_tokens": 0},
+		},
+	})
+	writeSSE("message_start", string(startMsg))
+
+	delta1, _ := json.Marshal(map[string]interface{}{
+		"type":  "content_block_delta",
+		"index": 0,
+		"delta": map[string]interface{}{"type": "text_delta", "text": testResponse},
+	})
+	writeSSE("content_block_delta", string(delta1))
+
+	msgDelta, _ := json.Marshal(map[string]interface{}{
+		"type":  "message_delta",
+		"delta": map[string]interface{}{"stop_reason": "end_turn", "stop_sequence": nil},
+		"usage": map[string]interface{}{"output_tokens": 12},
+	})
+	writeSSE("message_delta", string(msgDelta))
+
+	writeSSE("message_stop", `{"type":"message_stop"}`)
+
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 func TestNRMessagesNewWithExistingTxn(t *testing.T) {
 	client := mockAnthropicServer(t, successHandler)
 	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
@@ -305,6 +348,149 @@ func TestNRMessagesNewWithExistingTxn(t *testing.T) {
 			Intrinsics: map[string]interface{}{
 				"type":      "Transaction",
 				"name":      "OtherTransaction/Go/my-existing-txn",
+				"guid":      internal.MatchAnything,
+				"priority":  internal.MatchAnything,
+				"sampled":   internal.MatchAnything,
+				"traceId":   internal.MatchAnything,
+				"timestamp": internal.MatchAnything,
+				"duration":  internal.MatchAnything,
+				"totalTime": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{},
+			AgentAttributes: map[string]interface{}{
+				"llm": true,
+			},
+		},
+	})
+}
+
+func TestNRMessagesNewStreaming(t *testing.T) {
+	client := mockAnthropicServer(t, streamingHandler)
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := NewClient(app.Application, client)
+
+	stream := nrClient.Messages.NewStreaming(context.Background(), anthropic.MessageNewParams{
+		Model:     anthropic.Model(testModel),
+		MaxTokens: 150,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(testPrompt)),
+		},
+	})
+
+	for stream.Next() {
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                             internal.MatchAnything,
+				"span_id":                        internal.MatchAnything,
+				"trace_id":                       internal.MatchAnything,
+				"request.model":                  testModel,
+				"request.max_tokens":             int64(150),
+				"vendor":                         "anthropic",
+				"ingest_source":                  "Go",
+				"duration":                       internal.MatchAnything,
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "end_turn",
+				"response.number_of_messages":    2,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       0,
+				"role":           "user",
+				"content":        testPrompt,
+				"vendor":         "anthropic",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       1,
+				"role":           "assistant",
+				"content":        testResponse,
+				"vendor":         "anthropic",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+				"is_response":    true,
+			},
+		},
+	})
+}
+
+func TestNRMessagesNewStreamingAIMonitoringNotEnabled(t *testing.T) {
+	client := mockAnthropicServer(t, streamingHandler)
+	app := integrationsupport.NewTestApp(nil) // AI monitoring NOT enabled
+	nrClient := NewClient(app.Application, client)
+
+	stream := nrClient.Messages.NewStreaming(context.Background(), anthropic.MessageNewParams{
+		Model:     anthropic.Model(testModel),
+		MaxTokens: 150,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(testPrompt)),
+		},
+	})
+	for stream.Next() {
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+	app.ExpectCustomEvents(t, []internal.WantEvent{})
+}
+
+func TestNRMessagesNewStreamingWithExistingTxn(t *testing.T) {
+	client := mockAnthropicServer(t, streamingHandler)
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := NewClient(app.Application, client)
+
+	txn := app.StartTransaction("my-existing-streaming-txn")
+	ctx := newrelic.NewContext(context.Background(), txn)
+
+	stream := nrClient.Messages.NewStreaming(ctx, anthropic.MessageNewParams{
+		Model:     anthropic.Model(testModel),
+		MaxTokens: 150,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(testPrompt)),
+		},
+	})
+	for stream.Next() {
+	}
+	stream.Close()
+	txn.End()
+
+	app.ExpectTxnEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "Transaction",
+				"name":      "OtherTransaction/Go/my-existing-streaming-txn",
 				"guid":      internal.MatchAnything,
 				"priority":  internal.MatchAnything,
 				"sampled":   internal.MatchAnything,

--- a/v3/integrations/nrawsbedrock/go.mod
+++ b/v3/integrations/nrawsbedrock/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.7.3
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.50.4
 	github.com/google/uuid v1.6.0
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrawssdk-v1/go.mod
+++ b/v3/integrations/nrawssdk-v1/go.mod
@@ -8,7 +8,7 @@ go 1.25
 require (
 	// v1.15.0 is the first aws-sdk-go version with module support.
 	github.com/aws/aws-sdk-go v1.34.0
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrawssdk-v2/go.mod
+++ b/v3/integrations/nrawssdk-v2/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.34.6
 	github.com/aws/smithy-go v1.24.2
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrb3/go.mod
+++ b/v3/integrations/nrb3/go.mod
@@ -2,7 +2,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrb3
 
 go 1.25
 
-require github.com/newrelic/go-agent/v3 v3.43.3
+require github.com/newrelic/go-agent/v3 v3.44.0
 
 
 replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nrconnect/example/go.mod
+++ b/v3/integrations/nrconnect/example/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	connectrpc.com/connect v1.16.2
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/newrelic/go-agent/v3/integrations/nrconnect v0.0.0
 	golang.org/x/net v0.38.0
 	google.golang.org/protobuf v1.34.2

--- a/v3/integrations/nrconnect/go.mod
+++ b/v3/integrations/nrconnect/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	connectrpc.com/connect v1.16.2
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	google.golang.org/protobuf v1.34.2
 )
 

--- a/v3/integrations/nrecho-v3/go.mod
+++ b/v3/integrations/nrecho-v3/go.mod
@@ -8,7 +8,7 @@ require (
 	// v3.1.0 is the earliest v3 version of Echo that works with modules due
 	// to the github.com/rsc/letsencrypt import of v3.0.0.
 	github.com/labstack/echo v3.1.0+incompatible
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrecho-v4/go.mod
+++ b/v3/integrations/nrecho-v4/go.mod
@@ -6,7 +6,7 @@ go 1.25
 
 require (
 	github.com/labstack/echo/v4 v4.9.0
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrelasticsearch-v7/go.mod
+++ b/v3/integrations/nrelasticsearch-v7/go.mod
@@ -6,7 +6,7 @@ go 1.25
 
 require (
 	github.com/elastic/go-elasticsearch/v7 v7.17.0
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrfasthttp/examples/client-fasthttp/go.mod
+++ b/v3/integrations/nrfasthttp/examples/client-fasthttp/go.mod
@@ -3,7 +3,7 @@ module client-example
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/newrelic/go-agent/v3/integrations/nrfasthttp v1.0.0
 	github.com/valyala/fasthttp v1.49.0
 )

--- a/v3/integrations/nrfasthttp/examples/server-fasthttp/go.mod
+++ b/v3/integrations/nrfasthttp/examples/server-fasthttp/go.mod
@@ -3,7 +3,7 @@ module server-example
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/newrelic/go-agent/v3/integrations/nrfasthttp v1.0.0
 	github.com/valyala/fasthttp v1.49.0
 )

--- a/v3/integrations/nrfasthttp/go.mod
+++ b/v3/integrations/nrfasthttp/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrfasthttp
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/valyala/fasthttp v1.49.0
 )
 

--- a/v3/integrations/nrfiber/go.mod
+++ b/v3/integrations/nrfiber/go.mod
@@ -4,30 +4,10 @@ go 1.25
 
 require (
 	github.com/gofiber/fiber/v2 v2.52.13
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/stretchr/testify v1.10.0
 	github.com/valyala/fasthttp v1.51.0
 )
 
-require (
-	github.com/andybalholm/brotli v1.1.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/klauspost/compress v1.17.9 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/tcplisten v1.0.0 // indirect
-	golang.org/x/net v0.49.0 // indirect
-	golang.org/x/sys v0.40.0 // indirect
-	golang.org/x/text v0.33.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 // indirect
-	google.golang.org/grpc v1.80.0 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
 
 replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nrfiber/go.mod
+++ b/v3/integrations/nrfiber/go.mod
@@ -3,11 +3,31 @@ module github.com/newrelic/go-agent/v3/integrations/nrfiber
 go 1.25
 
 require (
-	github.com/gofiber/fiber/v2 v2.52.12
+	github.com/gofiber/fiber/v2 v2.52.13
 	github.com/newrelic/go-agent/v3 v3.43.3
 	github.com/stretchr/testify v1.10.0
 	github.com/valyala/fasthttp v1.51.0
 )
 
+require (
+	github.com/andybalholm/brotli v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/klauspost/compress v1.17.9 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/tcplisten v1.0.0 // indirect
+	golang.org/x/net v0.49.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
+	golang.org/x/text v0.33.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 // indirect
+	google.golang.org/grpc v1.80.0 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
 
 replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nrgin/go.mod
+++ b/v3/integrations/nrgin/go.mod
@@ -6,7 +6,7 @@ go 1.25
 
 require (
 	github.com/gin-gonic/gin v1.9.1
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrgochi/go.mod
+++ b/v3/integrations/nrgochi/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/go-chi/chi/v5 v5.2.2
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nrgocqlx/LICENSE.txt
+++ b/v3/integrations/nrgocqlx/LICENSE.txt
@@ -1,0 +1,206 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+Versions 3.8.0 and above for this project are licensed under Apache 2.0. For
+prior versions of this project, please see the LICENCE.txt file in the root
+directory of that version for more information.

--- a/v3/integrations/nrgocqlx/README.md
+++ b/v3/integrations/nrgocqlx/README.md
@@ -1,0 +1,10 @@
+# v3/integrations/nrgocqlx [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgocqlx?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgocqlx)
+
+Package `nrgocqlx` instruments https://github.com/scylladb/gocqlx.
+
+```go
+import "github.com/newrelic/go-agent/v3/integrations/nrgocqlx"
+```
+
+For more information, see
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrgocqlx).

--- a/v3/integrations/nrgocqlx/example/main.go
+++ b/v3/integrations/nrgocqlx/example/main.go
@@ -1,0 +1,158 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Run a local Scylla instance in Docker:
+//
+//	docker run --name my-scylla \
+//	  -p 9042:9042 \
+//	  -d scylladb/scylla \
+//	  --developer-mode 1 \
+//	  --memory 1G \
+//	  --smp 1 \
+//	  --rpc-address 0.0.0.0 \
+//	  --broadcast-rpc-address 127.0.0.1
+//
+// Create the keyspace:
+//
+//	docker exec -it my-scylla cqlsh -e "CREATE KEYSPACE IF NOT EXISTS example WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};"
+//
+// Create the table:
+//
+//	docker exec -it my-scylla cqlsh -e "CREATE TABLE IF NOT EXISTS example.tweet (timeline text, id uuid, text text, PRIMARY KEY (timeline, id));"
+//
+// Set NEW_RELIC_LICENSE_KEY then run with `go run main.go`.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	gocql "github.com/gocql/gocql"
+	"github.com/scylladb/gocqlx/v3/qb"
+	"github.com/scylladb/gocqlx/v3/table"
+
+	"github.com/newrelic/go-agent/v3/integrations/nrgocqlx"
+	"github.com/newrelic/go-agent/v3/newrelic"
+)
+
+type Tweet struct {
+	Timeline string
+	ID       gocql.UUID
+	Text     string
+}
+
+func main() {
+	app, err := newrelic.NewApplication(
+		newrelic.ConfigAppName("Cassandra Example"),
+		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+		newrelic.ConfigDistributedTracerEnabled(true),
+		newrelic.ConfigDebugLogger(os.Stdout),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = app.WaitForConnection(10 * time.Second)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer app.Shutdown(10 * time.Second)
+
+	cluster := gocql.NewCluster("127.0.0.1")
+	cluster.Consistency = gocql.One
+	cluster.Keyspace = "example"
+	cluster.ConnectTimeout = 15 * time.Second
+	cluster.Timeout = 10 * time.Second
+
+	// Set the New Relic query and batch observers
+	cluster.QueryObserver = nrgocqlx.NewQueryObserver(nil)
+	cluster.BatchObserver = nrgocqlx.NewBatchObserver(nil)
+	session, err := nrgocqlx.NRGoCQLXWrapSession(cluster)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer session.Close()
+
+	// Start a New Relic transaction
+	txn := app.StartTransaction("gocqlx-operations")
+	defer txn.End()
+
+	// Add transaction to context
+	ctx := newrelic.NewContext(context.Background(), txn)
+	var tweetMetadata = table.Metadata{
+		Name:    "tweet",
+		Columns: []string{"timeline", "id", "text"},
+		PartKey: []string{"timeline"},
+		SortKey: []string{"id"},
+	}
+	tweetTable := table.New(tweetMetadata)
+
+	uuid := gocql.TimeUUID()
+
+	/*
+		Insert a tweet with the above UUID
+	*/
+	insertStruct := Tweet{
+		Timeline: "timeline",
+		ID:       uuid,
+		Text:     "hello world",
+	}
+	stmt, names := tweetTable.Insert()
+	insertQuery := session.ContextQuery(ctx, stmt, names).BindStruct(insertStruct)
+	if err := insertQuery.ExecRelease(); err != nil {
+		log.Fatal(err)
+	}
+
+	/*
+		Insert several more tweets in a single batch
+	*/
+	batchTweets := []Tweet{
+		{Timeline: "timeline", ID: gocql.TimeUUID(), Text: "hello batch 1"},
+		{Timeline: "timeline", ID: gocql.TimeUUID(), Text: "hello batch 2"},
+		{Timeline: "timeline", ID: gocql.TimeUUID(), Text: "hello batch 3"},
+	}
+	batchQuery := session.ContextQuery(ctx, stmt, names)
+	batch := session.ContextBatch(ctx, gocql.LoggedBatch)
+	for _, t := range batchTweets {
+		if err := batch.BindStruct(batchQuery, t); err != nil {
+			log.Fatal(err)
+		}
+	}
+	if err := batch.Exec(); err != nil {
+		log.Fatal(err)
+	}
+
+	/*
+		Select all tweets with the above timeline
+	*/
+	var tweets []Tweet
+	selectMap := qb.M{"timeline": "timeline"}
+	stmt, names = tweetTable.Select()
+	selectQuery := session.ContextQuery(ctx, stmt, names).BindMap(selectMap)
+	if err := selectQuery.SelectRelease(&tweets); err != nil {
+		log.Fatal(err)
+	}
+
+	/*
+		Get tweet with the above UUID
+	*/
+	getStruct := Tweet{
+		Timeline: "timeline",
+		ID:       uuid,
+		Text:     "hello world",
+	}
+	stmt, names = tweetTable.Get()
+	getQuery := session.ContextQuery(ctx, stmt, names).BindStruct(getStruct)
+	if err := getQuery.GetRelease(&getStruct); err != nil {
+		log.Fatal(err)
+	}
+
+	/*
+		Display results
+	*/
+	fmt.Printf("\n\n\nNew Inserted row: %v\n\n\n", getStruct)
+	fmt.Printf("\n\n\nTweets containing timeline: %v", tweets)
+
+}

--- a/v3/integrations/nrgocqlx/go.mod
+++ b/v3/integrations/nrgocqlx/go.mod
@@ -1,0 +1,27 @@
+module github.com/newrelic/go-agent/v3/integrations/nrgocqlx
+
+go 1.25.0
+
+replace github.com/newrelic/go-agent/v3 => ../..
+
+replace github.com/gocql/gocql => github.com/scylladb/gocql v1.16.0
+
+require (
+	github.com/gocql/gocql v1.7.0
+	github.com/newrelic/go-agent/v3 v3.0.0-00010101000000-000000000000
+	github.com/scylladb/gocqlx/v3 v3.0.4
+)
+
+require github.com/scylladb/go-reflectx v1.0.1 // indirect
+
+require (
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/klauspost/compress v1.18.1 // indirect
+	golang.org/x/net v0.46.0 // indirect
+	golang.org/x/sys v0.37.0 // indirect
+	golang.org/x/text v0.30.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240528184218-531527333157 // indirect
+	google.golang.org/grpc v1.65.0 // indirect
+	google.golang.org/protobuf v1.34.2 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+)

--- a/v3/integrations/nrgocqlx/go.mod
+++ b/v3/integrations/nrgocqlx/go.mod
@@ -7,7 +7,7 @@ replace github.com/gocql/gocql => github.com/scylladb/gocql v1.16.0
 
 require (
 	github.com/gocql/gocql v1.7.0
-	github.com/newrelic/go-agent/v3 v3.44.0-00010101000000-000000000000
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/scylladb/gocqlx/v3 v3.0.4
 )
 

--- a/v3/integrations/nrgocqlx/go.mod
+++ b/v3/integrations/nrgocqlx/go.mod
@@ -1,27 +1,15 @@
 module github.com/newrelic/go-agent/v3/integrations/nrgocqlx
 
-go 1.25.0
+go 1.25
 
-replace github.com/newrelic/go-agent/v3 => ../..
 
 replace github.com/gocql/gocql => github.com/scylladb/gocql v1.16.0
 
 require (
 	github.com/gocql/gocql v1.7.0
-	github.com/newrelic/go-agent/v3 v3.0.0-00010101000000-000000000000
+	github.com/newrelic/go-agent/v3 v3.44.0-00010101000000-000000000000
 	github.com/scylladb/gocqlx/v3 v3.0.4
 )
 
-require github.com/scylladb/go-reflectx v1.0.1 // indirect
 
-require (
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/klauspost/compress v1.18.1 // indirect
-	golang.org/x/net v0.46.0 // indirect
-	golang.org/x/sys v0.37.0 // indirect
-	golang.org/x/text v0.30.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240528184218-531527333157 // indirect
-	google.golang.org/grpc v1.65.0 // indirect
-	google.golang.org/protobuf v1.34.2 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
-)
+replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nrgocqlx/nrgocqlx.go
+++ b/v3/integrations/nrgocqlx/nrgocqlx.go
@@ -1,0 +1,653 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package nrgocqlx instruments https://github.com/scylladb/gocqlx/
+
+Use this package to instrument your ScyllaDB calls using the gocqlx package.
+
+To instrument your database operations, set the *gocql.ClusterConfig.QueryObserver
+and/or the *gocql.ClusterConfig.BatchObserver to an instrumented observer.  These will
+be nrgocqlx.NewQueryObserver and nrgocqlx.NewBatchObserver respectively.
+
+After setting the observer, call nrgocqlx.NRGoCQLXWrapSession(cluster).  This returns a
+wrapped *gocqlx.Session which can be used to execute queries.  Only ContextBatch and
+ContextQuery on the wrapped session record database operations; all other *gocqlx.Session
+methods pass through unchanged.
+
+NOTE: Calls to ContextQuery return a *nrgocqlx.NRGocqlxQueryxWrapper which wraps a
+*gocqlx.Queryx, and calls to ContextBatch return a *nrgocqlx.NRGocqlxBatchWrapper which
+wraps a *gocqlx.Batch.  Both wrappers allow chaining, but only the methods reimplemented
+on the wrapper produce segments — chaining off any other method silently drops
+instrumentation.
+
+For example:
+
+	import (
+		"log"
+
+		gocql "github.com/gocql/gocql"
+		"github.com/newrelic/go-agent/v3/integrations/nrgocqlx"
+	)
+
+	func main() {
+		cluster := gocql.NewCluster("127.0.0.1")
+
+		// Set the New Relic observers
+		cluster.QueryObserver = nrgocqlx.NewQueryObserver(nil)
+		cluster.BatchObserver = nrgocqlx.NewBatchObserver(nil)
+
+		session, err := nrgocqlx.NRGoCQLXWrapSession(cluster)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer session.Close()
+
+		// This will record a database operation because BindStruct is implemented by *nrgocqlx.NRGocqlxQueryxWrapper.
+		insertQuery := session.ContextQuery(ctx, stmt, names).BindStruct(insertStruct)
+		if err := insertQuery.ExecRelease(); err != nil {
+			log.Fatal(err)
+		}
+
+		// This will NOT record a database operation because DefaultTimestamp is not implemented by *nrgocqlx.NRGocqlxQueryxWrapper.
+		_ = session.ContextQuery(ctx, stmt, names).DefaultTimestamp(true)
+	}
+*/
+package nrgocqlx
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	gocql "github.com/gocql/gocql"
+	"github.com/newrelic/go-agent/v3/internal"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v3/newrelic/cqlparse"
+	"github.com/scylladb/gocqlx/v3"
+)
+
+func init() { internal.TrackUsage("integration", "datastore", "gocql") }
+
+type gocqlContextKey string
+
+var (
+	queryKey gocqlContextKey = "nrGocqlxSegment"
+	batchKey gocqlContextKey = "nrGocqlxBatchSegment"
+)
+
+/*
+queryObserver contains the implementation for ObserveQuery
+and a field for the original ObserveQuery if the user chooses to
+call it
+*/
+type queryObserver struct {
+	original interface {
+		ObserveQuery(ctx context.Context, query gocql.ObservedQuery)
+	}
+}
+
+/*
+batchObserver contains the implementation for ObserveBatch
+and a field for the original ObserveBatch if the user chooses to
+call it
+*/
+type batchObserver struct {
+	original interface {
+		ObserveBatch(ctx context.Context, batch gocql.ObservedBatch)
+	}
+}
+
+/*
+Wrapper for gocqlx.Session that implements gocqlx.Session.ContextQuery. All other gocqlx.Session
+functions are accessible through this struct's embedded field *gocqlx.Session. This wrapper
+does not implement any gocql.Session functions, however those functions are also accessible through
+embedded fields. The wrapper's implementation of ContextQuery must be used in order to instrument
+with New Relic properly.
+*/
+type NRGocqlxSessionWrapper struct {
+	*gocqlx.Session
+}
+
+/*
+Wrapper for gocqlx.Queryx that implements gocqlx.Queryx functions: Bind, BindMap, BindStruct,
+BindStructMap, SelectRelease, Select, GetRelease, Get, GetCAS, GetCASRelease, ExecRelease, Exec,
+ExecCAS, ExecCASRelease and Scan. All other gocqlx.Queryx functions are accessible through this
+struct's embedded field *gocqlx.Queryx.  This wrapper does not implement any gocql.Query functions,
+however those functions are also accessible through embedded fields.  NOTE: In order to properly
+instrument with New Relic, you must use only the implemented functions for NRGocqlxQueryxWrapper,
+especially if you are chaining.
+*/
+type NRGocqlxQueryxWrapper struct {
+	*gocqlx.Queryx
+	segmentRunner    func(fn func() error) error
+	CASSegmentRunner func(fn func() (bool, error)) (bool, error)
+}
+
+/*
+Wrapper for gocqlx.Batch that implements gocqlx.Batch functions: Bind, BindMap, BindStruct,
+BindStructMap, Query, Exec, WithContext, SetRequestTimeout, SetHostID, DefaultTimestamp,
+WithTimestamp, Observer, RetryPolicy, SerialConsistency, SpeculativeExecutionPolicy and Trace.
+All other gocqlx.Batch functions are accessible through this struct's embedded field *gocqlx.Batch.
+NOTE: In order to properly instrument with New Relic, you must use only the implemented functions
+for NRGocqlxBatchWrapper,
+especially if you are chaining.
+*/
+type NRGocqlxBatchWrapper struct {
+	*gocqlx.Batch
+	segmentRunner    func(fn func() error) error
+	CASSegmentRunner func(fn func() (bool, error)) (bool, error)
+}
+
+/*
+Call that wraps a gocqlx.Session.  This function takes a gocql.ClusterConfig and returns a
+NRGocqlxSessionWrapper.
+*/
+func NRGoCQLXWrapSession(cluster *gocql.ClusterConfig) (*NRGocqlxSessionWrapper, error) {
+	session, err := gocqlx.WrapSession(cluster.CreateSession())
+	if err != nil {
+		return nil, err
+	}
+	return &NRGocqlxSessionWrapper{&session}, nil
+}
+
+/*
+Executes a passed in function while beginning a New Relic Datastore Segment. This function does
+not accept a spread operator and only will function for one destination. If a transaction
+cannot be pulled from context, no segment will be created but the passed in function will still execute. The
+segment gets populated with its StartTime and Product as the function that is called will enrich the rest of
+the segment.  The segment is stored in context to be enriched later.
+*/
+func execOriginal(ctx context.Context, fn func(ctx context.Context) error, contextKey gocqlContextKey) error {
+	txn := newrelic.FromContext(ctx)
+	if txn == nil {
+		return fn(ctx)
+	}
+
+	// start datastore segment
+	sgmt := &newrelic.DatastoreSegment{
+		StartTime: txn.StartSegmentNow(),
+		Product:   newrelic.DatastoreCassandra,
+	}
+	defer sgmt.End()
+
+	// security agent?
+	ctx = context.WithValue(ctx, contextKey, sgmt)
+	return fn(ctx) // enriching of sgmt called within fn()
+}
+
+/*
+Executes a passed in function while beginning a New Relic Datastore Segment. This function is to be
+used with any lightweight queries.  It will return a bool in addition to an error to indicate if a
+query was applied.  If a transaction cannot be pulled from context, no segment will be created but
+the passed in function will still execute. The segment gets populated with its StartTime and Product
+as the function that is called will enrich the rest of the segment.  The segment is stored in context
+to be enriched later.
+*/
+func execOriginalCAS(ctx context.Context, fn func(ctx context.Context) (bool, error), contextKey gocqlContextKey) (bool, error) {
+	txn := newrelic.FromContext(ctx)
+	if txn == nil {
+		return fn(ctx)
+	}
+
+	// start datastore segment
+	sgmt := &newrelic.DatastoreSegment{
+		StartTime: txn.StartSegmentNow(),
+		Product:   newrelic.DatastoreCassandra,
+	}
+	defer sgmt.End()
+
+	// security agent?
+	ctx = context.WithValue(ctx, contextKey, sgmt)
+	return fn(ctx) // enriching of sgmt called within fn()
+}
+
+/*
+Returns a new NRGocqlxQueryxWrapper.  This sets the Queryx field to the passed in parameter queryx,
+the segmentRunner field, and the CASSegmentRunner.
+*/
+func newNRGocqlxQueryxWrapper(queryx *gocqlx.Queryx) *NRGocqlxQueryxWrapper {
+	w := &NRGocqlxQueryxWrapper{Queryx: queryx}
+	w.segmentRunner = func(fn func() error) error {
+		return execOriginal(w.Context(), func(ctx context.Context) error {
+			w.Query = w.Query.WithContext(ctx)
+			return fn()
+		}, queryKey)
+	}
+	w.CASSegmentRunner = func(fn func() (bool, error)) (bool, error) {
+		return execOriginalCAS(w.Context(), func(ctx context.Context) (bool, error) {
+			w.Query = w.Query.WithContext(ctx)
+			return fn()
+		}, queryKey)
+	}
+	return w
+}
+
+/*
+Returns a new NRGocqlxBatchWrapper.  This sets the Batch field to the passed in parameter batch
+and the segmentRunner field.
+*/
+func newNRGocqlxBatchWrapper(batch *gocqlx.Batch) *NRGocqlxBatchWrapper {
+	w := &NRGocqlxBatchWrapper{Batch: batch}
+	w.segmentRunner = func(fn func() error) error {
+		return execOriginal(w.Context(), func(ctx context.Context) error {
+			w.Batch = w.Batch.WithContext(ctx)
+			return fn()
+		}, batchKey)
+	}
+	return w
+}
+
+/*
+Sets the NRGocqlxBatchWrapper.Batch to the parameter batch and returns the wrapper.  This should be
+called by any NRGocqlxBatchWrapper methods (such as WithContext) that return a NRGocqlxBatchWrapper.
+*/
+func (b *NRGocqlxBatchWrapper) withBatch(batch *gocqlx.Batch) *NRGocqlxBatchWrapper {
+	b.Batch = batch
+	return b
+}
+
+/*
+Binds query positional parameters to values from args.  Use this function, which belongs to the
+wrapper NRGocqlxBatchWrapper, to add a statement to the batch.  If you use gocqlx.Batch.Bind, you
+will not be able to instrument with New Relic.
+*/
+func (b *NRGocqlxBatchWrapper) Bind(qry *NRGocqlxQueryxWrapper, args ...any) error {
+	return b.Batch.Bind(qry.Queryx, args...)
+}
+
+/*
+Binds query named parameters to values from a map.  Use this function, which belongs to the
+wrapper NRGocqlxBatchWrapper, to add a statement to the batch.  If you use gocqlx.Batch.BindMap,
+you will not be able to instrument with New Relic.
+*/
+func (b *NRGocqlxBatchWrapper) BindMap(qry *NRGocqlxQueryxWrapper, arg map[string]any) error {
+	return b.Batch.BindMap(qry.Queryx, arg)
+}
+
+/*
+Binds query named parameters to values from a struct.  Use this function, which belongs to the
+wrapper NRGocqlxBatchWrapper, to add a statement to the batch.  If you use gocqlx.Batch.BindStruct,
+you will not be able to instrument with New Relic.
+*/
+func (b *NRGocqlxBatchWrapper) BindStruct(qry *NRGocqlxQueryxWrapper, arg any) error {
+	return b.Batch.BindStruct(qry.Queryx, arg)
+}
+
+/*
+Binds query named parameters to values from a struct and a map.  Use this function, which belongs
+to the wrapper NRGocqlxBatchWrapper, to add a statement to the batch.  If you use
+gocqlx.Batch.BindStructMap, you will not be able to instrument with New Relic.
+*/
+func (b *NRGocqlxBatchWrapper) BindStructMap(qry *NRGocqlxQueryxWrapper, arg0 any, arg1 map[string]any) error {
+	return b.Batch.BindStructMap(qry.Queryx, arg0, arg1)
+}
+
+/*
+Adds a raw statement with positional arguments to the batch and returns the wrapper for chaining.
+Use this function, which belongs to the wrapper NRGocqlxBatchWrapper, to add a statement to the
+batch.  If you use gocqlx.Batch.Query, you will not be able to instrument with New Relic.
+*/
+func (b *NRGocqlxBatchWrapper) Query(stmt string, args ...any) *NRGocqlxBatchWrapper {
+	return b.withBatch(b.Batch.Query(stmt, args...))
+}
+
+/*
+Returns a shallow copy of the batch with its context set to ctx and returns the wrapper for
+chaining.  Use this function, which belongs to the wrapper NRGocqlxBatchWrapper, to set the
+context.  If you use gocqlx.Batch.WithContext, you will not be able to instrument with New Relic.
+*/
+func (b *NRGocqlxBatchWrapper) WithContext(ctx context.Context) *NRGocqlxBatchWrapper {
+	return b.withBatch(b.Batch.WithContext(ctx))
+}
+
+/*
+Sets the time the driver waits for a server response and returns the wrapper for chaining.  Use
+this function, which belongs to the wrapper NRGocqlxBatchWrapper, to configure the timeout.  If you
+use gocqlx.Batch.SetRequestTimeout, you will not be able to instrument with New Relic.
+*/
+func (b *NRGocqlxBatchWrapper) SetRequestTimeout(timeout time.Duration) *NRGocqlxBatchWrapper {
+	return b.withBatch(b.Batch.SetRequestTimeout(timeout))
+}
+
+/*
+Pins the batch to a specific host by ID and returns the wrapper for chaining.  Use this function,
+which belongs to the wrapper NRGocqlxBatchWrapper, to set the host.  If you use
+gocqlx.Batch.SetHostID, you will not be able to instrument with New Relic.
+*/
+func (b *NRGocqlxBatchWrapper) SetHostID(hostID string) *NRGocqlxBatchWrapper {
+	return b.withBatch(b.Batch.SetHostID(hostID))
+}
+
+/*
+Enables or disables the default timestamp flag on the batch and returns the wrapper for chaining.
+Use this function, which belongs to the wrapper NRGocqlxBatchWrapper, to configure the timestamp
+behavior.  If you use gocqlx.Batch.DefaultTimestamp, you will not be able to instrument with New
+Relic.
+*/
+func (b *NRGocqlxBatchWrapper) DefaultTimestamp(enable bool) *NRGocqlxBatchWrapper {
+	return b.withBatch(b.Batch.DefaultTimestamp(enable))
+}
+
+/*
+Sets an explicit timestamp on the batch and returns the wrapper for chaining.  Use this function,
+which belongs to the wrapper NRGocqlxBatchWrapper, to set the timestamp.  If you use
+gocqlx.Batch.WithTimestamp, you will not be able to instrument with New Relic.
+*/
+func (b *NRGocqlxBatchWrapper) WithTimestamp(timestamp int64) *NRGocqlxBatchWrapper {
+	return b.withBatch(b.Batch.WithTimestamp(timestamp))
+}
+
+/*
+Sets a batch-level observer and returns the wrapper for chaining.  Use this function, which belongs
+to the wrapper NRGocqlxBatchWrapper, to attach an observer.  If you use gocqlx.Batch.Observer, you
+will not be able to instrument with New Relic.
+*/
+func (b *NRGocqlxBatchWrapper) Observer(observer gocql.BatchObserver) *NRGocqlxBatchWrapper {
+	return b.withBatch(b.Batch.Observer(observer))
+}
+
+/*
+Sets the retry policy for the batch and returns the wrapper for chaining.  Use this function, which
+belongs to the wrapper NRGocqlxBatchWrapper, to configure retries.  If you use
+gocqlx.Batch.RetryPolicy, you will not be able to instrument with New Relic.
+*/
+func (b *NRGocqlxBatchWrapper) RetryPolicy(policy gocql.RetryPolicy) *NRGocqlxBatchWrapper {
+	return b.withBatch(b.Batch.RetryPolicy(policy))
+}
+
+/*
+Sets the serial consistency level for conditional updates in the batch and returns the wrapper for
+chaining.  Use this function, which belongs to the wrapper NRGocqlxBatchWrapper, to configure
+serial consistency.  If you use gocqlx.Batch.SerialConsistency, you will not be able to instrument
+with New Relic.
+*/
+func (b *NRGocqlxBatchWrapper) SerialConsistency(cons gocql.Consistency) *NRGocqlxBatchWrapper {
+	return b.withBatch(b.Batch.SerialConsistency(cons))
+}
+
+/*
+Sets the speculative execution policy for the batch and returns the wrapper for chaining.  Use this
+function, which belongs to the wrapper NRGocqlxBatchWrapper, to configure speculative execution.
+If you use gocqlx.Batch.SpeculativeExecutionPolicy, you will not be able to instrument with New
+Relic.
+*/
+func (b *NRGocqlxBatchWrapper) SpeculativeExecutionPolicy(policy gocql.SpeculativeExecutionPolicy) *NRGocqlxBatchWrapper {
+	return b.withBatch(b.Batch.SpeculativeExecutionPolicy(policy))
+}
+
+/*
+Enables tracing on the batch and returns the wrapper for chaining.  Use this function, which
+belongs to the wrapper NRGocqlxBatchWrapper, to attach a tracer.  If you use gocqlx.Batch.Trace,
+you will not be able to instrument with New Relic.
+*/
+func (b *NRGocqlxBatchWrapper) Trace(trace gocql.Tracer) *NRGocqlxBatchWrapper {
+	return b.withBatch(b.Batch.Trace(trace))
+}
+
+/*
+Executes the batch.  This function calls execOriginal with a function that calls gocqlx.Batch.Exec
+with updated context.
+*/
+func (b *NRGocqlxBatchWrapper) Exec() error {
+	return b.segmentRunner(func() error {
+		return b.Batch.Exec()
+	})
+}
+
+/*
+Returns a wrapper NRGocqlxQueryxWrapper which contains embedded fields and overridden implementations
+for gocqlx.Queryx.
+*/
+func (s *NRGocqlxSessionWrapper) ContextQuery(ctx context.Context, stmt string, names []string) *NRGocqlxQueryxWrapper {
+	return newNRGocqlxQueryxWrapper(s.Session.ContextQuery(ctx, stmt, names))
+}
+
+func (s *NRGocqlxSessionWrapper) ContextBatch(ctx context.Context, bt gocql.BatchType) *NRGocqlxBatchWrapper {
+	return newNRGocqlxBatchWrapper(s.Session.ContextBatch(ctx, bt))
+}
+
+/*
+Sets the NRGocqlxQueryxWrapper.Queryx to the parameter q and returns the wrapper.  This should be
+called by any NRGocqlxQueryxWrapper methods (such as Bind) that return a NRGocqlxQueryxWrapper.
+*/
+func (x *NRGocqlxQueryxWrapper) withQueryx(queryx *gocqlx.Queryx) *NRGocqlxQueryxWrapper {
+	x.Queryx = queryx
+	return x
+}
+
+/*
+Sets the arguments of a query.  Use this function, which belongs to the wrapper NRGocqlxQueryxWrapper,
+to set the arguments and return a NRGocqlxQueryxWrapper.  If you use gocqlx.Queryx.Bind, you will not be able
+to instrument with New Relic.
+*/
+func (x *NRGocqlxQueryxWrapper) Bind(v ...any) *NRGocqlxQueryxWrapper {
+	return x.withQueryx(x.Queryx.Bind(v...))
+}
+
+/*
+Sets the arguments of a query using a map.  Use this function, which belongs to the wrapper NRGocqlxQueryxWrapper,
+to set the arguments and return a NRGocqlxQueryxWrapper.  If you use gocqlx.Queryx.BindMap, you will not be able
+to instrument with New Relic.
+*/
+func (x *NRGocqlxQueryxWrapper) BindMap(arg map[string]any) *NRGocqlxQueryxWrapper {
+	return x.withQueryx(x.Queryx.BindMap(arg))
+}
+
+/*
+Sets the arguments of a query using a struct.  Use this function, which belongs to the wrapper NRGocqlxQueryxWrapper,
+to set the arguments and return a NRGocqlxQueryxWrapper.  If you use gocqlx.Queryx.BindStruct, you will not be able
+to instrument with New Relic.
+*/
+func (x *NRGocqlxQueryxWrapper) BindStruct(arg any) *NRGocqlxQueryxWrapper {
+	return x.withQueryx(x.Queryx.BindStruct(arg))
+}
+
+/*
+Sets the arguments of a struct on a map.  Use this function, which belongs to the wrapper NRGocqlxQueryxWrapper,
+to set the arguments and return a NRGocqlxQueryxWrapper.  If you use gocqlx.Queryx.BindStructMap, you will not be able
+to instrument with New Relic.
+*/
+func (x *NRGocqlxQueryxWrapper) BindStructMap(arg0 any, arg1 map[string]any) *NRGocqlxQueryxWrapper {
+	return x.withQueryx(x.Queryx.BindStructMap(arg0, arg1))
+}
+
+/*
+Run a Select query and release it immediately after.  Released queries cannot be reused.  This function calls
+execOriginal with a function that calls gocqlx.Queryx.SelectRelease with updated context.
+*/
+func (x *NRGocqlxQueryxWrapper) SelectRelease(dest any) error {
+	return x.segmentRunner(func() error { return x.Queryx.SelectRelease(dest) })
+}
+
+/*
+Run a Select query. This function calls execOriginal with a function that calls gocqlx.Queryx.Select with
+updated context.
+*/
+func (x *NRGocqlxQueryxWrapper) Select(dest any) error {
+	return x.segmentRunner(func() error { return x.Queryx.Select(dest) })
+}
+
+/*
+Run a Get query and release it immediately after.  Released queries cannot be reused.  This function calls
+execOriginal with a function that calls gocqlx.Queryx.Get with updated context.
+*/
+func (x *NRGocqlxQueryxWrapper) GetRelease(dest any) error {
+	return x.segmentRunner(func() error { return x.Queryx.GetRelease(dest) })
+}
+
+/*
+Run a Get query.  This function calls execOriginal with a function that calls gocqlx.Queryx.Get with
+updated context.
+*/
+func (x *NRGocqlxQueryxWrapper) Get(dest any) error {
+	return x.segmentRunner(func() error { return x.Queryx.Get(dest) })
+}
+
+/*
+Run a Get lightweight transaction and release it immediately after.  Released queries cannot be reused.  This function
+calls execOriginalCAS with a function that calls gocqlx.Queryx.GetCASRelease with updated context.
+*/
+func (x *NRGocqlxQueryxWrapper) GetCASRelease(dest any) (bool, error) {
+	return x.CASSegmentRunner(func() (bool, error) { return x.Queryx.GetCASRelease(dest) })
+}
+
+/*
+Run a Get lightweight transaction.  This function calls execOriginalCAS with a function that calls gocqlx.Queryx.GetCAS
+with updated context.
+*/
+func (x *NRGocqlxQueryxWrapper) GetCAS(dest any) (bool, error) {
+	return x.CASSegmentRunner(func() (bool, error) { return x.Queryx.GetCAS(dest) })
+}
+
+/*
+Run an Exec query and release it immediately after.  Released queries cannot be reused.  This function calls
+execOriginal with a function that calls gocqlx.Queryx.ExecRelease with updated context.
+*/
+func (x *NRGocqlxQueryxWrapper) ExecRelease() error {
+	return x.segmentRunner(func() error { return x.Queryx.ExecRelease() })
+}
+
+/*
+Run an Exec query.  This function calls execOriginal with a function that calls gocqlx.Queryx.Exec with
+updated context.
+*/
+func (x *NRGocqlxQueryxWrapper) Exec() error {
+	return x.segmentRunner(func() error { return x.Queryx.Exec() })
+}
+
+/*
+Run an Exec lightweight transaction.  This function calls execOriginalCAS with a function that calls gocqlx.Queryx.ExecCAS
+with updated context.
+*/
+func (x *NRGocqlxQueryxWrapper) ExecCAS() (bool, error) {
+	return x.CASSegmentRunner(func() (bool, error) { return x.Queryx.ExecCAS() })
+}
+
+/*
+Run an Exec lightweight transaction and release it immediately after.  Released queries cannot be reused.  This function
+calls execOriginalCAS with a function that calls gocqlx.Queryx.ExecCASRelease with updated context.
+*/
+func (x *NRGocqlxQueryxWrapper) ExecCASRelease() (bool, error) {
+	return x.CASSegmentRunner(func() (bool, error) { return x.Queryx.ExecCASRelease() })
+}
+
+/*
+Run a query and copies the columns of the first selected row into the values pointed at by dest and discards the rest.
+This function calls execOriginal with a function that calls gocqlx.Queryx.Scan with updated context.
+*/
+func (x *NRGocqlxQueryxWrapper) Scan(v ...any) error {
+	return x.segmentRunner(func() error { return x.Queryx.Scan(v...) })
+}
+
+/*
+NewQueryObserver returns a gocql.QueryObserver that creates newrelic.DatastoreSegment for each database query. If provided,
+the original gocql.QueryObserver will be called as well.
+*/
+func NewQueryObserver(original interface {
+	ObserveQuery(ctx context.Context, query gocql.ObservedQuery)
+}) *queryObserver {
+	if original != nil && reflect.ValueOf(original).IsNil() {
+		original = nil
+	}
+	return &queryObserver{
+		original: original,
+	}
+}
+
+/*
+NewBatchObserver returns a gocql.BatchObserver that creates newrelic.DatastoreSegment for each database batch query. If provided,
+the original gocql.BatchObserver will be called as well.
+*/
+func NewBatchObserver(original interface {
+	ObserveBatch(ctx context.Context, batch gocql.ObservedBatch)
+}) *batchObserver {
+	if original != nil && reflect.ValueOf(original).IsNil() {
+		original = nil
+	}
+	return &batchObserver{
+		original: original,
+	}
+}
+
+/*
+ObserveQuery is the implementation for the gocql.QueryObserver.  This will run after the
+query is executed.  It will execute the original implementation of ObserveQuery if it is
+passed in.  If there is no new relic transaction in context, it will return early.  Otherwise,
+it will take the segment from context, and enrich it with query data.
+*/
+func (o *queryObserver) ObserveQuery(ctx context.Context, query gocql.ObservedQuery) {
+
+	if o.original != nil {
+		o.original.ObserveQuery(ctx, query)
+	}
+
+	txn := newrelic.FromContext(ctx)
+	if txn == nil {
+		return
+	}
+
+	var host, statement, keyspace string
+	var port int
+
+	if query.Host != nil {
+		host = query.Host.HostID()
+		port = query.Host.Port()
+	}
+	statement = query.Statement
+	keyspace = query.Keyspace
+
+	// enrich segment
+	segment, ok := ctx.Value(queryKey).(*newrelic.DatastoreSegment)
+	if !ok {
+		return
+	}
+	cqlparse.ParseQuery(segment, statement)
+	segment.ParameterizedQuery = statement
+	segment.Host = host
+	segment.PortPathOrID = strconv.Itoa(port)
+	segment.DatabaseName = keyspace
+
+	// security agent?
+}
+
+/*
+ObserveBatch is the implementation for the gocql.BatchObserver.  This will run after the
+batch is executed.  It will execute the original implementation of ObserveBatch if it is
+passed in.  If there is no new relic transaction in context, it will return early.  Otherwise,
+it will take the segment from context, and enrich it with batch data.
+*/
+func (o *batchObserver) ObserveBatch(ctx context.Context, batch gocql.ObservedBatch) {
+	if o.original != nil {
+		o.original.ObserveBatch(ctx, batch)
+	}
+
+	txn := newrelic.FromContext(ctx)
+	if txn == nil {
+		return
+	}
+
+	var host, keyspace string
+	var statements []string
+	var port int
+
+	if batch.Host != nil {
+		host = batch.Host.HostID()
+		port = batch.Host.Port()
+	}
+	statements = batch.Statements
+	keyspace = batch.Keyspace
+
+	segment, ok := ctx.Value(batchKey).(*newrelic.DatastoreSegment)
+	if !ok {
+		return
+	}
+	segment.Operation = "batch"
+	segment.ParameterizedQuery = strings.Join(statements, "; ") // join statements together
+	segment.Host = host
+	segment.PortPathOrID = strconv.Itoa(port)
+	segment.DatabaseName = keyspace
+	// enrich segment below
+}

--- a/v3/integrations/nrgocqlx/nrgocqlx_test.go
+++ b/v3/integrations/nrgocqlx/nrgocqlx_test.go
@@ -1,0 +1,660 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nrgocqlx
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	gocql "github.com/gocql/gocql"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v3/newrelic/integrationsupport"
+	"github.com/scylladb/gocqlx/v3"
+)
+
+type mockObserver struct {
+	called   bool
+	original interface {
+		ObserveQuery(ctx context.Context, query gocql.ObservedQuery)
+	}
+}
+
+type mockBatchObserver struct {
+	called   bool
+	original interface {
+		ObserveBatch(ctx context.Context, batch gocql.ObservedBatch)
+	}
+}
+
+func (m *mockObserver) ObserveQuery(ctx context.Context, q gocql.ObservedQuery) {
+	m.called = true
+}
+
+func (m *mockBatchObserver) ObserveBatch(ctx context.Context, batch gocql.ObservedBatch) {
+	m.called = true
+}
+
+func TestObserveQuery(t *testing.T) {
+	app := integrationsupport.NewTestApp(
+		integrationsupport.SampleEverythingReplyFn,
+		integrationsupport.ConfigFullTraces,
+	)
+
+	hostWithID := new(gocql.HostInfo)
+	hostWithID.SetHostID("test-host-id")
+
+	tests := []struct {
+		name             string
+		startTransaction bool
+		storeSegment     bool
+		original         *mockObserver
+		query            gocql.ObservedQuery
+		wantOrigCalled   bool
+		wantQuery        string
+		wantKeyspace     string
+		wantHost         string
+	}{
+		{
+			name:             "nil transaction returns early",
+			startTransaction: false,
+			storeSegment:     false,
+			original:         nil,
+			query:            gocql.ObservedQuery{Statement: "SELECT 1"},
+		},
+		{
+			name:             "original observer is called",
+			startTransaction: true,
+			storeSegment:     true,
+			original:         &mockObserver{},
+			query:            gocql.ObservedQuery{Statement: "SELECT * FROM users", Keyspace: "ks"},
+			wantOrigCalled:   true,
+			wantQuery:        "SELECT * FROM users",
+			wantKeyspace:     "ks",
+		},
+		{
+			name:             "segment is enriched",
+			startTransaction: true,
+			storeSegment:     true,
+			query:            gocql.ObservedQuery{Statement: "INSERT INTO t", Keyspace: "mykeyspace"},
+			wantQuery:        "INSERT INTO t",
+			wantKeyspace:     "mykeyspace",
+		},
+		{
+			name:             "host info is captured",
+			startTransaction: true,
+			storeSegment:     true,
+			query: gocql.ObservedQuery{
+				Statement: "SELECT * FROM t",
+				Keyspace:  "ks",
+				Host:      hostWithID,
+			},
+			wantQuery:    "SELECT * FROM t",
+			wantKeyspace: "ks",
+			wantHost:     "test-host-id",
+		},
+		{
+			name:             "early return no segment",
+			startTransaction: true,
+			storeSegment:     false,
+			query: gocql.ObservedQuery{
+				Statement: "SELECT * FROM t",
+				Keyspace:  "ks",
+				Host:      hostWithID,
+			},
+			wantQuery:    "SELECT * FROM t",
+			wantKeyspace: "ks",
+			wantHost:     "test-host-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			var seg *newrelic.DatastoreSegment
+
+			if tt.startTransaction {
+				txn := app.StartTransaction("test-txn")
+				defer txn.End()
+				ctx = newrelic.NewContext(ctx, txn)
+
+				if tt.storeSegment {
+					seg = &newrelic.DatastoreSegment{StartTime: newrelic.SegmentStartTime{}}
+					defer seg.End()
+					ctx = context.WithValue(ctx, queryKey, seg)
+
+				}
+			}
+
+			NewQueryObserver(tt.original).ObserveQuery(ctx, tt.query)
+
+			if tt.original != nil && tt.original.called != tt.wantOrigCalled {
+				t.Errorf("original.called = %v, want %v", tt.original.called, tt.wantOrigCalled)
+			}
+			if seg != nil {
+				if seg.ParameterizedQuery != tt.wantQuery {
+					t.Errorf("ParameterizedQuery = %q, want %q", seg.ParameterizedQuery, tt.wantQuery)
+				}
+				if seg.DatabaseName != tt.wantKeyspace {
+					t.Errorf("DatabaseName = %q, want %q", seg.DatabaseName, tt.wantKeyspace)
+				}
+				if seg.Host != tt.wantHost {
+					t.Errorf("Host = %q, want %q", seg.Host, tt.wantHost)
+				}
+			}
+		})
+	}
+}
+
+func Test_execOriginal(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		fn               func(ctx context.Context) error
+		wantErr          bool
+		ctx              context.Context
+		startTransaction bool
+	}{
+		{
+			name: "Context is nil, should execute function and not begin a segment",
+			fn: func(ctx context.Context) error {
+				return nil
+			},
+			wantErr:          false,
+			ctx:              nil,
+			startTransaction: false,
+		},
+		{
+			name: "Context exists, should execute function and not begin a segment",
+			fn: func(ctx context.Context) error {
+				return nil
+			},
+			wantErr:          false,
+			ctx:              context.Background(),
+			startTransaction: false,
+		},
+		{
+			name: "Context is nil, should execute function that returns error and not begin a segment",
+			fn: func(ctx context.Context) error {
+				return fmt.Errorf("testing error")
+			},
+			wantErr:          true,
+			ctx:              nil,
+			startTransaction: false,
+		},
+		{
+			name: "Context exists, should execute function that returns error and not begin a segment",
+			fn: func(ctx context.Context) error {
+				return fmt.Errorf("testing error")
+			},
+			wantErr:          true,
+			ctx:              context.Background(),
+			startTransaction: false,
+		},
+		{
+			name: "Context exists, should execute function and begin segment",
+			fn: func(ctx context.Context) error {
+				return nil
+			},
+			wantErr:          false,
+			ctx:              context.Background(),
+			startTransaction: true,
+		},
+		{
+			name: "Context exists, should execute function that returns error and begin segment",
+			fn: func(ctx context.Context) error {
+				return fmt.Errorf("testing error")
+			},
+			wantErr:          true,
+			ctx:              context.Background(),
+			startTransaction: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.ctx
+			if tt.startTransaction {
+				app := integrationsupport.NewTestApp(
+					integrationsupport.SampleEverythingReplyFn,
+					integrationsupport.ConfigFullTraces,
+				)
+				txn := app.StartTransaction("test-txn")
+				defer txn.End()
+				ctx = newrelic.NewContext(ctx, txn)
+			}
+			gotErr := execOriginal(ctx, tt.fn, queryKey)
+
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("execOriginal() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("execOriginal() succeeded unexpectedly")
+			}
+
+		})
+	}
+}
+
+func Test_execOriginalCAS(t *testing.T) {
+	tests := []struct {
+		name             string
+		fn               func(ctx context.Context) (bool, error)
+		wantErr          bool
+		wantApplied      bool
+		ctx              context.Context
+		startTransaction bool
+	}{
+		{
+			name: "Context is nil, should execute function and not begin a segment",
+			fn: func(ctx context.Context) (bool, error) {
+				return true, nil
+			},
+			wantErr:          false,
+			wantApplied:      true,
+			ctx:              nil,
+			startTransaction: false,
+		},
+		{
+			name: "Context exists, should execute function and not begin a segment",
+			fn: func(ctx context.Context) (bool, error) {
+				return true, nil
+			},
+			wantErr:          false,
+			wantApplied:      true,
+			ctx:              context.Background(),
+			startTransaction: false,
+		},
+		{
+			name: "Context is nil, should execute function that returns error and not begin a segment",
+			fn: func(ctx context.Context) (bool, error) {
+				return false, fmt.Errorf("testing error")
+			},
+			wantErr:          true,
+			wantApplied:      false,
+			ctx:              nil,
+			startTransaction: false,
+		},
+		{
+			name: "Context exists, should execute function that returns error and not begin a segment",
+			fn: func(ctx context.Context) (bool, error) {
+				return false, fmt.Errorf("testing error")
+			},
+			wantErr:          true,
+			wantApplied:      false,
+			ctx:              context.Background(),
+			startTransaction: false,
+		},
+		{
+			name: "Context exists, should execute function and begin segment, applied true",
+			fn: func(ctx context.Context) (bool, error) {
+				return true, nil
+			},
+			wantErr:          false,
+			wantApplied:      true,
+			ctx:              context.Background(),
+			startTransaction: true,
+		},
+		{
+			name: "Context exists, should execute function and begin segment, applied false",
+			fn: func(ctx context.Context) (bool, error) {
+				return false, nil
+			},
+			wantErr:          false,
+			wantApplied:      false,
+			ctx:              context.Background(),
+			startTransaction: true,
+		},
+		{
+			name: "Context exists, should execute function that returns error and begin segment",
+			fn: func(ctx context.Context) (bool, error) {
+				return false, fmt.Errorf("testing error")
+			},
+			wantErr:          true,
+			wantApplied:      false,
+			ctx:              context.Background(),
+			startTransaction: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.ctx
+			if tt.startTransaction {
+				app := integrationsupport.NewTestApp(
+					integrationsupport.SampleEverythingReplyFn,
+					integrationsupport.ConfigFullTraces,
+				)
+				txn := app.StartTransaction("test-txn")
+				defer txn.End()
+				ctx = newrelic.NewContext(ctx, txn)
+			}
+			gotApplied, gotErr := execOriginalCAS(ctx, tt.fn, queryKey)
+
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("execOriginalCAS() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("execOriginalCAS() succeeded unexpectedly")
+			}
+			if gotApplied != tt.wantApplied {
+				t.Errorf("execOriginalCAS() applied = %v, want %v", gotApplied, tt.wantApplied)
+			}
+		})
+	}
+}
+
+func Test_newNRGocqlxQueryxWrapper(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		queryx *gocqlx.Queryx
+	}{
+		{
+			name:   "Wrapper with runners set and queryx set",
+			queryx: &gocqlx.Queryx{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newNRGocqlxQueryxWrapper(tt.queryx)
+
+			if got.segmentRunner == nil {
+				t.Errorf("newNRGocqlxQueryxWrapper() segmentRunner is nil")
+			}
+
+			if got.CASSegmentRunner == nil {
+				t.Errorf("newNRGocqlxQueryxWrapper() CASSegmentRunner is nil")
+			}
+		})
+	}
+}
+
+func Test_segmentRunner_Query(t *testing.T) {
+
+	app := integrationsupport.NewTestApp(
+		integrationsupport.SampleEverythingReplyFn,
+		integrationsupport.ConfigFullTraces,
+	)
+	w := newNRGocqlxQueryxWrapper(&gocqlx.Queryx{Query: &gocql.Query{}})
+	ctx := context.Background()
+	txn := app.StartTransaction("test-txn")
+	defer txn.End()
+	ctx = newrelic.NewContext(ctx, txn)
+	w.WithContext(ctx)
+
+	seg := &newrelic.DatastoreSegment{StartTime: txn.StartSegmentNow()}
+	defer seg.End()
+	ctx = context.WithValue(ctx, queryKey, seg)
+
+	t.Run("runWithSegment and runCASWithSegment no error", func(t *testing.T) {
+		err := w.segmentRunner(func() error {
+			return nil
+		})
+		if err != nil {
+			t.Errorf("runWithSegment returning error while should be nil")
+		}
+		_, err = w.CASSegmentRunner(func() (bool, error) {
+			return true, nil
+		})
+		if err != nil {
+			t.Errorf("runCASWithSegment returning error while should be nil")
+		}
+	})
+}
+
+func Test_segmentRunner_Batch(t *testing.T) {
+
+	app := integrationsupport.NewTestApp(
+		integrationsupport.SampleEverythingReplyFn,
+		integrationsupport.ConfigFullTraces,
+	)
+	w := newNRGocqlxBatchWrapper(&gocqlx.Batch{Batch: &gocql.Batch{}})
+	ctx := context.Background()
+	txn := app.StartTransaction("test-txn")
+	defer txn.End()
+	ctx = newrelic.NewContext(ctx, txn)
+	w.WithContext(ctx)
+
+	seg := &newrelic.DatastoreSegment{StartTime: txn.StartSegmentNow()}
+	defer seg.End()
+	ctx = context.WithValue(ctx, batchKey, seg)
+
+	t.Run("runWithSegment and runCASWithSegment no error", func(t *testing.T) {
+		err := w.segmentRunner(func() error {
+			return nil
+		})
+		if err != nil {
+			t.Errorf("runWithSegment returning error while should be nil")
+		}
+	})
+}
+
+func TestNewQueryObserver(t *testing.T) {
+	var explicitNil *queryObserver = nil
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		original interface {
+			ObserveQuery(ctx context.Context, query gocql.ObservedQuery)
+		}
+		want *queryObserver
+	}{
+		{
+			name:     "Original is explicit nil return original as nil",
+			original: nil,
+			want:     &queryObserver{nil},
+		},
+		{
+			name:     "Original is type nil return original as nil",
+			original: explicitNil,
+			want:     &queryObserver{nil},
+		},
+		{
+			name:     "Original is an observer, return original as set",
+			original: &mockObserver{},
+			want:     &queryObserver{original: &mockObserver{}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewQueryObserver(tt.original)
+			if tt.want.original == nil && got.original != nil {
+				t.Errorf("NewQueryObserver() = %v, want %v", got.original, tt.want.original)
+			}
+			if tt.want.original != nil && got.original == nil {
+				t.Errorf("NewQueryObserver() = %v, want %v", got.original, tt.want.original)
+			}
+		})
+	}
+}
+
+func TestObserveBatch(t *testing.T) {
+	app := integrationsupport.NewTestApp(
+		integrationsupport.SampleEverythingReplyFn,
+		integrationsupport.ConfigFullTraces,
+	)
+
+	hostWithID := new(gocql.HostInfo)
+	hostWithID.SetHostID("test-host-id")
+
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		batch            gocql.ObservedBatch
+		startTransaction bool
+		storeSegment     bool
+		original         *mockBatchObserver
+		wantOrigCalled   bool
+		wantBatch        string
+		wantKeyspace     string
+		wantHost         string
+	}{
+		{
+			name:             "nil transaction returns early",
+			startTransaction: false,
+			storeSegment:     false,
+			original:         nil,
+			batch:            gocql.ObservedBatch{Statements: []string{}},
+		},
+		{
+			name:             "original observer is called",
+			startTransaction: true,
+			storeSegment:     true,
+			original:         &mockBatchObserver{},
+			batch:            gocql.ObservedBatch{Statements: []string{"SELECT * FROM USERS", "INSERT INTO t"}, Keyspace: "mykeyspace"},
+			wantOrigCalled:   true,
+			wantBatch:        "SELECT * FROM USERS; INSERT INTO t",
+			wantKeyspace:     "mykeyspace",
+		},
+		{
+			name:             "segment is enriched",
+			startTransaction: true,
+			storeSegment:     true,
+			batch:            gocql.ObservedBatch{Statements: []string{"INSERT INTO t", "DELETE FROM t"}, Keyspace: "mykeyspace"},
+			wantBatch:        "INSERT INTO t; DELETE FROM t",
+			wantKeyspace:     "mykeyspace",
+		},
+		{
+			name:             "host info is captured",
+			startTransaction: true,
+			storeSegment:     true,
+			batch: gocql.ObservedBatch{
+				Statements: []string{"SELECT * FROM t"},
+				Keyspace:   "ks",
+				Host:       hostWithID,
+			},
+			wantBatch:    "SELECT * FROM t",
+			wantKeyspace: "ks",
+			wantHost:     "test-host-id",
+		},
+		{
+			name:             "early return no segment",
+			startTransaction: true,
+			storeSegment:     false,
+			batch: gocql.ObservedBatch{
+				Statements: []string{"SELECT * FROM t"},
+				Keyspace:   "ks",
+				Host:       hostWithID,
+			},
+		},
+		{
+			name:             "more than two statements joined",
+			startTransaction: true,
+			storeSegment:     true,
+			batch: gocql.ObservedBatch{
+				Statements: []string{"SELECT * FROM a", "INSERT INTO b", "DELETE FROM c"},
+				Keyspace:   "ks",
+			},
+			wantBatch:    "SELECT * FROM a; INSERT INTO b; DELETE FROM c",
+			wantKeyspace: "ks",
+		},
+		{
+			name:             "empty statements",
+			startTransaction: true,
+			storeSegment:     true,
+			batch:            gocql.ObservedBatch{Statements: []string{}, Keyspace: "ks"},
+			wantBatch:        "",
+			wantKeyspace:     "ks",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			var seg *newrelic.DatastoreSegment
+
+			if tt.startTransaction {
+				txn := app.StartTransaction("test-txn")
+				defer txn.End()
+				ctx = newrelic.NewContext(ctx, txn)
+				if tt.storeSegment {
+					seg = &newrelic.DatastoreSegment{StartTime: newrelic.SegmentStartTime{}}
+					defer seg.End()
+					ctx = context.WithValue(ctx, batchKey, seg)
+				}
+			}
+			NewBatchObserver(tt.original).ObserveBatch(ctx, tt.batch)
+
+			if tt.original != nil && tt.original.called != tt.wantOrigCalled {
+				t.Errorf("original.called = %v, want %v", tt.original.called, tt.wantOrigCalled)
+			}
+			if seg != nil {
+				if seg.ParameterizedQuery != tt.wantBatch {
+					t.Errorf("ParameterizedQuery = %q, want %q", seg.ParameterizedQuery, tt.wantBatch)
+				}
+				if seg.DatabaseName != tt.wantKeyspace {
+					t.Errorf("DatabaseName = %q, want %q", seg.DatabaseName, tt.wantKeyspace)
+				}
+				if seg.Host != tt.wantHost {
+					t.Errorf("Host = %q, want %q", seg.Host, tt.wantHost)
+				}
+			}
+		})
+	}
+}
+
+func TestNewBatchObserver(t *testing.T) {
+	var explicitNil *batchObserver = nil
+
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		original interface {
+			ObserveBatch(ctx context.Context, batch gocql.ObservedBatch)
+		}
+		want *batchObserver
+	}{
+		{
+			name:     "Original is explicit nil return original as nil",
+			original: nil,
+			want:     &batchObserver{nil},
+		},
+		{
+			name:     "Orignal is type nil return original as nil",
+			original: explicitNil,
+			want:     &batchObserver{nil},
+		},
+		{
+			name:     "Orignal is an observer return original as observer",
+			original: &mockBatchObserver{},
+			want:     &batchObserver{original: &mockBatchObserver{}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewBatchObserver(tt.original)
+			if tt.want.original == nil && got.original != nil {
+				t.Errorf("NewBatchObserver() = %v, want %v", got, tt.want)
+			}
+			if tt.want.original != nil && got.original == nil {
+				t.Errorf("NewBatchObserver() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_newNRGocqlxBatchWrapper(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		batch *gocqlx.Batch
+	}{
+		{
+			name:  "Wrapper with runner set and batch set",
+			batch: &gocqlx.Batch{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newNRGocqlxBatchWrapper(tt.batch)
+			if got.segmentRunner == nil {
+				t.Errorf("newNRGocqlxBatchWrapper() segmentRunner is nil")
+			}
+		})
+	}
+}

--- a/v3/integrations/nrgorilla/go.mod
+++ b/v3/integrations/nrgorilla/go.mod
@@ -7,7 +7,7 @@ go 1.25
 require (
 	// v1.7.0 is the earliest version of Gorilla using modules.
 	github.com/gorilla/mux v1.7.0
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrgraphgophers/go.mod
+++ b/v3/integrations/nrgraphgophers/go.mod
@@ -7,7 +7,7 @@ go 1.25
 require (
 	// graphql-go has no tagged releases as of Jan 2020.
 	github.com/graph-gophers/graphql-go v1.3.0
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrgraphqlgo/example/go.mod
+++ b/v3/integrations/nrgraphqlgo/example/go.mod
@@ -5,7 +5,7 @@ go 1.25
 require (
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/graphql-go-handler v0.2.3
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/newrelic/go-agent/v3/integrations/nrgraphqlgo v1.0.0
 )
 

--- a/v3/integrations/nrgraphqlgo/go.mod
+++ b/v3/integrations/nrgraphqlgo/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/graphql-go/graphql v0.8.1
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrgrpc/go.mod
+++ b/v3/integrations/nrgrpc/go.mod
@@ -12,7 +12,7 @@ require (
 )
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/newrelic/go-agent/v3/integrations/nrsecurityagent v1.1.0
 )
 

--- a/v3/integrations/nrhttprouter/go.mod
+++ b/v3/integrations/nrhttprouter/go.mod
@@ -7,7 +7,7 @@ go 1.25
 require (
 	// v1.3.0 is the earliest version of httprouter using modules.
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrlambda/go.mod
+++ b/v3/integrations/nrlambda/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/aws/aws-lambda-go v1.41.0
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrlogrus/go.mod
+++ b/v3/integrations/nrlogrus/go.mod
@@ -5,7 +5,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrlogrus
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrlogrus v1.0.0
 	// v1.1.0 is required for the Logger.GetLevel method, and is the earliest
 	// version of logrus using modules.

--- a/v3/integrations/nrlogxi/go.mod
+++ b/v3/integrations/nrlogxi/go.mod
@@ -7,7 +7,7 @@ go 1.25
 require (
 	// 'v1', at commit aebf8a7d67ab, is the only logxi release.
 	github.com/mgutz/logxi v0.0.0-20161027140823-aebf8a7d67ab
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrmicro/go.mod
+++ b/v3/integrations/nrmicro/go.mod
@@ -9,7 +9,7 @@ toolchain go1.24.2
 require (
 	github.com/golang/protobuf v1.5.4
 	github.com/micro/go-micro v1.8.0
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	google.golang.org/protobuf v1.36.6
 )
 

--- a/v3/integrations/nrmongo-v2/go.mod
+++ b/v3/integrations/nrmongo-v2/go.mod
@@ -4,7 +4,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrmongo-v2
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	// mongo-driver does not support modules as of Nov 2019.
 	go.mongodb.org/mongo-driver/v2 v2.2.2
 )

--- a/v3/integrations/nrmongo/go.mod
+++ b/v3/integrations/nrmongo/go.mod
@@ -5,7 +5,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrmongo
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	// mongo-driver does not support modules as of Nov 2019.
 	go.mongodb.org/mongo-driver v1.17.4
 )

--- a/v3/integrations/nrmssql/go.mod
+++ b/v3/integrations/nrmssql/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/microsoft/go-mssqldb v0.19.0
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrmysql/go.mod
+++ b/v3/integrations/nrmysql/go.mod
@@ -7,7 +7,7 @@ require (
 	// v1.5.0 is the first mysql version to support gomod
 	github.com/go-sql-driver/mysql v1.6.0
 	// v3.3.0 includes the new location of ParseQuery
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrnats/go.mod
+++ b/v3/integrations/nrnats/go.mod
@@ -4,10 +4,8 @@ module github.com/newrelic/go-agent/v3/integrations/nrnats
 // https://github.com/nats-io/nats.go/blob/master/.travis.yml
 go 1.25
 
-toolchain go1.23.4
-
 require (
-	github.com/nats-io/nats-server v1.4.1
+	github.com/nats-io/nats-server/v2 v2.10.22
 	github.com/nats-io/nats.go v1.36.0
 	github.com/newrelic/go-agent/v3 v3.43.2
 )

--- a/v3/integrations/nrnats/go.mod
+++ b/v3/integrations/nrnats/go.mod
@@ -7,7 +7,7 @@ go 1.25
 require (
 	github.com/nats-io/nats-server/v2 v2.10.22
 	github.com/nats-io/nats.go v1.36.0
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrnats/nrnats_test.go
+++ b/v3/integrations/nrnats/nrnats_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/nats-server/test"
+	"github.com/nats-io/nats-server/v2/test"
 	nats "github.com/nats-io/nats.go"
 	"github.com/newrelic/go-agent/v3/internal"
 	newrelic "github.com/newrelic/go-agent/v3/newrelic"

--- a/v3/integrations/nrnats/test/go.mod
+++ b/v3/integrations/nrnats/test/go.mod
@@ -5,11 +5,4 @@ go 1.25
 
 replace github.com/newrelic/go-agent/v3/integrations/nrnats v1.0.0 => ../
 
-require (
-	github.com/nats-io/nats-server v1.4.1
-	github.com/nats-io/nats.go v1.36.0
-	github.com/newrelic/go-agent/v3 v3.43.2
-	github.com/newrelic/go-agent/v3/integrations/nrnats v1.0.0
-)
-
 replace github.com/newrelic/go-agent/v3 => ../../..

--- a/v3/integrations/nrnats/test/go.mod
+++ b/v3/integrations/nrnats/test/go.mod
@@ -5,4 +5,3 @@ go 1.25
 
 replace github.com/newrelic/go-agent/v3/integrations/nrnats v1.0.0 => ../
 
-replace github.com/newrelic/go-agent/v3 => ../../..

--- a/v3/integrations/nropenai/go.mod
+++ b/v3/integrations/nropenai/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/pkoukk/tiktoken-go v0.1.6
 	github.com/sashabaranov/go-openai v1.20.2
 )

--- a/v3/integrations/nrpgx/example/sqlx/go.mod
+++ b/v3/integrations/nrpgx/example/sqlx/go.mod
@@ -4,7 +4,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrpgx/example/sqlx
 go 1.25
 require (
 	github.com/jmoiron/sqlx v1.2.0
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/newrelic/go-agent/v3/integrations/nrpgx v0.0.0
 )
 replace github.com/newrelic/go-agent/v3/integrations/nrpgx => ../../

--- a/v3/integrations/nrpgx/go.mod
+++ b/v3/integrations/nrpgx/go.mod
@@ -5,7 +5,7 @@ go 1.25
 require (
 	github.com/jackc/pgx v3.6.2+incompatible
 	github.com/jackc/pgx/v4 v4.18.2
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrpgx5/go.mod
+++ b/v3/integrations/nrpgx5/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/jackc/pgx/v5 v5.9.2
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/v3/integrations/nrpkgerrors/go.mod
+++ b/v3/integrations/nrpkgerrors/go.mod
@@ -5,7 +5,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrpkgerrors
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	// v0.8.0 was the last release in 2016, and when
 	// major development on pkg/errors stopped.
 	github.com/pkg/errors v0.8.0

--- a/v3/integrations/nrpq/example/sqlx/go.mod
+++ b/v3/integrations/nrpq/example/sqlx/go.mod
@@ -5,7 +5,7 @@ go 1.25
 require (
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.1.0
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/newrelic/go-agent/v3/integrations/nrpq v0.0.0
 )
 replace github.com/newrelic/go-agent/v3/integrations/nrpq => ../../

--- a/v3/integrations/nrpq/go.mod
+++ b/v3/integrations/nrpq/go.mod
@@ -6,7 +6,7 @@ require (
 	// NewConnector dsn parsing tests expect v1.1.0 error return behavior.
 	github.com/lib/pq v1.1.0
 	// v3.3.0 includes the new location of ParseQuery
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrredis-v7/go.mod
+++ b/v3/integrations/nrredis-v7/go.mod
@@ -5,7 +5,7 @@ go 1.25
 
 require (
 	github.com/go-redis/redis/v7 v7.0.0-beta.5
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrredis-v8/go.mod
+++ b/v3/integrations/nrredis-v8/go.mod
@@ -5,7 +5,7 @@ go 1.25
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nrredis-v9/go.mod
+++ b/v3/integrations/nrredis-v9/go.mod
@@ -4,7 +4,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrredis-v9
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/redis/go-redis/v9 v9.0.2
 )
 

--- a/v3/integrations/nrsarama/go.mod
+++ b/v3/integrations/nrsarama/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.2
 
 require (
 	github.com/Shopify/sarama v1.38.1
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/v3/integrations/nrsecurityagent/go.mod
+++ b/v3/integrations/nrsecurityagent/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/newrelic/csec-go-agent v1.6.0
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/newrelic/go-agent/v3/integrations/nrsqlite3 v1.2.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/v3/integrations/nrslog/go.mod
+++ b/v3/integrations/nrslog/go.mod
@@ -4,7 +4,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrslog
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/v3/integrations/nrsnowflake/go.mod
+++ b/v3/integrations/nrsnowflake/go.mod
@@ -5,7 +5,7 @@ go 1.25
 toolchain go1.23.2
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/snowflakedb/gosnowflake v1.14.0
 )
 

--- a/v3/integrations/nrsqlite3/go.mod
+++ b/v3/integrations/nrsqlite3/go.mod
@@ -7,7 +7,7 @@ go 1.25
 require (
 	github.com/mattn/go-sqlite3 v1.0.0
 	// v3.3.0 includes the new location of ParseQuery
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrstan/examples/go.mod
+++ b/v3/integrations/nrstan/examples/go.mod
@@ -5,7 +5,7 @@ go 1.25
 
 require (
 	github.com/nats-io/stan.go v0.10.4
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/newrelic/go-agent/v3/integrations/nrnats v0.0.0
 	github.com/newrelic/go-agent/v3/integrations/nrstan v0.0.0
 )

--- a/v3/integrations/nrstan/go.mod
+++ b/v3/integrations/nrstan/go.mod
@@ -8,7 +8,7 @@ toolchain go1.24.2
 
 require (
 	github.com/nats-io/stan.go v0.10.4
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 )
 
 

--- a/v3/integrations/nrstan/test/go.mod
+++ b/v3/integrations/nrstan/test/go.mod
@@ -9,7 +9,7 @@ toolchain go1.24.2
 require (
 	github.com/nats-io/nats-streaming-server v0.25.6
 	github.com/nats-io/stan.go v0.10.4
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/newrelic/go-agent/v3/integrations/nrstan v0.0.0
 )
 

--- a/v3/integrations/nrzap/go.mod
+++ b/v3/integrations/nrzap/go.mod
@@ -5,7 +5,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrzap
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	// v1.12.0 is the earliest version of zap using modules.
 	go.uber.org/zap v1.12.0
 )

--- a/v3/integrations/nrzerolog/go.mod
+++ b/v3/integrations/nrzerolog/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/go-agent/v3/integrations/nrzerolog
 go 1.25
 
 require (
-	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3 v3.44.0
 	github.com/rs/zerolog v1.28.0
 )
 replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/newrelic/cqlparse/cqlparse.go
+++ b/v3/newrelic/cqlparse/cqlparse.go
@@ -1,0 +1,73 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cqlparse
+
+import (
+	"regexp"
+	"strings"
+
+	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+)
+
+func extractTable(s string) string {
+	s = extractTableRegex.ReplaceAllString(s, "")
+	if idx := strings.Index(s, "."); idx > 0 {
+		s = s[idx+1:]
+	}
+	return s
+}
+
+/*
+CQL is similar to SQL in syntax with a few key differences.  There are no Common Table Expressions (CTE),
+so the WITH keyword is not captured with regular expressions below.  Additionally, there are no
+sub-queries in CQL.  In some SQL queries, INTO may be an optional keyword to use with INSERT.  However, in
+CQL is required.  We only capture the DatastoreSegmemt.Collection (table in CQL) for DML queries (SELECT, UPDATE,
+INSERT, DELETE) and TRUNCATE.
+*/
+var (
+	basicTable        = `[^)(\]\[\}\{\s,;]+`
+	enclosedTable     = `[\[\(\{]` + `\s*` + basicTable + `\s*` + `[\]\)\}]`
+	tablePattern      = `(` + `\s+` + basicTable + `|` + `\s*` + enclosedTable + `)`
+	extractTableRegex = regexp.MustCompile(`[\s` + "`" + `"'\(\)\{\}\[\]]*`)
+	updateRegex       = regexp.MustCompile(`(?is)^update` + tablePattern)
+	truncateRegex     = regexp.MustCompile(`(?is)^truncate(?:\s+table)?` + tablePattern)
+	cqlOperations     = map[string]*regexp.Regexp{
+		"select":   regexp.MustCompile(`(?is)^.*\sfrom` + tablePattern),
+		"delete":   regexp.MustCompile(`(?is)^.*\sfrom` + tablePattern),
+		"insert":   regexp.MustCompile(`(?is)^.*\sinto` + tablePattern), // INTO is a required keyword after INSERT
+		"update":   updateRegex,
+		"create":   nil,
+		"drop":     nil,
+		"alter":    nil,
+		"truncate": truncateRegex, // drops all rows from table
+		"use":      nil,
+		"begin":    nil, // BEGIN BATCH
+		"apply":    nil, // APPLY BATCH
+	}
+	firstWordRegex   = regexp.MustCompile(`^\w+`)
+	cCommentRegex    = regexp.MustCompile(`(?is)/\*.*?\*/`)
+	lineCommentRegex = regexp.MustCompile(`(?im)--.*?$`)
+	cqlPrefixRegex   = regexp.MustCompile(`^[\s;]*`)
+)
+
+/*
+ParseQuery parses table and operation from a CQL query string. It is a
+helper meant to be used when writing Cassandra driver instrumentation.
+This is not meant to be used to parse SQL.
+*/
+func ParseQuery(segment *newrelic.DatastoreSegment, query string) {
+	s := cCommentRegex.ReplaceAllString(query, "")
+	s = lineCommentRegex.ReplaceAllString(s, "")
+	s = cqlPrefixRegex.ReplaceAllString(s, "")
+	op := strings.ToLower(firstWordRegex.FindString(s))
+	if rg, ok := cqlOperations[op]; ok {
+		segment.Operation = op
+		segment.RawQuery = query
+		if nil != rg {
+			if m := rg.FindStringSubmatch(s); len(m) > 1 {
+				segment.Collection = extractTable(m[1])
+			}
+		}
+	}
+}

--- a/v3/newrelic/cqlparse/cqlparse_test.go
+++ b/v3/newrelic/cqlparse/cqlparse_test.go
@@ -1,0 +1,461 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cqlparse
+
+import (
+	"testing"
+
+	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+)
+
+func TestParseQuery(t *testing.T) {
+	tests := []struct {
+		// Named input parameters for target function.
+		query string
+
+		expectedCollection string
+		expectedOperation  string
+	}{
+		{
+			query:              "SELECT * FROM table",
+			expectedCollection: "table",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "SELECT name, occupation FROM users;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "SELECT name, occupation FROM users",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "SELECT name, occupation FROM users WHERE userid IN (199, 200, 207);",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "SELECT JSON name, occupation FROM users WHERE userid IN (199, 200, 207);",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "SELECT name AS user_name, occupation AS user_occupation FROM users;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		// SELECT — additional cases from https://cassandra.apache.org/doc/4.0/cassandra/cql/dml.html
+		{
+			query:              "SELECT COUNT(*) AS user_count FROM users;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "SELECT intAsBlob(4) AS four FROM t;",
+			expectedCollection: "t",
+			expectedOperation:  "select",
+		},
+		{
+			query: `SELECT time, value
+FROM events
+WHERE event_type = 'myEvent'
+  AND time > '2011-02-03'
+  AND time <= '2012-01-01';`,
+			expectedCollection: "events",
+			expectedOperation:  "select",
+		},
+		{
+			query: `SELECT entry_title, content FROM posts
+ WHERE userid = 'john doe'
+   AND blog_title = 'John''s Blog'
+   AND posted_at >= '2012-01-01' AND posted_at < '2012-01-31';`,
+			expectedCollection: "posts",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "SELECT * FROM posts WHERE token(userid) > token('tom') AND token(userid) < token('bob');",
+			expectedCollection: "posts",
+			expectedOperation:  "select",
+		},
+		{
+			query: `SELECT * FROM posts
+ WHERE userid = 'john doe'
+   AND (blog_title, posted_at) > ('John''s Blog', '2012-01-01');`,
+			expectedCollection: "posts",
+			expectedOperation:  "select",
+		},
+		{
+			query: `SELECT * FROM posts
+ WHERE userid = 'john doe'
+   AND (blog_title, posted_at) IN (('John''s Blog', '2012-01-01'), ('Extreme Chess', '2014-06-01'));`,
+			expectedCollection: "posts",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "SELECT * FROM users WHERE birth_year = 1981 AND country = 'FR' ALLOW FILTERING;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		// SELECT — mixed case
+		{
+			query:              "select name, occupation from users;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "Select * From users;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		// SELECT — line comments
+		{
+			query: `SELECT -- * FROM tricky
+* FROM users`,
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query: `    -- SELECT * FROM tricky
+SELECT * FROM users`,
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query: `SELECT * FROM -- tricky
+users`,
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		// SELECT — block comments
+		{
+			query:              `/* find all users */ SELECT * FROM users;`,
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query: `SELECT /* columns */ name, occupation
+FROM /* table */ users;`,
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query: `/* multi
+line
+comment */
+SELECT * FROM users;`,
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		// SELECT — semicolon/whitespace prefixes
+		{
+			query:              ";SELECT * FROM users;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query:              "  ;;  ; SELECT * FROM users;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		{
+			query: ` ;
+SELECT * FROM users`,
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		// SELECT — keyspace-qualified
+		{
+			query:              "SELECT * FROM mykeyspace.users;",
+			expectedCollection: "users",
+			expectedOperation:  "select",
+		},
+		// INSERT — from https://cassandra.apache.org/doc/4.0/cassandra/cql/dml.html
+		{
+			query: `INSERT INTO NerdMovies (movie, director, main_actor, year)
+   VALUES ('Serenity', 'Joss Whedon', 'Nathan Fillion', 2005)
+   USING TTL 86400;`,
+			expectedCollection: "NerdMovies",
+			expectedOperation:  "insert",
+		},
+		{
+			query:              `INSERT INTO NerdMovies JSON '{"movie": "Serenity", "director": "Joss Whedon", "year": 2005}';`,
+			expectedCollection: "NerdMovies",
+			expectedOperation:  "insert",
+		},
+		{
+			query:              "INSERT INTO users (userid, password, name) VALUES ('user2', 'ch@ngem3b', 'second user') IF NOT EXISTS;",
+			expectedCollection: "users",
+			expectedOperation:  "insert",
+		},
+		{
+			query:              "INSERT INTO users (userid, password) VALUES ('user4', 'ch@ngem3c');",
+			expectedCollection: "users",
+			expectedOperation:  "insert",
+		},
+		// INSERT — mixed case
+		{
+			query:              "insert into users (userid) values ('u1');",
+			expectedCollection: "users",
+			expectedOperation:  "insert",
+		},
+		{
+			query:              "Insert Into users (userid) Values ('u1');",
+			expectedCollection: "users",
+			expectedOperation:  "insert",
+		},
+		// INSERT — line comment
+		{
+			query: `-- INSERT INTO tricky (x) VALUES (1)
+INSERT INTO users (userid) VALUES ('u1')`,
+			expectedCollection: "users",
+			expectedOperation:  "insert",
+		},
+		// INSERT — block comment
+		{
+			query:              `/* INSERT INTO tricky */ INSERT INTO users (userid) VALUES ('u1');`,
+			expectedCollection: "users",
+			expectedOperation:  "insert",
+		},
+		// INSERT — semicolon prefix
+		{
+			query:              "   INSERT INTO users (userid) VALUES ('u1');",
+			expectedCollection: "users",
+			expectedOperation:  "insert",
+		},
+		// INSERT — keyspace-qualified
+		{
+			query:              "INSERT INTO mykeyspace.NerdMovies (movie) VALUES ('Serenity');",
+			expectedCollection: "NerdMovies",
+			expectedOperation:  "insert",
+		},
+		// UPDATE — from https://cassandra.apache.org/doc/4.0/cassandra/cql/dml.html
+		{
+			query: `UPDATE NerdMovies USING TTL 400
+   SET director   = 'Joss Whedon',
+       main_actor = 'Nathan Fillion',
+       year       = 2005
+ WHERE movie = 'Serenity';`,
+			expectedCollection: "NerdMovies",
+			expectedOperation:  "update",
+		},
+		{
+			query: `UPDATE UserActions
+   SET total = total + 2
+   WHERE user = B70DE1D0-9908-4AE3-BE34-5573E5B09F14
+     AND action = 'click';`,
+			expectedCollection: "UserActions",
+			expectedOperation:  "update",
+		},
+		{
+			query:              "UPDATE users SET password = 'ps22dhds' WHERE userid = 'user3';",
+			expectedCollection: "users",
+			expectedOperation:  "update",
+		},
+		// UPDATE — mixed case
+		{
+			query:              "update users set name = 'foo' where userid = 'u1';",
+			expectedCollection: "users",
+			expectedOperation:  "update",
+		},
+		// UPDATE — line comment
+		{
+			query: `UPDATE -- NerdMovies
+users SET name = 'foo' WHERE userid = 'u1';`,
+			expectedCollection: "users",
+			expectedOperation:  "update",
+		},
+		// UPDATE — block comment
+		{
+			query: `UPDATE users /* USING TTL 400 */
+SET name = 'foo'
+WHERE userid = 'u1';`,
+			expectedCollection: "users",
+			expectedOperation:  "update",
+		},
+		// UPDATE — keyspace-qualified
+		{
+			query:              "UPDATE mykeyspace.users SET name = 'foo' WHERE userid = 'u1';",
+			expectedCollection: "users",
+			expectedOperation:  "update",
+		},
+		// DELETE — from https://cassandra.apache.org/doc/4.0/cassandra/cql/dml.html
+		{
+			query: `DELETE FROM NerdMovies USING TIMESTAMP 1240003134
+ WHERE movie = 'Serenity';`,
+			expectedCollection: "NerdMovies",
+			expectedOperation:  "delete",
+		},
+		{
+			query: `DELETE phone FROM Users
+ WHERE userid IN (C73DE1D3-AF08-40F3-B124-3FF3E5109F22, B70DE1D0-9908-4AE3-BE34-5573E5B09F14);`,
+			expectedCollection: "Users",
+			expectedOperation:  "delete",
+		},
+		{
+			query:              "DELETE name FROM users WHERE userid = 'user1';",
+			expectedCollection: "users",
+			expectedOperation:  "delete",
+		},
+		// DELETE — mixed case
+		{
+			query:              "delete from users where userid = 'u1';",
+			expectedCollection: "users",
+			expectedOperation:  "delete",
+		},
+		// DELETE — line comment
+		{
+			query: `DELETE -- phone
+FROM users WHERE userid = 'u1';`,
+			expectedCollection: "users",
+			expectedOperation:  "delete",
+		},
+		// DELETE — block comment
+		{
+			query:              `/* comment */ DELETE FROM users WHERE userid = 'u1';`,
+			expectedCollection: "users",
+			expectedOperation:  "delete",
+		},
+		// DELETE — keyspace-qualified
+		{
+			query:              "DELETE FROM mykeyspace.users WHERE userid = 'u1';",
+			expectedCollection: "users",
+			expectedOperation:  "delete",
+		},
+		// TRUNCATE
+		{
+			query:              "TRUNCATE users;",
+			expectedCollection: "users",
+			expectedOperation:  "truncate",
+		},
+		{
+			query:              "TRUNCATE TABLE users;",
+			expectedCollection: "users",
+			expectedOperation:  "truncate",
+		},
+		{
+			query:              "truncate table NerdMovies;",
+			expectedCollection: "NerdMovies",
+			expectedOperation:  "truncate",
+		},
+		{
+			query:              "TRUNCATE TABLE mykeyspace.users;",
+			expectedCollection: "users",
+			expectedOperation:  "truncate",
+		},
+		// BATCH — from https://cassandra.apache.org/doc/4.0/cassandra/cql/dml.html
+		{
+			query: `BEGIN BATCH
+   INSERT INTO users (userid, password, name) VALUES ('user2', 'ch@ngem3b', 'second user');
+   UPDATE users SET password = 'ps22dhds' WHERE userid = 'user3';
+   INSERT INTO users (userid, password) VALUES ('user4', 'ch@ngem3c');
+   DELETE name FROM users WHERE userid = 'user1';
+APPLY BATCH;`,
+			expectedCollection: "",
+			expectedOperation:  "begin",
+		},
+		{
+			query:              "BEGIN UNLOGGED BATCH",
+			expectedCollection: "",
+			expectedOperation:  "begin",
+		},
+		{
+			query:              "BEGIN COUNTER BATCH",
+			expectedCollection: "",
+			expectedOperation:  "begin",
+		},
+		{
+			query:              "begin batch",
+			expectedCollection: "",
+			expectedOperation:  "begin",
+		},
+		{
+			query:              "APPLY BATCH;",
+			expectedCollection: "",
+			expectedOperation:  "apply",
+		},
+		{
+			query:              "apply batch;",
+			expectedCollection: "",
+			expectedOperation:  "apply",
+		},
+		// DDL — operation detected, no collection extracted
+		{
+			query:              "CREATE TABLE users (userid text PRIMARY KEY, name text);",
+			expectedCollection: "",
+			expectedOperation:  "create",
+		},
+		{
+			query:              "CREATE KEYSPACE mykeyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};",
+			expectedCollection: "",
+			expectedOperation:  "create",
+		},
+		{
+			query:              "CREATE INDEX ON users(birth_year);",
+			expectedCollection: "",
+			expectedOperation:  "create",
+		},
+		{
+			query:              "DROP TABLE users;",
+			expectedCollection: "",
+			expectedOperation:  "drop",
+		},
+		{
+			query:              "DROP KEYSPACE mykeyspace;",
+			expectedCollection: "",
+			expectedOperation:  "drop",
+		},
+		{
+			query:              "ALTER TABLE users ADD email text;",
+			expectedCollection: "",
+			expectedOperation:  "alter",
+		},
+		{
+			query:              "ALTER TABLE users DROP email;",
+			expectedCollection: "",
+			expectedOperation:  "alter",
+		},
+		{
+			query:              "USE mykeyspace;",
+			expectedCollection: "",
+			expectedOperation:  "use",
+		},
+		// Unknown operations
+		{
+			query:              "",
+			expectedCollection: "",
+			expectedOperation:  "other",
+		},
+		{
+			query:              "EXPLAIN SELECT * FROM users;",
+			expectedCollection: "",
+			expectedOperation:  "other",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			seg := &newrelic.DatastoreSegment{}
+			ParseQuery(seg, tt.query)
+			if tt.expectedOperation == "other" {
+				// Allow for matching of Operation "other" to ""
+				if seg.Operation != "" {
+					t.Errorf("operation mismatch query='%s' wanted='%s' got='%s'",
+						tt.query, tt.expectedOperation, seg.Operation)
+				}
+			} else if seg.Operation != tt.expectedOperation {
+				t.Errorf("operation mismatch query='%s' wanted='%s' got='%s'",
+					tt.query, tt.expectedOperation, seg.Operation)
+			}
+			// The Go agent subquery behavior does not matth the PHP Agent.
+			if tt.expectedCollection == "(subquery)" {
+				return
+			}
+			if tt.expectedCollection != seg.Collection {
+				t.Errorf("table mismatch query='%s' wanted='%s' got='%s'",
+					tt.query, tt.expectedCollection, seg.Collection)
+			}
+		})
+	}
+}

--- a/v3/newrelic/integrationsupport/types.go
+++ b/v3/newrelic/integrationsupport/types.go
@@ -1,0 +1,56 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package integrationsupport
+
+import "github.com/newrelic/go-agent/v3/internal"
+
+// Re-export internal test types so external packages can use the test
+// infrastructure without importing the restricted internal package.
+
+// Validator is used for testing.
+type Validator = internal.Validator
+
+// WantMetric is a metric expectation.
+type WantMetric = internal.WantMetric
+
+// WantError is a traced error expectation.
+type WantError = internal.WantError
+
+// WantLog is a traced log event expectation.
+type WantLog = internal.WantLog
+
+// WantEvent is a transaction or error event expectation.
+type WantEvent = internal.WantEvent
+
+// WantTxn provides the expectation parameters to ExpectTxnMetrics.
+type WantTxn = internal.WantTxn
+
+// WantTxnTrace is a transaction trace expectation.
+type WantTxnTrace = internal.WantTxnTrace
+
+// WantTraceSegment is a transaction trace segment expectation.
+type WantTraceSegment = internal.WantTraceSegment
+
+// WantSlowQuery is a slow query expectation.
+type WantSlowQuery = internal.WantSlowQuery
+
+// ConnectReply holds settings returned by the New Relic collector.
+type ConnectReply = internal.ConnectReply
+
+var (
+	// MatchAnything can be used in attribute maps to accept any value.
+	MatchAnything = internal.MatchAnything
+
+	// MatchAnyString accepts any string value in attribute comparisons.
+	MatchAnyString = internal.MatchAnyString
+
+	// MatchAnyUnixMilli accepts any unix millisecond timestamp in log comparisons.
+	MatchAnyUnixMilli = internal.MatchAnyUnixMilli
+)
+
+// HarvestTesting sets up an in-memory harvest for use in tests.
+var HarvestTesting = internal.HarvestTesting
+
+// NewTraceIDGenerator creates a new deterministic trace ID generator for tests.
+var NewTraceIDGenerator = internal.NewTraceIDGenerator

--- a/v3/newrelic/sqlparse/sqlparse.go
+++ b/v3/newrelic/sqlparse/sqlparse.go
@@ -24,11 +24,12 @@ var (
 	tablePattern      = `(` + `\s+` + basicTable + `|` + `\s*` + enclosedTable + `)`
 	extractTableRegex = regexp.MustCompile(`[\s` + "`" + `"'\(\)\{\}\[\]]*`)
 	updateRegex       = regexp.MustCompile(`(?is)^update(?:\s+(?:low_priority|ignore|or|rollback|abort|replace|fail|only))*` + tablePattern)
+	insertRegex       = regexp.MustCompile(`(?is)^insert(?:\s+(?:low_priority|delayed|high_priority|ignore))*(?:\s+into)?` + tablePattern)
 	withRegex         = regexp.MustCompile(`(?is)^with(?:\s+recursive)?.*\)\s*select.*?\sfrom` + tablePattern)
 	sqlOperations     = map[string]*regexp.Regexp{
 		"select":   regexp.MustCompile(`(?is)^.*\sfrom` + tablePattern),
 		"delete":   regexp.MustCompile(`(?is)^.*\sfrom` + tablePattern),
-		"insert":   regexp.MustCompile(`(?is)^.*\sinto?` + tablePattern),
+		"insert":   insertRegex,
 		"update":   updateRegex,
 		"call":     nil,
 		"create":   nil,

--- a/v3/newrelic/sqlparse/sqlparse_test.go
+++ b/v3/newrelic/sqlparse/sqlparse_test.go
@@ -207,3 +207,22 @@ func TestParseSQLWith(t *testing.T) {
 		tc.test(t)
 	}
 }
+
+func TestInsertSQL(t *testing.T) {
+	for _, tc := range []sqlTestcase{
+		// standard form
+		{Input: "INSERT INTO employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
+		// INTO is optional
+		{Input: "INSERT employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
+		// modifiers without INTO
+		{Input: "INSERT DELAYED employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
+		{Input: "INSERT HIGH_PRIORITY employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
+		{Input: "INSERT LOW_PRIORITY IGNORE employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
+		//modifiers with INTO
+		{Input: "INSERT DELAYED INTO employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
+		{Input: "INSERT HIGH_PRIORITY INTO employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
+		{Input: "INSERT LOW_PRIORITY IGNORE INTO employees VALUES (1, 'Alice')", Operation: "insert", Table: "employees"},
+	} {
+		tc.test(t)
+	}
+}

--- a/v3/newrelic/version.go
+++ b/v3/newrelic/version.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Version is the full string version of this Go Agent.
-	Version = "3.43.3"
+	Version = "3.44.0"
 )
 
 var (


### PR DESCRIPTION
## 3.44.0
### Added
  * Added Support for Anthropic SDK `nranthropic`
  * Added Support for GocqlX `nrgocqlx`
### Fixed
  * Export Internal Test Types via `integrationsupport` to unblock external test consumers
    * Thank you to community member @nitinprajwal for contributing to this solution
  * Fixed a bug in sqlparse to support optional `INTO` statements in sql integrations
  * Fixed a bug in `nrnats` that caused flaky testing
### Security
  * Dependabot Security Bumps
    * `nrfiber`
### Support statement
We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
See the [Go agent EOL Policy](https://docs.newrelic.com/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.

