### PR TITLE
(Gemini) go-genai integration support

### DIFF
--- a/integration-tests.mk
+++ b/integration-tests.mk
@@ -56,4 +56,5 @@ GO_INTEGRATION_TESTS=$${INTEGRATION_TESTS:-\
 	nrzap \
 	nrzerolog \
 	nranthropic \
+	nrgemini \
 }

--- a/v3/integrations/nrgemini/examples/simple/main.go
+++ b/v3/integrations/nrgemini/examples/simple/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/newrelic/go-agent/v3/integrations/nrgemini"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"google.golang.org/genai"
+)
+
+func main() {
+	// Initialize New Relic
+	app, err := newrelic.NewApplication(
+		newrelic.ConfigAppName("Gemini Simple Example"),
+		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+		newrelic.ConfigDebugLogger(os.Stdout),
+		newrelic.ConfigAIMonitoringEnabled(true),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := app.WaitForConnection(5 * time.Second); err != nil {
+		log.Fatalf("New Relic failed to connect: %v", err)
+	}
+	defer app.Shutdown(10 * time.Second)
+
+	ctx := context.Background()
+	nrClient, err := nrgemini.NewClient(app, ctx, &genai.ClientConfig{
+		APIKey:  os.Getenv("GEMINI_API_KEY"),
+		Backend: genai.BackendGeminiAPI,
+	})
+	if err != nil {
+		log.Fatalf("Error creating Gemini client: %v", err)
+	}
+
+	// Send a message
+	prompt := "Write a haiku about programming in Go"
+	resp, err := nrClient.Models.GenerateContent(ctx, "gemini-2.5-flash", genai.Text(prompt), nil)
+	if err != nil {
+		log.Fatalf("Error generating content: %v", err)
+	}
+
+	fmt.Println("=== Simple Message Example ===")
+	fmt.Printf("Prompt: %s\n\n", prompt)
+	fmt.Printf("Response: %s\n", resp.Text())
+	if resp.UsageMetadata != nil {
+		fmt.Printf("\nInput tokens:  %d\n", resp.UsageMetadata.PromptTokenCount)
+		fmt.Printf("Output tokens: %d\n", resp.UsageMetadata.CandidatesTokenCount)
+	}
+}

--- a/v3/integrations/nrgemini/examples/streaming/main.go
+++ b/v3/integrations/nrgemini/examples/streaming/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/newrelic/go-agent/v3/integrations/nrgemini"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"google.golang.org/genai"
+)
+
+func main() {
+	// Initialize New Relic
+	app, err := newrelic.NewApplication(
+		newrelic.ConfigAppName("Gemini Streaming Example"),
+		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+		newrelic.ConfigDebugLogger(os.Stdout),
+		newrelic.ConfigAIMonitoringEnabled(true),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := app.WaitForConnection(5 * time.Second); err != nil {
+		log.Fatalf("New Relic failed to connect: %v", err)
+	}
+	defer app.Shutdown(10 * time.Second)
+
+	// Start a transaction
+	txn := app.StartTransaction("streaming-message")
+	defer txn.End()
+
+	ctx := newrelic.NewContext(context.Background(), txn)
+	nrClient, err := nrgemini.NewClient(app, ctx, &genai.ClientConfig{
+		APIKey:  os.Getenv("GEMINI_API_KEY"),
+		Backend: genai.BackendGeminiAPI,
+	})
+	if err != nil {
+		log.Fatalf("Error creating Gemini client: %v", err)
+	}
+
+	prompt := "Explain the benefits of using Go for backend services in 3 points"
+	fmt.Println("=== Streaming Message Example ===")
+	fmt.Printf("Prompt: %s\n\n", prompt)
+	fmt.Print("Response: ")
+
+	// Create a streaming message
+	stream := nrClient.Models.GenerateContentStream(ctx, "gemini-2.5-flash", genai.Text(prompt), nil)
+
+	// Process stream chunks as they arrive
+	for stream.Next() {
+		chunk := stream.Current()
+		if chunk == nil || len(chunk.Candidates) == 0 || chunk.Candidates[0].Content == nil {
+			continue
+		}
+		for _, part := range chunk.Candidates[0].Content.Parts {
+			if part != nil && part.Text != "" {
+				fmt.Print(part.Text)
+			}
+		}
+	}
+
+	if err := stream.Err(); err != nil {
+		log.Fatalf("Stream error: %v", err)
+	}
+
+	if err := stream.Close(); err != nil {
+		log.Fatalf("Stream close error: %v", err)
+	}
+
+	fmt.Println()
+}

--- a/v3/integrations/nrgemini/go.mod
+++ b/v3/integrations/nrgemini/go.mod
@@ -1,0 +1,30 @@
+module github.com/newrelic/go-agent/v3/integrations/nrgemini
+
+go 1.25
+
+require (
+	github.com/google/uuid v1.6.0
+	github.com/newrelic/go-agent/v3 v3.44.1
+	google.golang.org/genai v1.64.0
+)
+
+require (
+	cloud.google.com/go v0.116.0 // indirect
+	cloud.google.com/go/auth v0.9.3 // indirect
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/s2a-go v0.1.8 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
+	go.opencensus.io v0.24.0 // indirect
+	golang.org/x/crypto v0.47.0 // indirect
+	golang.org/x/net v0.49.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
+	golang.org/x/text v0.33.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 // indirect
+	google.golang.org/grpc v1.80.0 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
+)
+
+replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nrgemini/nrgemini.go
+++ b/v3/integrations/nrgemini/nrgemini.go
@@ -1,0 +1,543 @@
+// Package nrgemini provides New Relic instrumentation for the Google GenAI Go
+// SDK (google.golang.org/genai).
+//
+// Wrap your GenAI client with NewClient, then use nrClient.Models.GenerateContent
+// in place of client.Models.GenerateContent to automatically record
+// LlmChatCompletionSummary and LlmChatCompletionMessage custom events and a
+// segment under the active transaction — mirroring the Python agent's
+// mlmodel_gemini instrumentation.
+//
+// The New Relic transaction must be present in the context (via
+// newrelic.NewContext) for instrumentation to activate. AI monitoring must also
+// be enabled on the application (newrelic.ConfigAIMonitoringEnabled(true)).
+package nrgemini
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/newrelic/go-agent/v3/internal"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v3/newrelic/integrationsupport"
+	"google.golang.org/genai"
+)
+
+var reportStreamingDisabled func()
+
+func init() {
+	reportStreamingDisabled = sync.OnceFunc(func() {
+		internal.TrackUsage("Go", "ML", "Streaming", "Disabled")
+	})
+	info, ok := debug.ReadBuildInfo()
+	if info != nil && ok {
+		for _, module := range info.Deps {
+			if module != nil && strings.Contains(module.Path, "google.golang.org/genai") {
+				internal.TrackUsage("Go", "ML", "Gemini", module.Version)
+				return
+			}
+		}
+	}
+	internal.TrackUsage("Go", "ML", "Gemini", "unknown")
+}
+
+// NRClient wraps a GenAI client with New Relic instrumentation.
+type NRClient struct {
+	Client *genai.Client
+	Models NRModelsService
+}
+
+// NRModelsService wraps the GenAI Models service with instrumentation.
+type NRModelsService struct {
+	models           *genai.Models
+	app              *newrelic.Application
+	customAttributes map[string]interface{}
+}
+
+// NewClient creates an NRClient wrapping a new GenAI client initialized with cfg.
+func NewClient(app *newrelic.Application, ctx context.Context, cfg *genai.ClientConfig) (*NRClient, error) {
+	client, err := genai.NewClient(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	nrc := &NRClient{Client: client}
+	nrc.Models = NRModelsService{
+		models:           client.Models,
+		app:              app,
+		customAttributes: make(map[string]interface{}),
+	}
+	return nrc, nil
+}
+
+// AddCustomAttributes attaches llm.* prefixed key-value pairs to all LLM events
+// recorded by this client.
+func (c *NRClient) AddCustomAttributes(attrs map[string]interface{}) {
+	for k, v := range attrs {
+		if strings.HasPrefix(k, "llm.") {
+			c.Models.customAttributes[k] = v
+		}
+	}
+}
+
+// GenerateContent wraps client.Models.GenerateContent with New Relic instrumentation.
+//
+// If ctx carries a New Relic transaction (via newrelic.NewContext) that
+// transaction is used and its lifecycle is left to the caller. If no
+// transaction is present a new one named "GeminiGenerateContent" is started and
+// ended automatically. AI monitoring must be enabled on the application
+// (newrelic.ConfigAIMonitoringEnabled(true)); otherwise the call is forwarded
+// to the underlying SDK without instrumentation.
+func (s *NRModelsService) GenerateContent(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig) (*genai.GenerateContentResponse, error) {
+	cfg, _ := s.app.Config()
+	if !cfg.AIMonitoring.Enabled {
+		return s.models.GenerateContent(ctx, model, contents, config)
+	}
+
+	txn := newrelic.FromContext(ctx)
+	if txn == nil {
+		txn = s.app.StartTransaction("GeminiGenerateContent")
+		defer txn.End()
+		ctx = newrelic.NewContext(ctx, txn)
+	}
+
+	integrationsupport.AddAgentAttribute(txn, "llm", "", true)
+
+	completionID := uuid.New().String()
+	spanID := txn.GetTraceMetadata().SpanID
+	traceID := txn.GetTraceMetadata().TraceID
+
+	seg := txn.StartSegment("Llm/completion/Gemini/GenerateContent")
+	start := time.Now()
+	resp, err := s.models.GenerateContent(ctx, model, contents, config)
+	duration := time.Since(start).Milliseconds()
+	seg.End()
+
+	if err != nil {
+		txn.NoticeError(newrelic.Error{
+			Message: err.Error(),
+			Class:   "GeminiError",
+			Attributes: map[string]interface{}{
+				"completion_id": completionID,
+			},
+		})
+		s.recordSummary(completionID, spanID, traceID, model, config, contents, nil, duration, true)
+		s.recordMessages(completionID, spanID, traceID, model, contents, nil)
+		return resp, err
+	}
+
+	s.recordSummary(completionID, spanID, traceID, model, config, contents, resp, duration, false)
+	s.recordMessages(completionID, spanID, traceID, model, contents, resp)
+	return resp, nil
+}
+
+func (s *NRModelsService) recordSummary(completionID, spanID, traceID, model string, config *genai.GenerateContentConfig, contents []*genai.Content, resp *genai.GenerateContentResponse, duration int64, isError bool) {
+	data := map[string]interface{}{
+		"id":            completionID,
+		"span_id":       spanID,
+		"trace_id":      traceID,
+		"request.model": model,
+		"vendor":        "gemini",
+		"ingest_source": "Go",
+		"duration":      duration,
+	}
+
+	if config != nil {
+		if config.MaxOutputTokens != 0 {
+			data["request.max_tokens"] = config.MaxOutputTokens
+		}
+		if config.Temperature != nil {
+			data["request.temperature"] = *config.Temperature
+		}
+	}
+
+	if isError {
+		data["error"] = true
+		data["response.number_of_messages"] = len(contents)
+	} else if resp != nil {
+		if resp.ModelVersion != "" {
+			data["response.model"] = resp.ModelVersion
+		}
+		if len(resp.Candidates) > 0 && resp.Candidates[0].FinishReason != "" {
+			data["response.choices.finish_reason"] = string(resp.Candidates[0].FinishReason)
+		}
+		data["response.number_of_messages"] = len(contents) + 1
+	}
+
+	s.appendCustomAttrs(data)
+	s.app.RecordCustomEvent("LlmChatCompletionSummary", data)
+}
+
+func (s *NRModelsService) recordMessages(completionID, spanID, traceID, model string, contents []*genai.Content, resp *genai.GenerateContentResponse) {
+	cfg, _ := s.app.Config()
+	responseModel := model
+	if resp != nil && resp.ModelVersion != "" {
+		responseModel = resp.ModelVersion
+	}
+
+	for i, c := range contents {
+		text := extractContentText(c)
+		role := c.Role
+		if role == "" {
+			role = genai.RoleUser
+		}
+		data := map[string]interface{}{
+			"id":             uuid.New().String(),
+			"span_id":        spanID,
+			"trace_id":       traceID,
+			"role":           role,
+			"completion_id":  completionID,
+			"sequence":       i,
+			"response.model": responseModel,
+			"vendor":         "gemini",
+			"ingest_source":  "Go",
+		}
+		if cfg.AIMonitoring.RecordContent.Enabled && text != "" {
+			data["content"] = text
+		}
+		if tokens, ok := s.app.InvokeLLMTokenCountCallback(responseModel, text); ok {
+			data["token_count"] = tokens
+		}
+		s.appendCustomAttrs(data)
+		s.app.RecordCustomEvent("LlmChatCompletionMessage", data)
+	}
+
+	if resp == nil {
+		return
+	}
+
+	responseText := extractResponseText(resp)
+	responseSeq := len(contents)
+	responseRole := genai.RoleModel
+	if len(resp.Candidates) > 0 && resp.Candidates[0].Content != nil && resp.Candidates[0].Content.Role != "" {
+		responseRole = resp.Candidates[0].Content.Role
+	}
+	data := map[string]interface{}{
+		"id":             fmt.Sprintf("%s-%d", resp.ResponseID, responseSeq),
+		"span_id":        spanID,
+		"trace_id":       traceID,
+		"role":           responseRole,
+		"completion_id":  completionID,
+		"sequence":       responseSeq,
+		"response.model": responseModel,
+		"vendor":         "gemini",
+		"ingest_source":  "Go",
+		"is_response":    true,
+	}
+	if cfg.AIMonitoring.RecordContent.Enabled && responseText != "" {
+		data["content"] = responseText
+	}
+	if tokens, ok := s.app.InvokeLLMTokenCountCallback(responseModel, responseText); ok {
+		data["token_count"] = tokens
+	}
+	s.appendCustomAttrs(data)
+	s.app.RecordCustomEvent("LlmChatCompletionMessage", data)
+}
+
+func (s *NRModelsService) appendCustomAttrs(data map[string]interface{}) {
+	for k, v := range s.customAttributes {
+		data[k] = v
+	}
+}
+
+func extractContentText(c *genai.Content) string {
+	if c == nil {
+		return ""
+	}
+	var parts []string
+	for _, p := range c.Parts {
+		if p != nil && p.Text != "" {
+			parts = append(parts, p.Text)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func extractResponseText(resp *genai.GenerateContentResponse) string {
+	if resp == nil || len(resp.Candidates) == 0 || resp.Candidates[0].Content == nil {
+		return ""
+	}
+	var parts []string
+	for _, p := range resp.Candidates[0].Content.Parts {
+		if p != nil && p.Text != "" {
+			parts = append(parts, p.Text)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// NRGenerateContentStreamWrapper wraps a GenAI streaming iterator with New Relic
+// instrumentation. Call Next() to advance the stream, Current() to read the
+// current chunk, Err() to check for errors, and Close() to flush NR events and
+// release resources.
+type NRGenerateContentStreamWrapper struct {
+	next             func() (*genai.GenerateContentResponse, error, bool)
+	stop             func()
+	err              error
+	current          *genai.GenerateContentResponse
+	app              *newrelic.Application
+	txn              *newrelic.Transaction
+	txnOwned         bool
+	seg              *newrelic.Segment
+	customAttributes map[string]interface{}
+	model            string
+	contents         []*genai.Content
+	config           *genai.GenerateContentConfig
+	completionID     string
+	spanID           string
+	traceID          string
+	responseText     strings.Builder
+	responseID       string
+	responseModel    string
+	finishReason     string
+	responseRole     string
+	start            time.Time
+	closed           bool
+}
+
+// GenerateContentStream wraps client.Models.GenerateContentStream with New Relic
+// instrumentation. The returned wrapper exposes Next/Current/Err/Close. Call
+// Close() after the stream is consumed to record NR events.
+func (s *NRModelsService) GenerateContentStream(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig) *NRGenerateContentStreamWrapper {
+	cfg, _ := s.app.Config()
+
+	if !cfg.AIMonitoring.Streaming.Enabled {
+		if reportStreamingDisabled != nil {
+			reportStreamingDisabled()
+		}
+	}
+
+	seq := s.models.GenerateContentStream(ctx, model, contents, config)
+	next, stop := iter.Pull2(seq)
+
+	if !cfg.AIMonitoring.Enabled || !cfg.AIMonitoring.Streaming.Enabled {
+		return &NRGenerateContentStreamWrapper{
+			app:      s.app,
+			model:    model,
+			contents: contents,
+			config:   config,
+			next:     next,
+			stop:     stop,
+			start:    time.Now(),
+		}
+	}
+
+	txn := newrelic.FromContext(ctx)
+	txnOwned := false
+	if txn == nil {
+		txn = s.app.StartTransaction("GeminiGenerateContentStream")
+		txnOwned = true
+		ctx = newrelic.NewContext(ctx, txn)
+	}
+
+	integrationsupport.AddAgentAttribute(txn, "llm", "", true)
+	seg := txn.StartSegment("Llm/completion/Gemini/GenerateContentStream")
+
+	return &NRGenerateContentStreamWrapper{
+		app:              s.app,
+		txn:              txn,
+		txnOwned:         txnOwned,
+		seg:              seg,
+		customAttributes: s.customAttributes,
+		model:            model,
+		contents:         contents,
+		config:           config,
+		completionID:     uuid.New().String(),
+		spanID:           txn.GetTraceMetadata().SpanID,
+		traceID:          txn.GetTraceMetadata().TraceID,
+		start:            time.Now(),
+		next:             next,
+		stop:             stop,
+	}
+}
+
+// Next advances the stream to the next chunk and accumulates response state.
+func (w *NRGenerateContentStreamWrapper) Next() bool {
+	chunk, err, ok := w.next()
+	if !ok {
+		return false
+	}
+	if err != nil {
+		w.err = err
+		return false
+	}
+	w.current = chunk
+	if chunk != nil {
+		if chunk.ResponseID != "" {
+			w.responseID = chunk.ResponseID
+		}
+		if chunk.ModelVersion != "" {
+			w.responseModel = chunk.ModelVersion
+		}
+		if len(chunk.Candidates) > 0 {
+			cand := chunk.Candidates[0]
+			if cand.Content != nil {
+				if cand.Content.Role != "" {
+					w.responseRole = cand.Content.Role
+				}
+				for _, p := range cand.Content.Parts {
+					if p != nil && p.Text != "" {
+						w.responseText.WriteString(p.Text)
+					}
+				}
+			}
+			if cand.FinishReason != "" {
+				w.finishReason = string(cand.FinishReason)
+			}
+		}
+	}
+	return true
+}
+
+// Current returns the most recent stream chunk.
+func (w *NRGenerateContentStreamWrapper) Current() *genai.GenerateContentResponse {
+	return w.current
+}
+
+// Err returns any error encountered during streaming.
+func (w *NRGenerateContentStreamWrapper) Err() error {
+	return w.err
+}
+
+// Close records LlmChatCompletionSummary and LlmChatCompletionMessage events,
+// ends the segment, ends the transaction if it was started by this wrapper,
+// and releases the underlying iterator.
+func (w *NRGenerateContentStreamWrapper) Close() error {
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+	w.recordCustomEvent()
+	if w.txnOwned {
+		w.txn.End()
+	}
+	w.stop()
+	return nil
+}
+
+func (w *NRGenerateContentStreamWrapper) recordCustomEvent() {
+	cfg, _ := w.app.Config()
+	if !cfg.AIMonitoring.Enabled || !cfg.AIMonitoring.Streaming.Enabled {
+		return
+	}
+
+	if w.seg != nil {
+		w.seg.End()
+	}
+
+	duration := time.Since(w.start).Milliseconds()
+	isError := w.err != nil
+
+	if isError {
+		w.txn.NoticeError(newrelic.Error{
+			Message: w.err.Error(),
+			Class:   "GeminiError",
+			Attributes: map[string]interface{}{
+				"completion_id": w.completionID,
+			},
+		})
+	}
+
+	model := w.model
+	if w.responseModel != "" {
+		model = w.responseModel
+	}
+
+	summaryData := map[string]interface{}{
+		"id":            w.completionID,
+		"span_id":       w.spanID,
+		"trace_id":      w.traceID,
+		"request.model": w.model,
+		"vendor":        "gemini",
+		"ingest_source": "Go",
+		"duration":      duration,
+	}
+	if w.config != nil {
+		if w.config.MaxOutputTokens != 0 {
+			summaryData["request.max_tokens"] = w.config.MaxOutputTokens
+		}
+		if w.config.Temperature != nil {
+			summaryData["request.temperature"] = *w.config.Temperature
+		}
+	}
+	if isError {
+		summaryData["error"] = true
+		summaryData["response.number_of_messages"] = len(w.contents)
+	} else {
+		summaryData["response.model"] = model
+		if w.finishReason != "" {
+			summaryData["response.choices.finish_reason"] = w.finishReason
+		}
+		summaryData["response.number_of_messages"] = len(w.contents) + 1
+	}
+	w.appendCustomAttrs(summaryData)
+	w.app.RecordCustomEvent("LlmChatCompletionSummary", summaryData)
+
+	for i, c := range w.contents {
+		text := extractContentText(c)
+		role := c.Role
+		if role == "" {
+			role = genai.RoleUser
+		}
+		msgData := map[string]interface{}{
+			"id":             uuid.New().String(),
+			"span_id":        w.spanID,
+			"trace_id":       w.traceID,
+			"role":           role,
+			"completion_id":  w.completionID,
+			"sequence":       i,
+			"response.model": model,
+			"vendor":         "gemini",
+			"ingest_source":  "Go",
+		}
+		if cfg.AIMonitoring.RecordContent.Enabled && text != "" {
+			msgData["content"] = text
+		}
+		if tokens, ok := w.app.InvokeLLMTokenCountCallback(model, text); ok {
+			msgData["token_count"] = tokens
+		}
+		w.appendCustomAttrs(msgData)
+		w.app.RecordCustomEvent("LlmChatCompletionMessage", msgData)
+	}
+
+	if isError {
+		return
+	}
+
+	responseText := w.responseText.String()
+	responseSeq := len(w.contents)
+	responseRole := w.responseRole
+	if responseRole == "" {
+		responseRole = genai.RoleModel
+	}
+	respData := map[string]interface{}{
+		"id":             fmt.Sprintf("%s-%d", w.responseID, responseSeq),
+		"span_id":        w.spanID,
+		"trace_id":       w.traceID,
+		"role":           responseRole,
+		"completion_id":  w.completionID,
+		"sequence":       responseSeq,
+		"response.model": model,
+		"vendor":         "gemini",
+		"ingest_source":  "Go",
+		"is_response":    true,
+	}
+	if cfg.AIMonitoring.RecordContent.Enabled && responseText != "" {
+		respData["content"] = responseText
+	}
+	if tokens, ok := w.app.InvokeLLMTokenCountCallback(model, responseText); ok {
+		respData["token_count"] = tokens
+	}
+	w.appendCustomAttrs(respData)
+	w.app.RecordCustomEvent("LlmChatCompletionMessage", respData)
+}
+
+func (w *NRGenerateContentStreamWrapper) appendCustomAttrs(data map[string]interface{}) {
+	for k, v := range w.customAttributes {
+		data[k] = v
+	}
+}

--- a/v3/integrations/nrgemini/nrgemini_test.go
+++ b/v3/integrations/nrgemini/nrgemini_test.go
@@ -1,0 +1,1178 @@
+package nrgemini
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/newrelic/go-agent/v3/internal"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v3/newrelic/integrationsupport"
+	"google.golang.org/genai"
+)
+
+const (
+	testModel     = "gemini-2.5-flash"
+	testPrompt    = "What is 8*5"
+	testResponse  = "Hello there, how may I assist you today?"
+	testMessageID = "resp_abc123"
+)
+
+// noCodeLevelMetrics disables CLM so code.* agent attributes don't appear in
+// test assertions and cause spurious length mismatches.
+func noCodeLevelMetrics(cfg *newrelic.Config) {
+	cfg.CodeLevelMetrics.Enabled = false
+}
+
+// mockGeminiClient returns an NRClient wired to a test HTTP server. The
+// handler is called for every request.
+func mockGeminiClient(t *testing.T, app *newrelic.Application, handler http.HandlerFunc) *NRClient {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	nrClient, err := NewClient(app, context.Background(), &genai.ClientConfig{
+		APIKey:  "test-key",
+		Backend: genai.BackendGeminiAPI,
+		HTTPOptions: genai.HTTPOptions{
+			BaseURL: srv.URL,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return nrClient
+}
+
+func successHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"candidates": []map[string]interface{}{
+			{
+				"content": map[string]interface{}{
+					"role":  "model",
+					"parts": []map[string]interface{}{{"text": testResponse}},
+				},
+				"finishReason": "STOP",
+			},
+		},
+		"modelVersion": testModel,
+		"responseId":   testMessageID,
+		"usageMetadata": map[string]interface{}{
+			"promptTokenCount":     9,
+			"candidatesTokenCount": 12,
+			"totalTokenCount":      21,
+		},
+	})
+}
+
+func errorHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    400,
+			"message": "test error",
+			"status":  "INVALID_ARGUMENT",
+		},
+	})
+}
+
+func streamingHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+
+	writeSSE := func(payload map[string]interface{}) {
+		data, _ := json.Marshal(payload)
+		fmt.Fprintf(w, "data: %s\n\n", data)
+	}
+
+	writeSSE(map[string]interface{}{
+		"candidates": []map[string]interface{}{
+			{
+				"content": map[string]interface{}{
+					"role":  "model",
+					"parts": []map[string]interface{}{{"text": testResponse}},
+				},
+			},
+		},
+		"modelVersion": testModel,
+		"responseId":   testMessageID,
+	})
+
+	writeSSE(map[string]interface{}{
+		"candidates": []map[string]interface{}{
+			{
+				"content": map[string]interface{}{
+					"role":  "model",
+					"parts": []map[string]interface{}{{"text": ""}},
+				},
+				"finishReason": "STOP",
+			},
+		},
+		"modelVersion": testModel,
+		"responseId":   testMessageID,
+	})
+
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func TestAddCustomAttributes(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, successHandler)
+
+	nrClient.AddCustomAttributes(map[string]interface{}{
+		"llm.foo": "bar",
+	})
+	if nrClient.Models.customAttributes["llm.foo"] != "bar" {
+		t.Errorf("expected llm.foo=bar, got %v", nrClient.Models.customAttributes["llm.foo"])
+	}
+}
+
+func TestAddCustomAttributesIncorrectPrefix(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, successHandler)
+
+	nrClient.AddCustomAttributes(map[string]interface{}{
+		"notllm.foo": "bar",
+	})
+	if len(nrClient.Models.customAttributes) != 0 {
+		t.Errorf("expected no custom attributes, got %d", len(nrClient.Models.customAttributes))
+	}
+}
+
+func TestGenerateContent(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, successHandler)
+
+	resp, err := nrClient.Models.GenerateContent(context.Background(), testModel, genai.Text(testPrompt), &genai.GenerateContentConfig{MaxOutputTokens: 150})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Text() != testResponse {
+		t.Errorf("unexpected response text: %q", resp.Text())
+	}
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                             internal.MatchAnything,
+				"span_id":                        internal.MatchAnything,
+				"trace_id":                       internal.MatchAnything,
+				"request.model":                  testModel,
+				"request.max_tokens":             int32(150),
+				"vendor":                         "gemini",
+				"ingest_source":                  "Go",
+				"duration":                       internal.MatchAnything,
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "STOP",
+				"response.number_of_messages":    2,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       0,
+				"role":           "user",
+				"content":        testPrompt,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       1,
+				"role":           "model",
+				"content":        testResponse,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+				"is_response":    true,
+			},
+		},
+	})
+}
+
+func TestGenerateContentAIMonitoringNotEnabled(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil) // AI monitoring NOT enabled
+	nrClient := mockGeminiClient(t, app.Application, successHandler)
+
+	resp, err := nrClient.Models.GenerateContent(context.Background(), testModel, genai.Text(testPrompt), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Text() != testResponse {
+		t.Errorf("unexpected response text: %q", resp.Text())
+	}
+	app.ExpectCustomEvents(t, []internal.WantEvent{})
+}
+
+func TestGenerateContentError(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, errorHandler)
+
+	_, err := nrClient.Models.GenerateContent(context.Background(), testModel, genai.Text(testPrompt), &genai.GenerateContentConfig{MaxOutputTokens: 150})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                          internal.MatchAnything,
+				"span_id":                     internal.MatchAnything,
+				"trace_id":                    internal.MatchAnything,
+				"request.model":               testModel,
+				"request.max_tokens":          int32(150),
+				"vendor":                      "gemini",
+				"ingest_source":               "Go",
+				"duration":                    internal.MatchAnything,
+				"error":                       true,
+				"response.number_of_messages": 1,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       0,
+				"role":           "user",
+				"content":        testPrompt,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+			},
+		},
+	})
+
+	app.ExpectErrorEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":            "TransactionError",
+				"transactionName": "OtherTransaction/Go/GeminiGenerateContent",
+				"guid":            internal.MatchAnything,
+				"priority":        internal.MatchAnything,
+				"sampled":         internal.MatchAnything,
+				"traceId":         internal.MatchAnything,
+				"error.class":     "GeminiError",
+				"error.message":   internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"completion_id": internal.MatchAnything,
+			},
+			AgentAttributes: map[string]interface{}{
+				"llm": true,
+			},
+		},
+	})
+}
+
+func TestGenerateContentWithExistingTxn(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, successHandler)
+
+	txn := app.StartTransaction("my-existing-txn")
+	ctx := newrelic.NewContext(context.Background(), txn)
+
+	resp, err := nrClient.Models.GenerateContent(ctx, testModel, genai.Text(testPrompt), &genai.GenerateContentConfig{MaxOutputTokens: 150})
+	txn.End()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Text() != testResponse {
+		t.Errorf("unexpected response text: %q", resp.Text())
+	}
+
+	// Events should be recorded under the caller's transaction
+	app.ExpectTxnEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "Transaction",
+				"name":      "OtherTransaction/Go/my-existing-txn",
+				"guid":      internal.MatchAnything,
+				"priority":  internal.MatchAnything,
+				"sampled":   internal.MatchAnything,
+				"traceId":   internal.MatchAnything,
+				"timestamp": internal.MatchAnything,
+				"duration":  internal.MatchAnything,
+				"totalTime": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{},
+			AgentAttributes: map[string]interface{}{
+				"llm": true,
+			},
+		},
+	})
+}
+
+func TestGenerateContentStream(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), &genai.GenerateContentConfig{MaxOutputTokens: 150})
+
+	for stream.Next() {
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                             internal.MatchAnything,
+				"span_id":                        internal.MatchAnything,
+				"trace_id":                       internal.MatchAnything,
+				"request.model":                  testModel,
+				"request.max_tokens":             int32(150),
+				"vendor":                         "gemini",
+				"ingest_source":                  "Go",
+				"duration":                       internal.MatchAnything,
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "STOP",
+				"response.number_of_messages":    2,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       0,
+				"role":           "user",
+				"content":        testPrompt,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       1,
+				"role":           "model",
+				"content":        testResponse,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+				"is_response":    true,
+			},
+		},
+	})
+}
+
+func TestGenerateContentStreamAIMonitoringNotEnabled(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil) // AI monitoring NOT enabled
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
+	for stream.Next() {
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+	app.ExpectCustomEvents(t, []internal.WantEvent{})
+	app.ExpectTxnEvents(t, []internal.WantEvent{})
+}
+
+func TestGenerateContentStreamDisabled(t *testing.T) {
+	// AI monitoring enabled but streaming specifically disabled — no txn should be started.
+	app := integrationsupport.NewTestApp(nil,
+		newrelic.ConfigAIMonitoringEnabled(true),
+		func(cfg *newrelic.Config) { cfg.AIMonitoring.Streaming.Enabled = false },
+		noCodeLevelMetrics,
+	)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
+
+	if stream.txn != nil {
+		t.Error("expected txn to be nil when streaming is disabled, but it was set")
+	}
+	if stream.txnOwned {
+		t.Error("expected txnOwned=false when streaming is disabled")
+	}
+
+	for stream.Next() {
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+	app.ExpectCustomEvents(t, []internal.WantEvent{})
+	app.ExpectTxnEvents(t, []internal.WantEvent{})
+}
+
+func TestGenerateContentStreamWithExistingTxn(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	txn := app.StartTransaction("my-existing-streaming-txn")
+	ctx := newrelic.NewContext(context.Background(), txn)
+
+	stream := nrClient.Models.GenerateContentStream(ctx, testModel, genai.Text(testPrompt), nil)
+	for stream.Next() {
+	}
+	stream.Close()
+	txn.End()
+
+	app.ExpectTxnEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "Transaction",
+				"name":      "OtherTransaction/Go/my-existing-streaming-txn",
+				"guid":      internal.MatchAnything,
+				"priority":  internal.MatchAnything,
+				"sampled":   internal.MatchAnything,
+				"traceId":   internal.MatchAnything,
+				"timestamp": internal.MatchAnything,
+				"duration":  internal.MatchAnything,
+				"totalTime": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{},
+			AgentAttributes: map[string]interface{}{
+				"llm": true,
+			},
+		},
+	})
+}
+
+// --- Pure helper function tests ---
+
+func TestExtractContentText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *genai.Content
+		want string
+	}{
+		{name: "nil", in: nil, want: ""},
+		{name: "empty parts", in: &genai.Content{}, want: ""},
+		{
+			name: "single text",
+			in:   &genai.Content{Parts: []*genai.Part{{Text: "hello"}}},
+			want: "hello",
+		},
+		{
+			name: "multiple text",
+			in: &genai.Content{Parts: []*genai.Part{
+				{Text: "hello"},
+				{Text: "world"},
+			}},
+			want: "hello world",
+		},
+		{
+			name: "empty text ignored",
+			in: &genai.Content{Parts: []*genai.Part{
+				{Text: "hello"},
+				{Text: ""},
+				{Text: "world"},
+			}},
+			want: "hello world",
+		},
+		{
+			name: "nil part ignored",
+			in: &genai.Content{Parts: []*genai.Part{
+				{Text: "hello"},
+				nil,
+				{Text: "world"},
+			}},
+			want: "hello world",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractContentText(tc.in); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractResponseText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *genai.GenerateContentResponse
+		want string
+	}{
+		{name: "nil", in: nil, want: ""},
+		{name: "no candidates", in: &genai.GenerateContentResponse{}, want: ""},
+		{
+			name: "nil content",
+			in: &genai.GenerateContentResponse{Candidates: []*genai.Candidate{
+				{Content: nil},
+			}},
+			want: "",
+		},
+		{
+			name: "single text",
+			in: &genai.GenerateContentResponse{Candidates: []*genai.Candidate{
+				{Content: &genai.Content{Parts: []*genai.Part{{Text: "hello"}}}},
+			}},
+			want: "hello",
+		},
+		{
+			name: "multiple text",
+			in: &genai.GenerateContentResponse{Candidates: []*genai.Candidate{
+				{Content: &genai.Content{Parts: []*genai.Part{
+					{Text: "hello"},
+					{Text: "world"},
+				}}},
+			}},
+			want: "hello world",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractResponseText(tc.in); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// --- NRGenerateContentStreamWrapper.appendCustomAttrs tests ---
+
+func TestStreamWrapperAppendCustomAttrs(t *testing.T) {
+	w := &NRGenerateContentStreamWrapper{
+		customAttributes: map[string]interface{}{
+			"llm.key1": "val1",
+			"llm.key2": 42,
+		},
+	}
+	data := map[string]interface{}{"existing": "preserved"}
+	w.appendCustomAttrs(data)
+
+	if data["llm.key1"] != "val1" {
+		t.Errorf("llm.key1: got %v, want val1", data["llm.key1"])
+	}
+	if data["llm.key2"] != 42 {
+		t.Errorf("llm.key2: got %v, want 42", data["llm.key2"])
+	}
+	if data["existing"] != "preserved" {
+		t.Errorf("existing key was overwritten, got %v", data["existing"])
+	}
+}
+
+func TestStreamWrapperAppendCustomAttrsEmpty(t *testing.T) {
+	w := &NRGenerateContentStreamWrapper{customAttributes: map[string]interface{}{}}
+	data := map[string]interface{}{"k": "v"}
+	w.appendCustomAttrs(data)
+	if len(data) != 1 || data["k"] != "v" {
+		t.Errorf("data should be unchanged, got %v", data)
+	}
+}
+
+// --- NRClient.AddCustomAttributes additional tests ---
+
+func TestAddCustomAttributesMixed(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, successHandler)
+
+	nrClient.AddCustomAttributes(map[string]interface{}{
+		"llm.valid":   "yes",
+		"notllm.skip": "no",
+		"also.skip":   "no",
+	})
+
+	if len(nrClient.Models.customAttributes) != 1 {
+		t.Fatalf("expected 1 attribute, got %d: %v", len(nrClient.Models.customAttributes), nrClient.Models.customAttributes)
+	}
+	if nrClient.Models.customAttributes["llm.valid"] != "yes" {
+		t.Errorf("llm.valid: got %v, want yes", nrClient.Models.customAttributes["llm.valid"])
+	}
+}
+
+func TestAddCustomAttributesEmpty(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil)
+	nrClient := mockGeminiClient(t, app.Application, successHandler)
+	nrClient.AddCustomAttributes(map[string]interface{}{})
+	if len(nrClient.Models.customAttributes) != 0 {
+		t.Errorf("expected no attributes, got %d", len(nrClient.Models.customAttributes))
+	}
+}
+
+// --- NRModelsService.recordSummary tests ---
+
+func newTestService(t *testing.T) (*NRModelsService, integrationsupport.ExpectApp) {
+	t.Helper()
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	svc := &NRModelsService{
+		app:              app.Application,
+		customAttributes: make(map[string]interface{}),
+	}
+	return svc, app
+}
+
+func baseContents() []*genai.Content {
+	return genai.Text(testPrompt)
+}
+
+func baseConfig() *genai.GenerateContentConfig {
+	return &genai.GenerateContentConfig{MaxOutputTokens: 150}
+}
+
+func TestRecordSummarySuccess(t *testing.T) {
+	svc, app := newTestService(t)
+	resp := &genai.GenerateContentResponse{
+		ResponseID:   testMessageID,
+		ModelVersion: testModel,
+		Candidates: []*genai.Candidate{
+			{FinishReason: genai.FinishReasonStop},
+		},
+	}
+
+	svc.recordSummary("cid", "sid", "tid", testModel, baseConfig(), baseContents(), resp, 100, false)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                             "cid",
+				"span_id":                        "sid",
+				"trace_id":                       "tid",
+				"request.model":                  testModel,
+				"request.max_tokens":             int32(150),
+				"vendor":                         "gemini",
+				"ingest_source":                  "Go",
+				"duration":                       int64(100),
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "STOP",
+				"response.number_of_messages":    2,
+			},
+		},
+	})
+}
+
+func TestRecordSummaryError(t *testing.T) {
+	svc, app := newTestService(t)
+
+	svc.recordSummary("cid", "sid", "tid", testModel, baseConfig(), baseContents(), nil, 50, true)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                          "cid",
+				"span_id":                     "sid",
+				"trace_id":                    "tid",
+				"request.model":               testModel,
+				"request.max_tokens":          int32(150),
+				"vendor":                      "gemini",
+				"ingest_source":               "Go",
+				"duration":                    int64(50),
+				"error":                       true,
+				"response.number_of_messages": 1,
+			},
+		},
+	})
+}
+
+func TestRecordSummaryWithTemperature(t *testing.T) {
+	svc, app := newTestService(t)
+	// Use a value exactly representable in float32 so the harness comparison
+	// isn't tripped by float32 precision loss.
+	temp := float32(0.5)
+	config := baseConfig()
+	config.Temperature = &temp
+	resp := &genai.GenerateContentResponse{
+		ResponseID:   testMessageID,
+		ModelVersion: testModel,
+		Candidates: []*genai.Candidate{
+			{FinishReason: genai.FinishReasonStop},
+		},
+	}
+
+	svc.recordSummary("cid", "sid", "tid", testModel, config, baseContents(), resp, 10, false)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                             "cid",
+				"span_id":                        "sid",
+				"trace_id":                       "tid",
+				"request.model":                  testModel,
+				"request.max_tokens":             int32(150),
+				"request.temperature":            float32(0.5),
+				"vendor":                         "gemini",
+				"ingest_source":                  "Go",
+				"duration":                       int64(10),
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "STOP",
+				"response.number_of_messages":    2,
+			},
+		},
+	})
+}
+
+func TestRecordSummaryCustomAttrs(t *testing.T) {
+	svc, app := newTestService(t)
+	svc.customAttributes["llm.env"] = "prod"
+	resp := &genai.GenerateContentResponse{
+		ModelVersion: testModel,
+		Candidates: []*genai.Candidate{
+			{FinishReason: genai.FinishReasonStop},
+		},
+	}
+
+	svc.recordSummary("cid", "sid", "tid", testModel, baseConfig(), baseContents(), resp, 10, false)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                             "cid",
+				"span_id":                        "sid",
+				"trace_id":                       "tid",
+				"request.model":                  testModel,
+				"request.max_tokens":             int32(150),
+				"vendor":                         "gemini",
+				"ingest_source":                  "Go",
+				"duration":                       int64(10),
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "STOP",
+				"response.number_of_messages":    2,
+				"llm.env":                        "prod",
+			},
+		},
+	})
+}
+
+func TestRecordSummaryNilConfig(t *testing.T) {
+	svc, app := newTestService(t)
+	resp := &genai.GenerateContentResponse{
+		ModelVersion: testModel,
+		Candidates: []*genai.Candidate{
+			{FinishReason: genai.FinishReasonStop},
+		},
+	}
+
+	svc.recordSummary("cid", "sid", "tid", testModel, nil, baseContents(), resp, 10, false)
+
+	// no request.max_tokens or request.temperature should be recorded when config is nil
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                             "cid",
+				"span_id":                        "sid",
+				"trace_id":                       "tid",
+				"request.model":                  testModel,
+				"vendor":                         "gemini",
+				"ingest_source":                  "Go",
+				"duration":                       int64(10),
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "STOP",
+				"response.number_of_messages":    2,
+			},
+		},
+	})
+}
+
+// --- NRModelsService.recordMessages tests ---
+
+func TestRecordMessagesWithResp(t *testing.T) {
+	svc, app := newTestService(t)
+	resp := &genai.GenerateContentResponse{
+		ResponseID:   testMessageID,
+		ModelVersion: testModel,
+		Candidates: []*genai.Candidate{
+			{Content: &genai.Content{
+				Role:  genai.RoleModel,
+				Parts: []*genai.Part{{Text: testResponse}},
+			}},
+		},
+	}
+
+	svc.recordMessages("cid", "sid", "tid", testModel, baseContents(), resp)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "user",
+				"completion_id":  "cid",
+				"sequence":       0,
+				"response.model": testModel,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"content":        testPrompt,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             fmt.Sprintf("%s-%d", testMessageID, 1),
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "model",
+				"completion_id":  "cid",
+				"sequence":       1,
+				"response.model": testModel,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"content":        testResponse,
+				"is_response":    true,
+			},
+		},
+	})
+}
+
+func TestRecordMessagesNilResp(t *testing.T) {
+	svc, app := newTestService(t)
+
+	svc.recordMessages("cid", "sid", "tid", testModel, baseContents(), nil)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "user",
+				"completion_id":  "cid",
+				"sequence":       0,
+				"response.model": testModel,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"content":        testPrompt,
+			},
+		},
+	})
+}
+
+func TestRecordMessagesContentDisabled(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil,
+		newrelic.ConfigAIMonitoringEnabled(true),
+		func(cfg *newrelic.Config) { cfg.AIMonitoring.RecordContent.Enabled = false },
+		noCodeLevelMetrics,
+	)
+	svc := &NRModelsService{
+		app:              app.Application,
+		customAttributes: make(map[string]interface{}),
+	}
+	resp := &genai.GenerateContentResponse{
+		ResponseID:   testMessageID,
+		ModelVersion: testModel,
+		Candidates: []*genai.Candidate{
+			{Content: &genai.Content{
+				Role:  genai.RoleModel,
+				Parts: []*genai.Part{{Text: testResponse}},
+			}},
+		},
+	}
+
+	svc.recordMessages("cid", "sid", "tid", testModel, baseContents(), resp)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "user",
+				"completion_id":  "cid",
+				"sequence":       0,
+				"response.model": testModel,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             fmt.Sprintf("%s-%d", testMessageID, 1),
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "model",
+				"completion_id":  "cid",
+				"sequence":       1,
+				"response.model": testModel,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"is_response":    true,
+			},
+		},
+	})
+}
+
+// --- NRGenerateContentStreamWrapper.Next state accumulation ---
+
+func TestStreamWrapperNextAccumulatesState(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
+
+	for stream.Next() {
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if stream.responseID != testMessageID {
+		t.Errorf("responseID: got %q, want %q", stream.responseID, testMessageID)
+	}
+	if stream.responseModel != testModel {
+		t.Errorf("responseModel: got %q, want %q", stream.responseModel, testModel)
+	}
+	if got := stream.responseText.String(); got != testResponse {
+		t.Errorf("responseText: got %q, want %q", got, testResponse)
+	}
+	if stream.finishReason != "STOP" {
+		t.Errorf("finishReason: got %q, want %q", stream.finishReason, "STOP")
+	}
+	if stream.responseRole != genai.RoleModel {
+		t.Errorf("responseRole: got %q, want %q", stream.responseRole, genai.RoleModel)
+	}
+
+	stream.Close()
+}
+
+// --- NRGenerateContentStreamWrapper.Close tests ---
+
+func TestStreamWrapperCloseReturnsNilOnSuccess(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
+	for stream.Next() {
+	}
+
+	if err := stream.Close(); err != nil {
+		t.Errorf("Close() returned unexpected error: %v", err)
+	}
+}
+
+func TestStreamWrapperCloseIdempotent(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
+	for stream.Next() {
+	}
+
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// Second Close should be a no-op (return nil, no double-flush of events).
+	if err := stream.Close(); err != nil {
+		t.Errorf("second Close() should be nil, got: %v", err)
+	}
+}
+
+func TestStreamWrapperCloseEndsTxnWhenOwned(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	// No txn in context — wrapper creates and owns the transaction.
+	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
+	for stream.Next() {
+	}
+	stream.Close()
+
+	app.ExpectTxnEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "Transaction",
+				"name":      "OtherTransaction/Go/GeminiGenerateContentStream",
+				"guid":      internal.MatchAnything,
+				"priority":  internal.MatchAnything,
+				"sampled":   internal.MatchAnything,
+				"traceId":   internal.MatchAnything,
+				"timestamp": internal.MatchAnything,
+				"duration":  internal.MatchAnything,
+				"totalTime": internal.MatchAnything,
+			},
+			UserAttributes:  map[string]interface{}{},
+			AgentAttributes: map[string]interface{}{"llm": true},
+		},
+	})
+}
+
+func TestStreamWrapperCloseNoTxnEndWhenNotOwned(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	// Inject an existing txn — wrapper must NOT end it.
+	txn := app.StartTransaction("caller-txn")
+	ctx := newrelic.NewContext(context.Background(), txn)
+
+	stream := nrClient.Models.GenerateContentStream(ctx, testModel, genai.Text(testPrompt), nil)
+	for stream.Next() {
+	}
+	stream.Close()
+
+	// Txn is still open; end it explicitly and verify the name is caller-txn, not the wrapper name.
+	txn.End()
+
+	app.ExpectTxnEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "Transaction",
+				"name":      "OtherTransaction/Go/caller-txn",
+				"guid":      internal.MatchAnything,
+				"priority":  internal.MatchAnything,
+				"sampled":   internal.MatchAnything,
+				"traceId":   internal.MatchAnything,
+				"timestamp": internal.MatchAnything,
+				"duration":  internal.MatchAnything,
+				"totalTime": internal.MatchAnything,
+			},
+			UserAttributes:  map[string]interface{}{},
+			AgentAttributes: map[string]interface{}{"llm": true},
+		},
+	})
+}
+
+// --- LLM content spec check: full content survives to serialized event ---
+
+// The LLM spec requires that LlmChatCompletionMessage.content is NOT truncated
+// at any stage. This test drives a long (>256-byte) prompt through the sync
+// integration and verifies the recorded event carries the full content.
+func TestGenerateContentLongPromptNotTruncated(t *testing.T) {
+	svc, app := newTestService(t)
+	longPrompt := strings.Repeat("a", 1024)
+	resp := &genai.GenerateContentResponse{
+		ResponseID:   testMessageID,
+		ModelVersion: testModel,
+		Candidates: []*genai.Candidate{
+			{Content: &genai.Content{
+				Role:  genai.RoleModel,
+				Parts: []*genai.Part{{Text: testResponse}},
+			}},
+		},
+	}
+
+	svc.recordMessages("cid", "sid", "tid", testModel, genai.Text(longPrompt), resp)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "user",
+				"completion_id":  "cid",
+				"sequence":       0,
+				"response.model": testModel,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"content":        longPrompt,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             fmt.Sprintf("%s-%d", testMessageID, 1),
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "model",
+				"completion_id":  "cid",
+				"sequence":       1,
+				"response.model": testModel,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"content":        testResponse,
+				"is_response":    true,
+			},
+		},
+	})
+}

