### PR TITLE
feat(nrotelhybrid): SpanProcessor Transaction Logic

### DIFF
--- a/v3/integrations/nrotelhybrid/examples/tracing/main.go
+++ b/v3/integrations/nrotelhybrid/examples/tracing/main.go
@@ -10,6 +10,8 @@ import (
 	"os/signal"
 	"time"
 
+	"github.com/newrelic/go-agent/v3/integrations/nrotelhybrid"
+	"github.com/newrelic/go-agent/v3/newrelic"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
@@ -24,7 +26,18 @@ func main() {
 }
 
 func run() (err error) {
+	app, err := newrelic.NewApplication(
+		newrelic.ConfigAppName("Hybrid Example"),
+		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+		newrelic.ConfigDistributedTracerEnabled(true),
+		newrelic.ConfigDebugLogger(os.Stdout),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer app.Shutdown(10 * time.Second)
 
+	processor := nrotelhybrid.NewHybridProcessor(app)
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
@@ -33,7 +46,7 @@ func run() (err error) {
 		return err
 	}
 
-	tp := trace.NewTracerProvider(trace.WithSyncer(exporter))
+	tp := trace.NewTracerProvider(trace.WithSyncer(exporter), trace.WithSpanProcessor(processor))
 	shutdown := func(ctx context.Context) error {
 		err := tp.Shutdown(ctx)
 		return err

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -10,6 +10,14 @@ type nrotelhybridProcessor struct {
 }
 
 func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSpan) {
+	// for now pretending like everything is enabled
+	// first check for case when span has a remote parent.  In this case, it must create a new transaction
+
+	// check if remote parent
+	// should be a valid span context and be marked as remote
+	// this begins a transaction
+	if s.Parent().IsValid() && s.Parent().IsRemote() {
+	}
 
 }
 
@@ -18,9 +26,9 @@ func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
 }
 
 func (p *nrotelhybridProcessor) Shutdown(ctx context.Context) error {
-
+	return nil
 }
 
 func (p *nrotelhybridProcessor) ForceFlush(ctx context.Context) error {
-
+	return nil
 }

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -76,6 +76,7 @@ func (p *nrotelhybridProcessor) isTransaction(kind oteltrace.SpanKind, current o
 }
 
 func isWithinTransaction(txnMap map[oteltrace.TraceID]txnMapEntry, traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool {
+	// if the transaction exists and is not the same span id, it is within an existing transaction
 	if val, ok := txnMap[traceID]; ok {
 		return val.spanID != spanID
 	}

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -2,6 +2,7 @@ package nrotelhybrid
 
 import (
 	"context"
+	"sync"
 
 	"github.com/newrelic/go-agent/v3/newrelic"
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -15,11 +16,14 @@ type txnMapEntry struct {
 
 type nrotelhybridProcessor struct {
 	app        *newrelic.Application
+	mu         sync.Mutex
 	txnMap     map[oteltrace.TraceID]txnMapEntry // Trace ID -> Transaction
 	txnChecker func(txnMap map[oteltrace.TraceID]txnMapEntry, traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool
 }
 
 func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSpan) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	// for now pretending like everything is enabled
 	// first check for case when span has a remote parent.  In this case, it must create a new transaction
 
@@ -34,6 +38,8 @@ func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSp
 }
 
 func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	// use the trace id from trace.ReadOnlySpan to end the transaction
 	if p.isTransaction(s.SpanKind(), s.SpanContext(), s.Parent()) {
 		if val, ok := p.txnMap[s.SpanContext().TraceID()]; ok && val.txn != nil {

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -1,1 +1,26 @@
 package nrotelhybrid
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+type nrotelhybridProcessor struct {
+}
+
+func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSpan) {
+
+}
+
+func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
+
+}
+
+func (p *nrotelhybridProcessor) Shutdown(ctx context.Context) error {
+
+}
+
+func (p *nrotelhybridProcessor) ForceFlush(ctx context.Context) error {
+
+}

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -10,7 +10,10 @@ import (
 
 type nrotelhybridProcessor struct {
 	app    *newrelic.Application
-	txnMap map[oteltrace.TraceID]*newrelic.Transaction // Trace ID -> Transaction
+	txnMap map[oteltrace.TraceID]struct {
+		txn    *newrelic.Transaction
+		spanID oteltrace.SpanID
+	} // Trace ID -> Transaction
 }
 
 func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSpan) {
@@ -20,19 +23,22 @@ func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSp
 	// check if remote parent
 	// should be a valid span context and be marked as remote
 	// this begins a transaction
-	if isTransaction(s.Parent()) {
+	if p.isTransaction(s.SpanKind(), s.SpanContext(), s.Parent()) {
 		txn := p.app.StartTransaction(s.Name())
-		p.txnMap[s.SpanContext().TraceID()] = txn
+		p.txnMap[s.SpanContext().TraceID()] = struct {
+			txn    *newrelic.Transaction
+			spanID oteltrace.SpanID
+		}{txn, s.SpanContext().SpanID()}
 	}
 
 }
 
 func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
 	// use the trace id from trace.ReadOnlySpan to end the transaction
-	if isTransaction(s.Parent()) {
-		txn := p.txnMap[s.SpanContext().TraceID()]
-		if txn != nil {
-			txn.End()
+	if p.isTransaction(s.SpanKind(), s.SpanContext(), s.Parent()) {
+		if val, ok := p.txnMap[s.SpanContext().TraceID()]; ok && val.txn != nil {
+			val.txn.End()
+			delete(p.txnMap, s.SpanContext().TraceID())
 		}
 	}
 }
@@ -45,6 +51,34 @@ func (p *nrotelhybridProcessor) ForceFlush(ctx context.Context) error {
 	return nil
 }
 
-func isTransaction(parent oteltrace.SpanContext) bool {
-	return !parent.IsValid() || parent.IsRemote()
+func (p *nrotelhybridProcessor) isTransaction(kind oteltrace.SpanKind, current oteltrace.SpanContext, parent oteltrace.SpanContext) bool {
+	if parent.IsRemote() {
+		// if valid remote parent
+		return parent.IsValid()
+	}
+	// check if within a transaction
+	switch kind {
+	case oteltrace.SpanKindUnspecified:
+		return false
+	case oteltrace.SpanKindInternal:
+		return false
+	case oteltrace.SpanKindServer:
+		return !p.isWithinTransaction(current.TraceID(), current.SpanID())
+	case oteltrace.SpanKindClient:
+		return false
+	case oteltrace.SpanKindProducer:
+		return false
+	case oteltrace.SpanKindConsumer:
+		return !p.isWithinTransaction(current.TraceID(), current.SpanID())
+	default:
+		return false
+
+	}
+}
+
+func (p *nrotelhybridProcessor) isWithinTransaction(traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool {
+	if val, ok := p.txnMap[traceID]; ok {
+		return val.spanID != spanID
+	}
+	return false
 }

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -21,6 +21,14 @@ type nrotelhybridProcessor struct {
 	txnChecker func(txnMap map[oteltrace.TraceID]txnMapEntry, traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool
 }
 
+func NewHybridProcessor(app *newrelic.Application) *nrotelhybridProcessor {
+	return &nrotelhybridProcessor{
+		app:        app,
+		txnMap:     map[oteltrace.TraceID]txnMapEntry{},
+		txnChecker: isWithinTransaction,
+	}
+}
+
 func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSpan) {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -14,8 +14,9 @@ type txnMapEntry struct {
 }
 
 type nrotelhybridProcessor struct {
-	app    *newrelic.Application
-	txnMap map[oteltrace.TraceID]txnMapEntry // Trace ID -> Transaction
+	app        *newrelic.Application
+	txnMap     map[oteltrace.TraceID]txnMapEntry // Trace ID -> Transaction
+	txnChecker func(txnMap map[oteltrace.TraceID]txnMapEntry, traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool
 }
 
 func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSpan) {
@@ -52,8 +53,8 @@ func (p *nrotelhybridProcessor) ForceFlush(ctx context.Context) error {
 
 func (p *nrotelhybridProcessor) isTransaction(kind oteltrace.SpanKind, current oteltrace.SpanContext, parent oteltrace.SpanContext) bool {
 	if parent.IsRemote() {
-		// if valid remote parent
-		return parent.IsValid()
+		// any span with a remote parent is a transaction
+		return true
 	}
 	// check if within a transaction
 	switch kind {
@@ -62,21 +63,20 @@ func (p *nrotelhybridProcessor) isTransaction(kind oteltrace.SpanKind, current o
 	case oteltrace.SpanKindInternal:
 		return false
 	case oteltrace.SpanKindServer:
-		return !p.isWithinTransaction(current.TraceID(), current.SpanID())
+		return !p.txnChecker(p.txnMap, current.TraceID(), current.SpanID())
 	case oteltrace.SpanKindClient:
 		return false
 	case oteltrace.SpanKindProducer:
 		return false
 	case oteltrace.SpanKindConsumer:
-		return !p.isWithinTransaction(current.TraceID(), current.SpanID())
+		return !p.txnChecker(p.txnMap, current.TraceID(), current.SpanID())
 	default:
 		return false
-
 	}
 }
 
-func (p *nrotelhybridProcessor) isWithinTransaction(traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool {
-	if val, ok := p.txnMap[traceID]; ok {
+func isWithinTransaction(txnMap map[oteltrace.TraceID]txnMapEntry, traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool {
+	if val, ok := txnMap[traceID]; ok {
 		return val.spanID != spanID
 	}
 	return false

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -28,7 +28,11 @@ func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSp
 }
 
 func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
-
+	// use the trace id from trace.ReadOnlySpan to end the transaction
+	if s.Parent().IsValid() && s.Parent().IsRemote() {
+		txn := p.txnMap[s.SpanContext().TraceID()]
+		txn.End()
+	}
 }
 
 func (p *nrotelhybridProcessor) Shutdown(ctx context.Context) error {

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -2,6 +2,7 @@ package nrotelhybrid
 
 import (
 	"context"
+	"net/url"
 	"sync"
 
 	"github.com/newrelic/go-agent/v3/newrelic"
@@ -39,17 +40,22 @@ func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSp
 	// check if remote parent
 	// should be a valid span context and be marked as remote
 	// this begins a transaction
-	if p.isTransaction(s.SpanKind(), s.SpanContext(), s.Parent()) {
+	if isTxn, isWeb := p.isTransaction(s.SpanKind(), s.SpanContext(), s.Parent()); isTxn {
 		txn := p.app.StartTransaction(s.Name())
-		attrs := s.Attributes()
-		var url string
-		for _, kv := range attrs {
-			if kv.Key == semconv.URLFullKey {
-				url = kv.Value.AsString()
+		if isWeb {
+			attrs := s.Attributes()
+			var fullURL string
+			for _, attr := range attrs {
+				if attr.Key == semconv.URLFullKey {
+					fullURL = attr.Value.AsString()
+				}
 			}
-		if isWebTransaction(s.SpanKind()) {
+			nrURL, err := url.Parse(fullURL)
+			if err != nil {
+				// debug log
+			}
 			txn.SetWebRequest(newrelic.WebRequest{
-				URL: url,
+				URL: nrURL,
 			})
 		}
 		p.txnMap[s.SpanContext().TraceID()] = txnMapEntry{txn, s.SpanContext().SpanID()}
@@ -61,7 +67,7 @@ func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	// use the trace id from trace.ReadOnlySpan to end the transaction
-	if p.isTransaction(s.SpanKind(), s.SpanContext(), s.Parent()) {
+	if isTxn, _ := p.isTransaction(s.SpanKind(), s.SpanContext(), s.Parent()); isTxn {
 		if val, ok := p.txnMap[s.SpanContext().TraceID()]; ok && val.txn != nil {
 			val.txn.End()
 			delete(p.txnMap, s.SpanContext().TraceID())
@@ -77,27 +83,27 @@ func (p *nrotelhybridProcessor) ForceFlush(ctx context.Context) error {
 	return nil
 }
 
-func (p *nrotelhybridProcessor) isTransaction(kind oteltrace.SpanKind, current oteltrace.SpanContext, parent oteltrace.SpanContext) bool {
+// isTransaction reports whether the span should start/continue a transaction (isTxn),
+// and whether that transaction is a web transaction (isWeb).
+func (p *nrotelhybridProcessor) isTransaction(kind oteltrace.SpanKind, current oteltrace.SpanContext, parent oteltrace.SpanContext) (isTxn, isWeb bool) {
 	if parent.IsRemote() {
 		// any span with a remote parent is a transaction
-		return true
+		switch kind {
+		case oteltrace.SpanKindServer, oteltrace.SpanKindClient:
+			return true, true
+		default:
+			return true, false
+		}
 	}
-	// check if within a transaction
 	switch kind {
-	case oteltrace.SpanKindUnspecified:
-		return false
-	case oteltrace.SpanKindInternal:
-		return false
 	case oteltrace.SpanKindServer:
-		return !p.txnChecker(p.txnMap, current.TraceID(), current.SpanID())
+		return !p.txnChecker(p.txnMap, current.TraceID(), current.SpanID()), true
 	case oteltrace.SpanKindClient:
-		return false
-	case oteltrace.SpanKindProducer:
-		return false
+		return false, true
 	case oteltrace.SpanKindConsumer:
-		return !p.txnChecker(p.txnMap, current.TraceID(), current.SpanID())
+		return !p.txnChecker(p.txnMap, current.TraceID(), current.SpanID()), false
 	default:
-		return false
+		return false, false
 	}
 }
 
@@ -107,24 +113,4 @@ func isWithinTransaction(txnMap map[oteltrace.TraceID]txnMapEntry, traceID otelt
 		return val.spanID != spanID
 	}
 	return false
-}
-
-func isWebTransaction(kind oteltrace.SpanKind) bool {
-	// check if within a transaction
-	switch kind {
-	case oteltrace.SpanKindUnspecified:
-		return false
-	case oteltrace.SpanKindInternal:
-		return false
-	case oteltrace.SpanKindServer:
-		return true
-	case oteltrace.SpanKindClient:
-		return true
-	case oteltrace.SpanKindProducer:
-		return false
-	case oteltrace.SpanKindConsumer:
-		return false
-	default:
-		return false
-	}
 }

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -8,12 +8,14 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
+type txnMapEntry struct {
+	txn    *newrelic.Transaction
+	spanID oteltrace.SpanID
+}
+
 type nrotelhybridProcessor struct {
 	app    *newrelic.Application
-	txnMap map[oteltrace.TraceID]struct {
-		txn    *newrelic.Transaction
-		spanID oteltrace.SpanID
-	} // Trace ID -> Transaction
+	txnMap map[oteltrace.TraceID]txnMapEntry // Trace ID -> Transaction
 }
 
 func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSpan) {
@@ -25,10 +27,7 @@ func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSp
 	// this begins a transaction
 	if p.isTransaction(s.SpanKind(), s.SpanContext(), s.Parent()) {
 		txn := p.app.StartTransaction(s.Name())
-		p.txnMap[s.SpanContext().TraceID()] = struct {
-			txn    *newrelic.Transaction
-			spanID oteltrace.SpanID
-		}{txn, s.SpanContext().SpanID()}
+		p.txnMap[s.SpanContext().TraceID()] = txnMapEntry{txn, s.SpanContext().SpanID()}
 	}
 
 }

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/newrelic/go-agent/v3/newrelic"
 	"go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -40,6 +41,17 @@ func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSp
 	// this begins a transaction
 	if p.isTransaction(s.SpanKind(), s.SpanContext(), s.Parent()) {
 		txn := p.app.StartTransaction(s.Name())
+		attrs := s.Attributes()
+		var url string
+		for _, kv := range attrs {
+			if kv.Key == semconv.URLFullKey {
+				url = kv.Value.AsString()
+			}
+		if isWebTransaction(s.SpanKind()) {
+			txn.SetWebRequest(newrelic.WebRequest{
+				URL: url,
+			})
+		}
 		p.txnMap[s.SpanContext().TraceID()] = txnMapEntry{txn, s.SpanContext().SpanID()}
 	}
 
@@ -95,4 +107,24 @@ func isWithinTransaction(txnMap map[oteltrace.TraceID]txnMapEntry, traceID otelt
 		return val.spanID != spanID
 	}
 	return false
+}
+
+func isWebTransaction(kind oteltrace.SpanKind) bool {
+	// check if within a transaction
+	switch kind {
+	case oteltrace.SpanKindUnspecified:
+		return false
+	case oteltrace.SpanKindInternal:
+		return false
+	case oteltrace.SpanKindServer:
+		return true
+	case oteltrace.SpanKindClient:
+		return true
+	case oteltrace.SpanKindProducer:
+		return false
+	case oteltrace.SpanKindConsumer:
+		return false
+	default:
+		return false
+	}
 }

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -3,10 +3,14 @@ package nrotelhybrid
 import (
 	"context"
 
+	"github.com/newrelic/go-agent/v3/newrelic"
 	"go.opentelemetry.io/otel/sdk/trace"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 type nrotelhybridProcessor struct {
+	app    *newrelic.Application
+	txnMap map[oteltrace.TraceID]*newrelic.Transaction // Trace ID -> Transaction
 }
 
 func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSpan) {
@@ -17,6 +21,8 @@ func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSp
 	// should be a valid span context and be marked as remote
 	// this begins a transaction
 	if s.Parent().IsValid() && s.Parent().IsRemote() {
+		txn := p.app.StartTransaction(s.Name())
+		p.txnMap[s.SpanContext().TraceID()] = txn
 	}
 
 }

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -50,13 +50,12 @@ func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSp
 					fullURL = attr.Value.AsString()
 				}
 			}
+			req := newrelic.WebRequest{}
 			nrURL, err := url.Parse(fullURL)
-			if err != nil {
-				// debug log
+			if err == nil {
+				req.URL = nrURL
 			}
-			txn.SetWebRequest(newrelic.WebRequest{
-				URL: nrURL,
-			})
+			txn.SetWebRequest(req)
 		}
 		p.txnMap[s.SpanContext().TraceID()] = txnMapEntry{txn, s.SpanContext().SpanID()}
 	}

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -20,7 +20,7 @@ func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSp
 	// check if remote parent
 	// should be a valid span context and be marked as remote
 	// this begins a transaction
-	if shouldStartTransaction(s.Parent()) {
+	if isTransaction(s.Parent()) {
 		txn := p.app.StartTransaction(s.Name())
 		p.txnMap[s.SpanContext().TraceID()] = txn
 	}
@@ -29,7 +29,7 @@ func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSp
 
 func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
 	// use the trace id from trace.ReadOnlySpan to end the transaction
-	if s.Parent().IsValid() && s.Parent().IsRemote() {
+	if isTransaction(s.Parent()) {
 		txn := p.txnMap[s.SpanContext().TraceID()]
 		if txn != nil {
 			txn.End()
@@ -45,6 +45,6 @@ func (p *nrotelhybridProcessor) ForceFlush(ctx context.Context) error {
 	return nil
 }
 
-func shouldStartTransaction(parent oteltrace.SpanContext) bool {
+func isTransaction(parent oteltrace.SpanContext) bool {
 	return !parent.IsValid() || parent.IsRemote()
 }

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -20,7 +20,7 @@ func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSp
 	// check if remote parent
 	// should be a valid span context and be marked as remote
 	// this begins a transaction
-	if s.Parent().IsValid() && s.Parent().IsRemote() {
+	if shouldStartTransaction(s.Parent()) {
 		txn := p.app.StartTransaction(s.Name())
 		p.txnMap[s.SpanContext().TraceID()] = txn
 	}
@@ -31,7 +31,9 @@ func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
 	// use the trace id from trace.ReadOnlySpan to end the transaction
 	if s.Parent().IsValid() && s.Parent().IsRemote() {
 		txn := p.txnMap[s.SpanContext().TraceID()]
-		txn.End()
+		if txn != nil {
+			txn.End()
+		}
 	}
 }
 
@@ -41,4 +43,8 @@ func (p *nrotelhybridProcessor) Shutdown(ctx context.Context) error {
 
 func (p *nrotelhybridProcessor) ForceFlush(ctx context.Context) error {
 	return nil
+}
+
+func shouldStartTransaction(parent oteltrace.SpanContext) bool {
+	return !parent.IsValid() || parent.IsRemote()
 }

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -1,0 +1,1 @@
+package nrotelhybrid

--- a/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
@@ -1,9 +1,9 @@
 package nrotelhybrid
 
 import (
-	"maps"
 	"testing"
 
+	"go.opentelemetry.io/otel/trace"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -13,11 +13,13 @@ func Test_isTransaction(t *testing.T) {
 	tests := []struct {
 		name string // description of this test case
 		// Named input parameters for target function.
-		parent oteltrace.SpanContext
-		want   bool
+		kind     oteltrace.SpanKind
+		parent   oteltrace.SpanContext
+		txnCheck bool
+		want     bool
 	}{
 		{
-			name: "Remote parent exists and is valid",
+			name: "Remote parent exists and is valid.",
 			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
 				TraceID: validTraceID,
 				SpanID:  validSpanID,
@@ -26,42 +28,149 @@ func Test_isTransaction(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "Local parent exists and is valid",
-			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
-				TraceID: validTraceID,
-				SpanID:  validSpanID,
-				Remote:  false,
-			}),
-			want: false,
-		},
-		{
-			name:   "No parent (root span)",
-			parent: oteltrace.SpanContext{},
-			want:   true,
-		},
-		{
-			name: "Invalid parent marked remote",
+			name: "Remote parent exists but is not valid.",
 			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
 				Remote: true,
 			}),
 			want: true,
 		},
 		{
-			name: "Partially invalid parent (zero SpanID), not remote",
+			name: "No parent. Kind is unspecified.",
+			kind: oteltrace.SpanKindUnspecified,
+			want: false,
+		},
+		{
+			name: "Parent is not remote. Kind is unspecified.",
 			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
-				TraceID: validTraceID,
-				Remote:  false,
+				Remote: false,
 			}),
-			want: true,
+			kind: oteltrace.SpanKindUnspecified,
+			want: false,
+		},
+		{
+			name: "No parent. Kind is internal.",
+			kind: oteltrace.SpanKindInternal,
+			want: false,
+		},
+		{
+			name: "Parent is not remote. Kind is internal.",
+			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+				Remote: false,
+			}),
+			kind: oteltrace.SpanKindInternal,
+			want: false,
+		},
+		{
+			name:     "No parent. Kind is server. txnChecker returns true.",
+			kind:     oteltrace.SpanKindServer,
+			txnCheck: true,
+			want:     false,
+		},
+		{
+			name:     "No parent. Kind is server. txnChecker returns false.",
+			kind:     oteltrace.SpanKindServer,
+			txnCheck: false,
+			want:     true,
+		},
+		{
+			name: "Parent is not remote. Kind is server. txnChecker returns true.",
+			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+				Remote: false,
+			}),
+			kind:     oteltrace.SpanKindServer,
+			txnCheck: true,
+			want:     false,
+		},
+		{
+			name: "Parent is not remote. Kind is server. txnChecker returns false.",
+			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+				Remote: false,
+			}),
+			kind:     oteltrace.SpanKindServer,
+			txnCheck: false,
+			want:     true,
+		},
+		{
+			name: "No parent. Kind is client.",
+			kind: oteltrace.SpanKindClient,
+			want: false,
+		},
+		{
+			name: "Parent is not remote. Kind is client.",
+			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+				Remote: false,
+			}),
+			kind: oteltrace.SpanKindClient,
+			want: false,
+		},
+		{
+			name: "No parent. Kind is producer.",
+			kind: oteltrace.SpanKindProducer,
+			want: false,
+		},
+		{
+			name: "Parent is not remote. Kind is producer.",
+			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+				Remote: false,
+			}),
+			kind: oteltrace.SpanKindProducer,
+			want: false,
+		},
+		{
+			name:     "No parent. Kind is consumer. txnCheck returns true.",
+			kind:     oteltrace.SpanKindConsumer,
+			txnCheck: true,
+			want:     false,
+		},
+		{
+			name:     "No parent. Kind is consumer. txnCheck returns false.",
+			kind:     oteltrace.SpanKindConsumer,
+			txnCheck: false,
+			want:     true,
+		},
+		{
+			name: "Parent is not remote. Kind is consumer. txnCheck returns true.",
+			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+				Remote: false,
+			}),
+			kind:     oteltrace.SpanKindConsumer,
+			txnCheck: true,
+			want:     false,
+		},
+		{
+			name: "Parent is not remote. Kind is consumer. txnCheck returns false",
+			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+				Remote: false,
+			}),
+			kind:     oteltrace.SpanKindConsumer,
+			txnCheck: false,
+			want:     true,
+		},
+		{
+			name: "No parent. Kind is not listed.",
+			kind: 7,
+			want: false,
+		},
+		{
+			name: "Parent is not remote. Kind is not listed.",
+			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+				Remote: false,
+			}),
+			kind: 8,
+			want: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			//p := nrotelhybridProcessor{}
-			//got := p.isTransaction(tt.parent)
-			// if true {
-			// 	t.Errorf("isTransaction() = %v, want %v", got, tt.want)
-			// }
+			p := nrotelhybridProcessor{
+				txnChecker: func(txnMap map[oteltrace.TraceID]txnMapEntry, traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool {
+					return tt.txnCheck
+				},
+			}
+			got := p.isTransaction(tt.kind, trace.SpanContext{}, tt.parent)
+			if got != tt.want {
+				t.Errorf("isTransaction() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }
@@ -144,11 +253,8 @@ func Test_nrotelhybridProcessor_isWithinTransaction(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var p nrotelhybridProcessor
-			p.txnMap = make(map[oteltrace.TraceID]txnMapEntry)
-			maps.Copy(p.txnMap, tt.txnMap)
 
-			got := p.isWithinTransaction(tt.traceID, tt.spanID)
+			got := isWithinTransaction(tt.txnMap, tt.traceID, tt.spanID)
 			if got != tt.want {
 				t.Errorf("isWithinTransaction() = %v, want %v", got, tt.want)
 			}

--- a/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
@@ -1,12 +1,13 @@
 package nrotelhybrid
 
 import (
+	"maps"
 	"testing"
 
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-func Test_shouldStartTransaction(t *testing.T) {
+func Test_isTransaction(t *testing.T) {
 	validTraceID := [16]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
 	validSpanID := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 	tests := []struct {
@@ -56,9 +57,100 @@ func Test_shouldStartTransaction(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isTransaction(tt.parent)
+			//p := nrotelhybridProcessor{}
+			//got := p.isTransaction(tt.parent)
+			// if true {
+			// 	t.Errorf("isTransaction() = %v, want %v", got, tt.want)
+			// }
+		})
+	}
+}
+
+func Test_nrotelhybridProcessor_isWithinTransaction(t *testing.T) {
+	validTraceID := [16]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	validSpanID := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	otherTraceID := [16]byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20}
+	otherSpanID := [8]byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18}
+	missingTraceID := [16]byte{0x12, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20}
+
+	noEntriesMap := map[oteltrace.TraceID]txnMapEntry{}
+
+	singleEntryMap := map[oteltrace.TraceID]txnMapEntry{
+		validTraceID: {txn: nil, spanID: validSpanID},
+	}
+
+	multiEntryMap := map[oteltrace.TraceID]txnMapEntry{
+		validTraceID: {txn: nil, spanID: validSpanID},
+		otherTraceID: {txn: nil, spanID: otherSpanID},
+	}
+
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		traceID oteltrace.TraceID
+		spanID  oteltrace.SpanID
+		txnMap  map[oteltrace.TraceID]txnMapEntry
+		want    bool
+	}{
+		{
+			name:    "TraceID is not within empty transaction map.",
+			traceID: validTraceID,
+			spanID:  validSpanID,
+			txnMap:  noEntriesMap,
+			want:    false,
+		},
+		{
+			name:    "TraceID is not within transaction map.",
+			traceID: otherTraceID,
+			spanID:  otherSpanID,
+			txnMap:  singleEntryMap,
+			want:    false,
+		},
+		{
+			name:    "TraceID is within transaction map and span ID is the same.", // should return false since it is the same transaction as in the map
+			traceID: validTraceID,
+			spanID:  validSpanID,
+			txnMap:  singleEntryMap,
+			want:    false,
+		},
+		{
+			name:    "TraceID is within transaction map and span ID not the same.",
+			traceID: validTraceID,
+			spanID:  otherSpanID,
+			txnMap:  singleEntryMap,
+			want:    true,
+		},
+		{
+			name:    "TraceID is within transaction map with multiple entries and span ID is the same.",
+			traceID: otherTraceID,
+			spanID:  otherSpanID,
+			txnMap:  multiEntryMap,
+			want:    false,
+		},
+		{
+			name:    "TraceID is within transaction map with multiple entries and span ID not the same.",
+			traceID: otherTraceID,
+			spanID:  validSpanID,
+			txnMap:  multiEntryMap,
+			want:    true,
+		},
+		{
+			name:    "TraceID is not within with multiple entries transaction map.",
+			traceID: missingTraceID,
+			spanID:  validSpanID,
+			txnMap:  multiEntryMap,
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var p nrotelhybridProcessor
+			p.txnMap = make(map[oteltrace.TraceID]txnMapEntry)
+			maps.Copy(p.txnMap, tt.txnMap)
+
+			got := p.isWithinTransaction(tt.traceID, tt.spanID)
 			if got != tt.want {
-				t.Errorf("isTransaction() = %v, want %v", got, tt.want)
+				t.Errorf("isWithinTransaction() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
@@ -16,61 +16,114 @@ func Test_isTransaction(t *testing.T) {
 		kind     oteltrace.SpanKind
 		parent   oteltrace.SpanContext
 		txnCheck bool
-		want     bool
+		wantTxn  bool
+		wantWeb  bool
 	}{
 		{
-			name: "Remote parent exists and is valid.",
+			name: "Remote parent exists and is valid. Kind is unspecified.",
 			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
 				TraceID: validTraceID,
 				SpanID:  validSpanID,
 				Remote:  true,
 			}),
-			want: true,
+			wantTxn: true,
+			wantWeb: false,
 		},
 		{
-			name: "Remote parent exists but is not valid.",
+			name: "Remote parent exists but is not valid. Kind is unspecified.",
 			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
 				Remote: true,
 			}),
-			want: true,
+			wantTxn: true,
+			wantWeb: false,
 		},
 		{
-			name: "No parent. Kind is unspecified.",
-			kind: oteltrace.SpanKindUnspecified,
-			want: false,
+			name: "Remote parent exists. Kind is server.",
+			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+				TraceID: validTraceID,
+				SpanID:  validSpanID,
+				Remote:  true,
+			}),
+			kind:    oteltrace.SpanKindServer,
+			wantTxn: true,
+			wantWeb: true,
+		},
+		{
+			name: "Remote parent exists. Kind is client.",
+			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+				TraceID: validTraceID,
+				SpanID:  validSpanID,
+				Remote:  true,
+			}),
+			kind:    oteltrace.SpanKindClient,
+			wantTxn: true,
+			wantWeb: true,
+		},
+		{
+			name: "Remote parent exists. Kind is consumer.",
+			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+				TraceID: validTraceID,
+				SpanID:  validSpanID,
+				Remote:  true,
+			}),
+			kind:    oteltrace.SpanKindConsumer,
+			wantTxn: true,
+			wantWeb: false,
+		},
+		{
+			name: "Remote parent exists. Kind is producer.",
+			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+				TraceID: validTraceID,
+				SpanID:  validSpanID,
+				Remote:  true,
+			}),
+			kind:    oteltrace.SpanKindProducer,
+			wantTxn: true,
+			wantWeb: false,
+		},
+		{
+			name:    "No parent. Kind is unspecified.",
+			kind:    oteltrace.SpanKindUnspecified,
+			wantTxn: false,
+			wantWeb: false,
 		},
 		{
 			name: "Parent is not remote. Kind is unspecified.",
 			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
 				Remote: false,
 			}),
-			kind: oteltrace.SpanKindUnspecified,
-			want: false,
+			kind:    oteltrace.SpanKindUnspecified,
+			wantTxn: false,
+			wantWeb: false,
 		},
 		{
-			name: "No parent. Kind is internal.",
-			kind: oteltrace.SpanKindInternal,
-			want: false,
+			name:    "No parent. Kind is internal.",
+			kind:    oteltrace.SpanKindInternal,
+			wantTxn: false,
+			wantWeb: false,
 		},
 		{
 			name: "Parent is not remote. Kind is internal.",
 			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
 				Remote: false,
 			}),
-			kind: oteltrace.SpanKindInternal,
-			want: false,
+			kind:    oteltrace.SpanKindInternal,
+			wantTxn: false,
+			wantWeb: false,
 		},
 		{
 			name:     "No parent. Kind is server. txnChecker returns true.",
 			kind:     oteltrace.SpanKindServer,
 			txnCheck: true,
-			want:     false,
+			wantTxn:  false,
+			wantWeb:  true,
 		},
 		{
 			name:     "No parent. Kind is server. txnChecker returns false.",
 			kind:     oteltrace.SpanKindServer,
 			txnCheck: false,
-			want:     true,
+			wantTxn:  true,
+			wantWeb:  true,
 		},
 		{
 			name: "Parent is not remote. Kind is server. txnChecker returns true.",
@@ -79,7 +132,8 @@ func Test_isTransaction(t *testing.T) {
 			}),
 			kind:     oteltrace.SpanKindServer,
 			txnCheck: true,
-			want:     false,
+			wantTxn:  false,
+			wantWeb:  true,
 		},
 		{
 			name: "Parent is not remote. Kind is server. txnChecker returns false.",
@@ -88,45 +142,52 @@ func Test_isTransaction(t *testing.T) {
 			}),
 			kind:     oteltrace.SpanKindServer,
 			txnCheck: false,
-			want:     true,
+			wantTxn:  true,
+			wantWeb:  true,
 		},
 		{
-			name: "No parent. Kind is client.",
-			kind: oteltrace.SpanKindClient,
-			want: false,
+			name:    "No parent. Kind is client.",
+			kind:    oteltrace.SpanKindClient,
+			wantTxn: false,
+			wantWeb: true,
 		},
 		{
 			name: "Parent is not remote. Kind is client.",
 			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
 				Remote: false,
 			}),
