### PR TITLE
feat: Otel tracing

### DIFF
--- a/v3/integrations/nrotelhybrid/examples/tracing/main.go
+++ b/v3/integrations/nrotelhybrid/examples/tracing/main.go
@@ -69,7 +69,7 @@ func newHttpHandler() http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/routeone/", routeOne)
-	mux.HandleFunc("routetwo/", routeTwo)
+	mux.HandleFunc("/routetwo/", routeTwo)
 
 	// Add HTTP instrumentation for the whole server.
 	handler := otelhttp.NewHandler(mux, "/")

--- a/v3/integrations/nrotelhybrid/examples/tracing/main.go
+++ b/v3/integrations/nrotelhybrid/examples/tracing/main.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"log"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+func main() {
+	// for pretty print to console
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() (err error) {
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	exporter, err := stdouttrace.New(stdouttrace.WithPrettyPrint())
+	if err != nil {
+		return err
+	}
+
+	tp := trace.NewTracerProvider(trace.WithSyncer(exporter))
+	shutdown := func(ctx context.Context) error {
+		err := tp.Shutdown(ctx)
+		return err
+	}
+	defer shutdown(context.Background())
+
+	otel.SetTracerProvider(tp)
+
+	srv := &http.Server{
+		Addr:         ":8080",
+		BaseContext:  func(net.Listener) context.Context { return ctx },
+		ReadTimeout:  time.Second,
+		WriteTimeout: 10 * time.Second,
+		Handler:      newHttpHandler(),
+	}
+	srvErr := make(chan error, 1)
+	go func() {
+		log.Println("Running HTTP server...")
+		srvErr <- srv.ListenAndServe()
+	}()
+
+	select {
+	case err = <-srvErr:
+		return err
+	case <-ctx.Done():
+		stop()
+	}
+	err = srv.Shutdown(context.Background())
+	return err
+}
+
+func newHttpHandler() http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/routeone/", routeOne)
+	mux.HandleFunc("routetwo/", routeTwo)
+
+	// Add HTTP instrumentation for the whole server.
+	handler := otelhttp.NewHandler(mux, "/")
+
+	return handler
+}
+
+func routeOne(w http.ResponseWriter, r *http.Request) {
+	tracer := otel.Tracer("nrotel-example")
+	ctx, span := tracer.Start(r.Context(), "route-one")
+	defer span.End()
+	nestedRouteOne(ctx)
+	leafCall(ctx)
+
+}
+
+func routeTwo(w http.ResponseWriter, r *http.Request) {
+	tracer := otel.Tracer("nrotel-example")
+	ctx, span := tracer.Start(r.Context(), "route-two")
+	defer span.End()
+	nestedRouteTwo(ctx)
+}
+
+func nestedRouteOne(ctx context.Context) {
+	_, span := otel.Tracer("nrotel-example").Start(ctx, "nested-route-two")
+	defer span.End()
+	leafCall(ctx)
+}
+
+func nestedRouteTwo(ctx context.Context) {
+	_, span := otel.Tracer("nrotel-example").Start(ctx, "nested-route-two")
+	defer span.End()
+	leafCall(ctx)
+}
+
+func leafCall(ctx context.Context) {
+	_, span := otel.Tracer("nrotel-example").Start(ctx, "leaf-call")
+	defer span.End()
+	n := rand.IntN(500)
+	//simulate some work
+	time.Sleep(time.Duration(n) * time.Millisecond)
+}

--- a/v3/integrations/nrotelhybrid/go.mod
+++ b/v3/integrations/nrotelhybrid/go.mod
@@ -1,0 +1,27 @@
+module github.com/newrelic/go-agent/v3/integrations/nrotelhybrid
+
+go 1.25.0
+
+require (
+	github.com/newrelic/go-agent/v3 v3.44.1
+	go.opentelemetry.io/otel v1.44.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0
+	go.opentelemetry.io/otel/sdk v1.44.0
+	go.opentelemetry.io/otel/sdk/metric v1.44.0
+	go.opentelemetry.io/otel/trace v1.44.0
+)
+
+require github.com/felixge/httpsnoop v1.0.4 // indirect
+
+require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
+	go.opentelemetry.io/otel/metric v1.44.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
+)
+
+replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nrotelhybrid/go.mod
+++ b/v3/integrations/nrotelhybrid/go.mod
@@ -11,17 +11,4 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 )
 
-require github.com/felixge/httpsnoop v1.0.4 // indirect
-
-require (
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
-	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
-	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
-	go.opentelemetry.io/otel/metric v1.44.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
-)
-
 replace github.com/newrelic/go-agent/v3 => ../..


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

<!--
Any relevant links that will help reviewers.
-->

## Details
### Issue
There is not yet an example for the OTEL Tracing API
### Goals
Set up a quick example
### Implementation
- Set up a server that runs on `:8080`
- It has two routes
- Those routes contain nested spans
- OTEL is configured to pretty print to the console
### How to test
- navigate to `go-agent/v3/integrations/nrotelhybrid/examples/racting` and run `go run main.go`
- [localhost:8080/routeone](localhost:8080/routeone)
- [localhost:8080/routetwo](localhost:8080/routetwo)

<!--
In-depth description of changes, other technical notes, etc.
-->