--- a/v3/newrelic/attributes_from_internal.go
+++ b/v3/newrelic/attributes_from_internal.go
@@ -464,16 +464,25 @@ func addUserAttribute(a *attributes, key string, val interface{}, d destinationS
 }
 
 func writeAttributeValueJSON(w *jsonFieldsWriter, key string, val interface{}) {
+	writeAttributeValueJSONLimit(w, key, val, maxAttributeLengthBytes)
+}
+
+// writeAttributeValueJSONLimit writes an attribute value to JSON, truncating
+// string values (and JSON-marshaled composites) at limit bytes. A limit <= 0
+// disables truncation and preserves the full value; this is required for
+// LlmChatCompletionMessage.content and LlmEmbedding.input per the LLM spec.
+// https://source.datanerd.us/agents/agent-specs/blob/main/artificial_intelligence/LLMs.md#llm-events
+func writeAttributeValueJSONLimit(w *jsonFieldsWriter, key string, val interface{}, limit int) {
 	switch v := val.(type) {
 	case string:
-		if len(v) > maxAttributeLengthBytes {
-			v = v[:maxAttributeLengthBytes]
+		if limit > 0 && len(v) > limit {
+			v = v[:limit]
 		}
 		w.stringField(key, v)
 	case error:
 		value := v.Error()
-		if len(value) > maxAttributeLengthBytes {
-			value = value[:maxAttributeLengthBytes]
+		if limit > 0 && len(value) > limit {
+			value = value[:limit]
 		}
 		w.stringField(key, value)
 	case bool:
@@ -509,22 +518,22 @@ func writeAttributeValueJSON(w *jsonFieldsWriter, key string, val interface{}) {
 	case float64:
 		w.floatField(key, v)
 	case time.Time:
-		writeAttributeValueJSON(w, key, v.String())
+		writeAttributeValueJSONLimit(w, key, v.String(), limit)
 	case time.Duration:
-		writeAttributeValueJSON(w, key, v.String())
+		writeAttributeValueJSONLimit(w, key, v.String(), limit)
 	case time.Weekday:
-		writeAttributeValueJSON(w, key, v.String())
+		writeAttributeValueJSONLimit(w, key, v.String(), limit)
 	case *time.Location:
-		writeAttributeValueJSON(w, key, v.String())
+		writeAttributeValueJSONLimit(w, key, v.String(), limit)
 	case time.Month:
-		writeAttributeValueJSON(w, key, v.String())
+		writeAttributeValueJSONLimit(w, key, v.String(), limit)
 	default:
 		// attempt to construct a JSON string
 		kind := reflect.ValueOf(v).Kind()
 		if kind == reflect.Struct || kind == reflect.Map || kind == reflect.Slice || kind == reflect.Array {
 			bytes, _ := json.Marshal(v)
-			if len(bytes) > maxAttributeLengthBytes {
-				bytes = bytes[:maxAttributeLengthBytes]
+			if limit > 0 && len(bytes) > limit {
+				bytes = bytes[:limit]
 			}
 			w.stringField(key, string(bytes))
 		} else {

--- a/v3/newrelic/attributes_test.go
+++ b/v3/newrelic/attributes_test.go
@@ -207,6 +207,24 @@ func TestWriteAttributeValueJSON(t *testing.T) {
 	}
 }
 
+func TestWriteAttributeValueJSONLimit(t *testing.T) {
+	buf := &bytes.Buffer{}
+	w := jsonFieldsWriter{buf: buf}
+
+	long := strings.Repeat("a", 300)
+
+	buf.WriteByte('{')
+	writeAttributeValueJSONLimit(&w, "truncated", long, 256)
+	writeAttributeValueJSONLimit(&w, "unlimited", long, 0)
+	buf.WriteByte('}')
+
+	expect := `{"truncated":"` + strings.Repeat("a", 256) + `","unlimited":"` + long + `"}`
+	js := buf.String()
+	if js != expect {
+		t.Error(js, expect)
+	}
+}
+
 func TestValidAttributeTypes(t *testing.T) {
 	testcases := []struct {
 		Input interface{}

--- a/v3/newrelic/custom_event.go
+++ b/v3/newrelic/custom_event.go
@@ -44,8 +44,18 @@ func (e *customEvent) WriteJSON(buf *bytes.Buffer) {
 	buf.WriteByte(',')
 	buf.WriteByte('{')
 	w = jsonFieldsWriter{buf: buf}
-	for key, val := range e.truncatedParams {
-		writeAttributeValueJSON(&w, key, val)
+	// LLM event types MUST preserve full-length attribute values so the
+	// collector can count tokens server-side. Every other custom event type
+	// keeps the default byte-limit truncation.
+	// https://source.datanerd.us/agents/agent-specs/blob/main/artificial_intelligence/LLMs.md#llm-events
+	if e.eventType == "LlmEmbedding" || e.eventType == "LlmChatCompletionSummary" || e.eventType == "LlmChatCompletionMessage" {
+		for key, val := range e.truncatedParams {
+			writeAttributeValueJSONLimit(&w, key, val, 0)
+		}
+	} else {
+		for key, val := range e.truncatedParams {
+			writeAttributeValueJSON(&w, key, val)
+		}
 	}
 	buf.WriteByte('}')
 

--- a/v3/newrelic/custom_event_test.go
+++ b/v3/newrelic/custom_event_test.go
@@ -224,3 +224,59 @@ func TestMultipleAttributeJSON(t *testing.T) {
 		t.Error(string(js))
 	}
 }
+
+func TestLlmChatCompletionMessageContentNotTruncated(t *testing.T) {
+	event, err := createCustomEventUnlimitedSize("LlmChatCompletionMessage", map[string]interface{}{"content": strLen512}, now)
+	if nil != err {
+		t.Fatal(err)
+	}
+	js, err := json.Marshal(event)
+	if nil != err {
+		t.Fatal(err)
+	}
+	if string(js) != `[{"type":"LlmChatCompletionMessage","timestamp":1417136460000},{"content":"`+strLen512+`"},{}]` {
+		t.Fatal(string(js))
+	}
+}
+
+func TestLlmChatCompletionSummaryContentNotTruncated(t *testing.T) {
+	event, err := createCustomEventUnlimitedSize("LlmChatCompletionSummary", map[string]interface{}{"content": strLen512}, now)
+	if nil != err {
+		t.Fatal(err)
+	}
+	js, err := json.Marshal(event)
+	if nil != err {
+		t.Fatal(err)
+	}
+	if string(js) != `[{"type":"LlmChatCompletionSummary","timestamp":1417136460000},{"content":"`+strLen512+`"},{}]` {
+		t.Fatal(string(js))
+	}
+}
+
+func TestLlmEmbeddingInputNotTruncated(t *testing.T) {
+	event, err := createCustomEventUnlimitedSize("LlmEmbedding", map[string]interface{}{"input": strLen512}, now)
+	if nil != err {
+		t.Fatal(err)
+	}
+	js, err := json.Marshal(event)
+	if nil != err {
+		t.Fatal(err)
+	}
+	if string(js) != `[{"type":"LlmEmbedding","timestamp":1417136460000},{"input":"`+strLen512+`"},{}]` {
+		t.Fatal(string(js))
+	}
+}
+
+func TestNonLlmEventStillTruncated(t *testing.T) {
+	event, err := createCustomEvent("myEvent", map[string]interface{}{"content": strLen512}, now)
+	if nil != err {
+		t.Fatal(err)
+	}
+	js, err := json.Marshal(event)
+	if nil != err {
+		t.Fatal(err)
+	}
+	if string(js) != `[{"type":"myEvent","timestamp":1417136460000},{"content":"`+strLen255+`"},{}]` {
+		t.Fatal(string(js))
+	}
+}


### PR DESCRIPTION

## Details

<!--
In-depth description of changes, other technical notes, etc.
-->

- Added Support for `go-genai`(Gemini integration)
  - Support for `GenerateContent` / `GenerateContentStream`
  - `nrgemini.GenerateContent()` 
    - Calls go-genai's `GenerateContent()` 
    - After a response, record `LlmChatCompletionSummary` and `LlmChatCompletionMessage` events
- Preserved full-length LLM event attributes being sent via custom events