-			kind: oteltrace.SpanKindClient,
-			want: false,
+			kind:    oteltrace.SpanKindClient,
+			wantTxn: false,
+			wantWeb: true,
 		},
 		{
-			name: "No parent. Kind is producer.",
-			kind: oteltrace.SpanKindProducer,
-			want: false,
+			name:    "No parent. Kind is producer.",
+			kind:    oteltrace.SpanKindProducer,
+			wantTxn: false,
+			wantWeb: false,
 		},
 		{
 			name: "Parent is not remote. Kind is producer.",
 			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
 				Remote: false,
 			}),
-			kind: oteltrace.SpanKindProducer,
-			want: false,
+			kind:    oteltrace.SpanKindProducer,
+			wantTxn: false,
+			wantWeb: false,
 		},
 		{
 			name:     "No parent. Kind is consumer. txnCheck returns true.",
 			kind:     oteltrace.SpanKindConsumer,
 			txnCheck: true,
-			want:     false,
+			wantTxn:  false,
+			wantWeb:  false,
 		},
 		{
 			name:     "No parent. Kind is consumer. txnCheck returns false.",
 			kind:     oteltrace.SpanKindConsumer,
 			txnCheck: false,
-			want:     true,
+			wantTxn:  true,
+			wantWeb:  false,
 		},
 		{
 			name: "Parent is not remote. Kind is consumer. txnCheck returns true.",
@@ -135,7 +196,8 @@ func Test_isTransaction(t *testing.T) {
 			}),
 			kind:     oteltrace.SpanKindConsumer,
 			txnCheck: true,
-			want:     false,
+			wantTxn:  false,
+			wantWeb:  false,
 		},
 		{
 			name: "Parent is not remote. Kind is consumer. txnCheck returns false",
@@ -144,20 +206,23 @@ func Test_isTransaction(t *testing.T) {
 			}),
 			kind:     oteltrace.SpanKindConsumer,
 			txnCheck: false,
-			want:     true,
+			wantTxn:  true,
+			wantWeb:  false,
 		},
 		{
-			name: "No parent. Kind is not listed.",
-			kind: 7,
-			want: false,
+			name:    "No parent. Kind is not listed.",
+			kind:    7,
+			wantTxn: false,
+			wantWeb: false,
 		},
 		{
 			name: "Parent is not remote. Kind is not listed.",
 			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
 				Remote: false,
 			}),
-			kind: 8,
-			want: false,
+			kind:    8,
+			wantTxn: false,
+			wantWeb: false,
 		},
 	}
 	for _, tt := range tests {
@@ -167,9 +232,9 @@ func Test_isTransaction(t *testing.T) {
 					return tt.txnCheck
 				},
 			}
-			got := p.isTransaction(tt.kind, trace.SpanContext{}, tt.parent)
-			if got != tt.want {
-				t.Errorf("isTransaction() = %v, want %v", got, tt.want)
+			gotTxn, gotWeb := p.isTransaction(tt.kind, trace.SpanContext{}, tt.parent)
+			if gotTxn != tt.wantTxn || gotWeb != tt.wantWeb {
+				t.Errorf("isTransaction() = (%v, %v), want (%v, %v)", gotTxn, gotWeb, tt.wantTxn, tt.wantWeb)
 			}
 		})
 	}

--- a/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
@@ -1,1 +1,65 @@
 package nrotelhybrid
+
+import (
+	"testing"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+func Test_shouldStartTransaction(t *testing.T) {
+	validTraceID := [16]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	validSpanID := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		parent oteltrace.SpanContext
+		want   bool
+	}{
+		{
+			name: "Remote parent exists and is valid",
+			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+				TraceID: validTraceID,
+				SpanID:  validSpanID,
+				Remote:  true,
+			}),
+			want: true,
+		},
+		{
+			name: "Local parent exists and is valid",
+			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+				TraceID: validTraceID,
+				SpanID:  validSpanID,
+				Remote:  false,
+			}),
+			want: false,
+		},
+		{
+			name:   "No parent (root span)",
+			parent: oteltrace.SpanContext{},
+			want:   true,
+		},
+		{
+			name: "Invalid parent marked remote",
+			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+				Remote: true,
+			}),
+			want: true,
+		},
+		{
+			name: "Partially invalid parent (zero SpanID), not remote",
+			parent: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+				TraceID: validTraceID,
+				Remote:  false,
+			}),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isTransaction(tt.parent)
+			if got != tt.want {
+				t.Errorf("isTransaction() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
@@ -1,0 +1,1 @@
+package nrotelhybrid


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

<!--
Any relevant links that will help reviewers.
-->

## Details
### Issue
We cannot determine yet if an OTEL Span needs to begin a Transaction
### Goals
- Determine if an OTEL Span needs to begin a transaction
- Start a transaction if necessary in `OnStart`
- End a transaction if necessary in `OnEnd`
### Implementation
- `nrotelhybridProcessor` with `OnStart` and `OnEnd` functions
- `OnStart` will be called when an OTEL span is started 
- `OnEnd` will be called when an OTEL span is ended
- Mutex on `nrotelhybridProcessor` because it can be accessed from multiple goroutines
- `txnMap` holds all started transactions
- `txnChecker` is a function defined when `nrotelhybridProcessor` is created.  It will default to `isWithinTransaction`.  It was created this way for testing purposes
- According to the spec, a transaction is started if it has a remote parent.  If it does not, then it will depend on the span kind/if the otel span occurs within a transaction already
- According to the spec, different span kinds create different kinds of new relic transactions.  Transactions that are `WebTransactions` call `txn.SetWebRequest`
### Not covered
- Beginning segments
- Saving spans
<!--
In-depth description of changes, other technical notes, etc.
-->
