### PR TITLE
fix: Transaction Tracing

### DIFF
--- a/v3/integrations/nrconnect/nrconnect_test.go
+++ b/v3/integrations/nrconnect/nrconnect_test.go
@@ -144,7 +144,7 @@ func TestUnaryClientInterceptor(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/UnaryUnary",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
+				Attributes:  map[string]interface{}{},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "External/" + sv.Listener.Addr().String() + "/Connect/TestApplication/DoUnaryUnary",
@@ -236,7 +236,7 @@ func TestUnaryStreamClientInterceptor(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/UnaryStream",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
+				Attributes:  map[string]interface{}{},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "External/" + sv.Listener.Addr().String() + "/Connect/TestApplication/DoUnaryStream",

--- a/v3/integrations/nrgrpc/nrgrpc_client_test.go
+++ b/v3/integrations/nrgrpc/nrgrpc_client_test.go
@@ -154,7 +154,7 @@ func TestUnaryClientInterceptor(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/UnaryUnary",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
+				Attributes:  map[string]interface{}{},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "External/bufnet/gRPC/TestApplication/DoUnaryUnary",
@@ -248,7 +248,7 @@ func TestUnaryStreamClientInterceptor(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/UnaryStream",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
+				Attributes:  map[string]interface{}{},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "External/bufnet/gRPC/TestApplication/DoUnaryStream",
@@ -340,7 +340,7 @@ func TestStreamUnaryClientInterceptor(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/StreamUnary",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
+				Attributes:  map[string]interface{}{},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "External/bufnet/gRPC/TestApplication/DoStreamUnary",
@@ -456,7 +456,7 @@ func TestStreamStreamClientInterceptor(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/StreamStream",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
+				Attributes:  map[string]interface{}{},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "External/bufnet/gRPC/TestApplication/DoStreamStream",
@@ -604,7 +604,7 @@ func TestClientStreamingError(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/UnaryStream",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
+				Attributes:  map[string]interface{}{},
 				Children:    []internal.WantTraceSegment{},
 			}},
 		},

--- a/v3/integrations/nrmicro/nrmicro_test.go
+++ b/v3/integrations/nrmicro/nrmicro_test.go
@@ -225,7 +225,7 @@ func testClientCallWithTransaction(c client.Client, t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/name",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
+				Attributes:  map[string]interface{}{},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "External/testing/Micro/TestHandler.Method",
@@ -379,7 +379,7 @@ func TestClientPublishWithTransaction(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/name",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
+				Attributes:  map[string]interface{}{},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "MessageBroker/Micro/Topic/Produce/Named/topic",
@@ -547,7 +547,7 @@ func TestClientStreamWrapperWithTransaction(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/name",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
+				Attributes:  map[string]interface{}{},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "External/testing/Micro/TestHandler.StreamingMethod",
@@ -645,7 +645,7 @@ func TestServerWrapperWithApp(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "WebTransaction/Go/TestHandler.Method",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
+				Attributes:  map[string]interface{}{},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "Custom/Method",
@@ -739,7 +739,7 @@ func TestServerWrapperWithAppReturnsError(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "WebTransaction/Go/TestHandlerWithError.Method",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
+				Attributes:  map[string]interface{}{},
 				Children:    []internal.WantTraceSegment{},
 			}},
 		},
@@ -979,7 +979,7 @@ func TestServerSubscribe(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/Message/Micro/Topic/Named/topic",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
+				Attributes:  map[string]interface{}{},
 				Children: []internal.WantTraceSegment{{
 					SegmentName: "Custom/segment",
 					Attributes:  map[string]interface{}{},
@@ -1051,7 +1051,7 @@ func TestServerSubscribeWithError(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/Message/Micro/Topic/Named/topic",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
+				Attributes:  map[string]interface{}{},
 				Children:    []internal.WantTraceSegment{},
 			}},
 		},

--- a/v3/integrations/nrnats/nrnats_test.go
+++ b/v3/integrations/nrnats/nrnats_test.go
@@ -115,7 +115,7 @@ func TestStartPublishSegmentBasic(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/testing",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
+				Attributes:  map[string]interface{}{},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "MessageBroker/NATS/Topic/Produce/Named/mysubject",

--- a/v3/newrelic/internal_segment_attributes_test.go
+++ b/v3/newrelic/internal_segment_attributes_test.go
@@ -57,7 +57,6 @@ func TestTraceSegments(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/hello",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "Custom/basic",
@@ -139,7 +138,6 @@ func TestTraceSegmentsNoBacktrace(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/hello",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "Custom/basic",
@@ -195,7 +193,6 @@ func TestTraceStacktraceServerSideConfig(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/hello",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "Custom/basic",
@@ -269,7 +266,6 @@ func TestTraceSegmentAttributesExcluded(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/hello",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "Custom/basic",
@@ -349,7 +345,6 @@ func TestTraceSegmentAttributesSpecificallyExcluded(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/hello",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "Custom/basic",
@@ -414,7 +409,6 @@ func TestTraceSegmentAttributesDisabled(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/hello",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "Custom/basic",
@@ -487,7 +481,6 @@ func TestTraceSegmentAttributesSpecificallyDisabled(t *testing.T) {
 			Attributes:  map[string]interface{}{},
 			Children: []internal.WantTraceSegment{{
 				SegmentName: "OtherTransaction/Go/hello",
-				Attributes:  map[string]interface{}{"exclusive_duration_millis": internal.MatchAnything},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName: "Custom/basic",

--- a/v3/newrelic/internal_txn.go
+++ b/v3/newrelic/internal_txn.go
@@ -363,8 +363,9 @@ func (txn *txn) MergeIntoHarvest(h *harvest) {
 
 	if txn.shouldSaveTrace() {
 		h.TxnTraces.Witness(harvestTrace{
-			txnEvent: txn.txnEvent,
-			Trace:    txn.TxnTrace,
+			txnEvent:  txn.txnEvent,
+			Trace:     txn.TxnTrace,
+			asyncWork: len(txn.asyncThreads) > 0,
 		})
 	}
 

--- a/v3/newrelic/stacktrace.go
+++ b/v3/newrelic/stacktrace.go
@@ -47,7 +47,15 @@ func (f StacktraceFrame) isAgent() bool {
 		strings.Contains(f.Name, "github.com/newrelic/go-agent/v3/newrelic.")
 }
 
+func (f StacktraceFrame) isPopulated() bool {
+	return f.Name != "" || f.File != "" || f.Line != 0
+}
+
 func (f StacktraceFrame) WriteJSON(buf *bytes.Buffer) {
+	if !f.isPopulated() {
+		jsonx.AppendString(buf, "")
+		return
+	}
 	jsonx.AppendString(buf, fmt.Sprintf("%s (%s:%d)", f.formattedName(), f.File, f.Line))
 }
 

--- a/v3/newrelic/stacktrace.go
+++ b/v3/newrelic/stacktrace.go
@@ -5,9 +5,12 @@ package newrelic
 
 import (
 	"bytes"
+	"fmt"
 	"path"
 	"runtime"
 	"strings"
+
+	"github.com/newrelic/go-agent/v3/internal/jsonx"
 )
 
 // stackTrace is a stack trace.
@@ -45,18 +48,7 @@ func (f StacktraceFrame) isAgent() bool {
 }
 
 func (f StacktraceFrame) WriteJSON(buf *bytes.Buffer) {
-	buf.WriteByte('{')
-	w := jsonFieldsWriter{buf: buf}
-	if f.Name != "" {
-		w.stringField("name", f.formattedName())
-	}
-	if f.File != "" {
-		w.stringField("filepath", f.File)
-	}
-	if f.Line != 0 {
-		w.intField("line", f.Line)
-	}
-	buf.WriteByte('}')
+	jsonx.AppendString(buf, fmt.Sprintf("%s (%s:%d)", f.formattedName(), f.File, f.Line))
 }
 
 func writeFrames(buf *bytes.Buffer, frames []StacktraceFrame) {

--- a/v3/newrelic/stacktrace_test.go
+++ b/v3/newrelic/stacktrace_test.go
@@ -39,16 +39,16 @@ func TestLongStackTraceLimitsFrames(t *testing.T) {
 func TestManyStackTraceFramesLimitsOutput(t *testing.T) {
 	frames := make([]StacktraceFrame, maxStackTraceFrames+20)
 	expect := `[
-	{},{},{},{},{},{},{},{},{},{},
-	{},{},{},{},{},{},{},{},{},{},
-	{},{},{},{},{},{},{},{},{},{},
-	{},{},{},{},{},{},{},{},{},{},
-	{},{},{},{},{},{},{},{},{},{},
-	{},{},{},{},{},{},{},{},{},{},
-	{},{},{},{},{},{},{},{},{},{},
-	{},{},{},{},{},{},{},{},{},{},
-	{},{},{},{},{},{},{},{},{},{},
-	{},{},{},{},{},{},{},{},{},{}
+	"","","","","","","","","","",
+	"","","","","","","","","","",
+	"","","","","","","","","","",
+	"","","","","","","","","","",
+	"","","","","","","","","","",
+	"","","","","","","","","","",
+	"","","","","","","","","","",
+	"","","","","","","","","","",
+	"","","","","","","","","","",
+	"","","","","","","","","",""
 	]`
 	estimate := 256 * len(frames)
 	output := bytes.NewBuffer(make([]byte, 0, estimate))
@@ -135,56 +135,16 @@ func TestStacktraceFrames(t *testing.T) {
 	buf := &bytes.Buffer{}
 	writeFrames(buf, inputFrames)
 	expectedJSON := `[
-		{
-			"name":"main.noticeError",
-			"filepath":"/Users/will/Desktop/gopath/src/github.com/newrelic/go-agent/v3/examples/server/main.go",
-			"line":30
-		},
-		{
-			"name":"http.HandlerFunc.ServeHTTP",
-			"filepath":"/Users/will/.gvm/gos/go1.13/src/net/http/server.go",
-			"line":2007
-		},
-		{
-			"name":"newrelic.WrapHandle.func1",
-			"filepath":"/Users/will/Desktop/gopath/src/github.com/newrelic/go-agent/v3/newrelic/instrumentation.go",
-			"line":41
-		},
-		{
-			"name":"http.HandlerFunc.ServeHTTP",
-			"filepath":"/Users/will/.gvm/gos/go1.13/src/net/http/server.go",
-			"line":2007
-		},
-		{
-			"name":"newrelic.WrapHandleFunc.func1",
-			"filepath":"/Users/will/Desktop/gopath/src/github.com/newrelic/go-agent/v3/newrelic/instrumentation.go",
-			"line":71
-		},
-		{
-			"name":"http.HandlerFunc.ServeHTTP",
-			"filepath":"/Users/will/.gvm/gos/go1.13/src/net/http/server.go",
-			"line":2007
-		},
-		{
-			"name":"http.(*ServeMux).ServeHTTP",
-			"filepath":"/Users/will/.gvm/gos/go1.13/src/net/http/server.go",
-			"line":2387
-		},
-		{
-			"name":"http.serverHandler.ServeHTTP",
-			"filepath":"/Users/will/.gvm/gos/go1.13/src/net/http/server.go",
-			"line":2802
-		},
-		{
-			"name":"http.(*conn).serve",
-			"filepath":"/Users/will/.gvm/gos/go1.13/src/net/http/server.go",
-			"line":1890
-		},
-		{
-			"name":"runtime.goexit",
-			"filepath":"/Users/will/.gvm/gos/go1.13/src/runtime/asm_amd64.s",
-			"line":1357
-		}]`
+		"main.noticeError (/Users/will/Desktop/gopath/src/github.com/newrelic/go-agent/v3/examples/server/main.go:30)",
+		"http.HandlerFunc.ServeHTTP (/Users/will/.gvm/gos/go1.13/src/net/http/server.go:2007)",
+		"newrelic.WrapHandle.func1 (/Users/will/Desktop/gopath/src/github.com/newrelic/go-agent/v3/newrelic/instrumentation.go:41)",
+		"http.HandlerFunc.ServeHTTP (/Users/will/.gvm/gos/go1.13/src/net/http/server.go:2007)",
+		"newrelic.WrapHandleFunc.func1 (/Users/will/Desktop/gopath/src/github.com/newrelic/go-agent/v3/newrelic/instrumentation.go:71)",
+		"http.HandlerFunc.ServeHTTP (/Users/will/.gvm/gos/go1.13/src/net/http/server.go:2007)",
+		"http.(*ServeMux).ServeHTTP (/Users/will/.gvm/gos/go1.13/src/net/http/server.go:2387)",
+		"http.serverHandler.ServeHTTP (/Users/will/.gvm/gos/go1.13/src/net/http/server.go:2802)",
+		"http.(*conn).serve (/Users/will/.gvm/gos/go1.13/src/net/http/server.go:1890)",
+		"runtime.goexit (/Users/will/.gvm/gos/go1.13/src/runtime/asm_amd64.s:1357)"]`
 	testExpectedJSON(t, expectedJSON, buf.String())
 }
 
@@ -197,24 +157,17 @@ func TestStackTraceTopFrame(t *testing.T) {
 		return js
 	})
 
-	stack := []struct {
-		Name     string `json:"name"`
-		FilePath string `json:"filepath"`
-		Line     int    `json:"line"`
-	}{}
+	stack := []string{}
 	if err := json.Unmarshal(stackJSON, &stack); err != nil {
 		t.Fatal(err)
 	}
 	if len(stack) < 2 {
 		t.Fatal(string(stackJSON))
 	}
-	if stack[0].Name != "stacktracetest.TopStackFrame" {
+	if !strings.HasPrefix(stack[0], "stacktracetest.TopStackFrame (") {
 		t.Error(string(stackJSON))
 	}
-	if stack[0].Line != 9 {
-		t.Error(string(stackJSON))
-	}
-	if !strings.Contains(stack[0].FilePath, "go-agent/v3/internal/stacktracetest/stacktracetest.go") {
+	if !strings.Contains(stack[0], "go-agent/v3/internal/stacktracetest/stacktracetest.go") {
 		t.Error(string(stackJSON))
 	}
 }

--- a/v3/newrelic/txn_trace.go
+++ b/v3/newrelic/txn_trace.go
@@ -214,7 +214,7 @@ func (trace *harvestTrace) writeJSON(buf *bytes.Buffer) {
 
 	buf.WriteByte('[') // begin trace
 
-	jsonx.AppendInt(buf, trace.Start.UnixNano()/1000)
+	jsonx.AppendFloat(buf, float64(trace.Start.UnixMilli()))
 	buf.WriteByte(',')
 	jsonx.AppendFloat(buf, trace.Duration.Seconds()*1000.0)
 	buf.WriteByte(',')
@@ -231,12 +231,12 @@ func (trace *harvestTrace) writeJSON(buf *bytes.Buffer) {
 
 	// If the trace string pool is used, insert another array here.
 
-	jsonx.AppendFloat(buf, 0.0) // unused timestamp
-	buf.WriteByte(',')          //
-	buf.WriteString("{}")       // unused: formerly request parameters
-	buf.WriteByte(',')          //
-	buf.WriteString("{}")       // unused: formerly custom parameters
-	buf.WriteByte(',')          //
+	jsonx.AppendFloat(buf, float64(trace.Start.UnixMilli())) // unused timestamp
+	buf.WriteByte(',')                                       //
+	buf.WriteString("{}")                                    // unused: formerly request parameters
+	buf.WriteByte(',')                                       //
+	buf.WriteString("{}")                                    // unused: formerly custom parameters
+	buf.WriteByte(',')                                       //
 
 	printNodeStart(buf, nodeDetails{ // begin outer root
 		name:          "ROOT",

--- a/v3/newrelic/txn_trace.go
+++ b/v3/newrelic/txn_trace.go
@@ -74,6 +74,8 @@ func (trace *txnTrace) witnessNode(end segmentEnd, name string, attrs spanAttrib
 	}
 	node.attributes = attrs
 	node.TransactionGUID = externalGUID
+	exclusiveMs := float64(end.exclusive.Milliseconds())
+	node.exclusiveDurationMillis = &exclusiveMs
 	if !trace.considerNode(end) {
 		return
 	}
@@ -102,7 +104,8 @@ func (trace *txnTrace) witnessNode(end segmentEnd, name string, attrs spanAttrib
 // the collector.
 type harvestTrace struct {
 	txnEvent
-	Trace txnTrace
+	Trace     txnTrace
+	asyncWork bool
 }
 
 type nodeDetails struct {
@@ -210,6 +213,12 @@ func (trace *harvestTrace) writeJSON(buf *bytes.Buffer) {
 	for i := 0; i < len(nodes); i++ {
 		nodes[i] = &trace.Trace.nodes[i]
 	}
+	// if there is not async work, don't calculate exclusiveDurationMillis
+	if !trace.asyncWork {
+		for _, n := range nodes {
+			n.exclusiveDurationMillis = nil
+		}
+	}
 	sort.Sort(nodes)
 
 	buf.WriteByte('[') // begin trace
@@ -244,17 +253,19 @@ func (trace *harvestTrace) writeJSON(buf *bytes.Buffer) {
 		relativeStop:  trace.Duration,
 	})
 
-	// exclusive_duration_millis field is added to fix the transaction trace
-	// summary tab.  If exclusive_duration_millis is not provided, the UIs
-	// will calculate exclusive time, which doesn't work for this root node
-	// since all async goroutines are children of this root.
-	exclusiveDurationMillis := trace.Duration.Seconds() * 1000.0
 	details := nodeDetails{ // begin inner root
 		name:          trace.FinalName,
 		relativeStart: 0,
 		relativeStop:  trace.Duration,
 	}
-	details.exclusiveDurationMillis = &exclusiveDurationMillis
+	if trace.asyncWork {
+		// exclusive_duration_millis field is added to fix the transaction trace
+		// summary tab.  If exclusive_duration_millis is not provided, the UIs
+		// will calculate exclusive time, which doesn't work for this root node
+		// since all async goroutines are children of this root.
+		exclusiveDurationMillis := trace.Duration.Seconds() * 1000.0
+		details.exclusiveDurationMillis = &exclusiveDurationMillis
+	}
 	printNodeStart(buf, details)
 
 	for next := 0; next < len(nodes); {

--- a/v3/newrelic/txn_trace_test.go
+++ b/v3/newrelic/txn_trace_test.go
@@ -136,7 +136,6 @@ func TestTxnTrace(t *testing.T) {
 				SegmentName:         "WebTransaction/Go/hello",
 				RelativeStartMillis: 0,
 				RelativeStopMillis:  20000,
-				Attributes:          map[string]interface{}{"exclusive_duration_millis": 20000},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName:         "Custom/t1",
@@ -266,7 +265,7 @@ func TestTxnTraceNoNodes(t *testing.T) {
 				SegmentName:         "WebTransaction/Go/hello",
 				RelativeStartMillis: 0,
 				RelativeStopMillis:  20000,
-				Attributes:          map[string]interface{}{"exclusive_duration_millis": 20000},
+				Attributes:          map[string]interface{}{},
 				Children:            []internal.WantTraceSegment{},
 			}},
 		},
@@ -357,7 +356,8 @@ func TestTxnTraceAsync(t *testing.T) {
 				Priority: 0.5,
 			},
 		},
-		Trace: txndata.TxnTrace,
+		Trace:     txndata.TxnTrace,
+		asyncWork: true,
 	})
 
 	expectTxnTraces(t, ht, []internal.WantTxnTrace{{
@@ -387,13 +387,13 @@ func TestTxnTraceAsync(t *testing.T) {
 						SegmentName:         "Custom/thread1.segment1",
 						RelativeStartMillis: 1000,
 						RelativeStopMillis:  8000,
-						Attributes:          map[string]interface{}{},
+						Attributes:          map[string]interface{}{"exclusive_duration_millis": 5000},
 						Children: []internal.WantTraceSegment{
 							{
 								SegmentName:         "Custom/thread1.segment2",
 								RelativeStartMillis: 2000,
 								RelativeStopMillis:  4000,
-								Attributes:          map[string]interface{}{},
+								Attributes:          map[string]interface{}{"exclusive_duration_millis": 2000},
 								Children:            []internal.WantTraceSegment{},
 							},
 						},
@@ -402,20 +402,20 @@ func TestTxnTraceAsync(t *testing.T) {
 						SegmentName:         "Custom/thread2.segment1",
 						RelativeStartMillis: 3000,
 						RelativeStopMillis:  5000,
-						Attributes:          map[string]interface{}{},
+						Attributes:          map[string]interface{}{"exclusive_duration_millis": 2000},
 						Children:            []internal.WantTraceSegment{},
 					},
 					{
 						SegmentName:         "Custom/thread3.segment1",
 						RelativeStartMillis: 6000,
 						RelativeStopMillis:  10000,
-						Attributes:          map[string]interface{}{},
+						Attributes:          map[string]interface{}{"exclusive_duration_millis": 2000},
 						Children: []internal.WantTraceSegment{
 							{
 								SegmentName:         "Custom/thread3.segment2",
 								RelativeStartMillis: 7000,
 								RelativeStopMillis:  9000,
-								Attributes:          map[string]interface{}{},
+								Attributes:          map[string]interface{}{"exclusive_duration_millis": 2000},
 								Children:            []internal.WantTraceSegment{},
 							},
 						},
@@ -486,7 +486,7 @@ func TestTxnTraceOldCAT(t *testing.T) {
 				SegmentName:         "WebTransaction/Go/hello",
 				RelativeStartMillis: 0,
 				RelativeStopMillis:  20000,
-				Attributes:          map[string]interface{}{"exclusive_duration_millis": 20000},
+				Attributes:          map[string]interface{}{},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName:         "ExternalTransaction/example.com/1#1/WebTransaction/Go/otherService",
@@ -555,7 +555,7 @@ func TestTxnTraceExcludeURI(t *testing.T) {
 				SegmentName:         "WebTransaction/Go/hello",
 				RelativeStartMillis: 0,
 				RelativeStopMillis:  20000,
-				Attributes:          map[string]interface{}{"exclusive_duration_millis": 20000},
+				Attributes:          map[string]interface{}{},
 				Children:            []internal.WantTraceSegment{},
 			}},
 		},
@@ -611,7 +611,7 @@ func TestTxnTraceNoSegmentsNoAttributes(t *testing.T) {
 				SegmentName:         "WebTransaction/Go/hello",
 				RelativeStartMillis: 0,
 				RelativeStopMillis:  20000,
-				Attributes:          map[string]interface{}{"exclusive_duration_millis": 20000},
+				Attributes:          map[string]interface{}{},
 				Children:            []internal.WantTraceSegment{},
 			}},
 		},
@@ -678,7 +678,7 @@ func TestTxnTraceSlowestNodesSaved(t *testing.T) {
 				SegmentName:         "WebTransaction/Go/hello",
 				RelativeStartMillis: 0,
 				RelativeStopMillis:  123000,
-				Attributes:          map[string]interface{}{"exclusive_duration_millis": 123000},
+				Attributes:          map[string]interface{}{},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName:         "Custom/5",
@@ -781,7 +781,7 @@ func TestTxnTraceSegmentThreshold(t *testing.T) {
 				SegmentName:         "WebTransaction/Go/hello",
 				RelativeStartMillis: 0,
 				RelativeStopMillis:  123000,
-				Attributes:          map[string]interface{}{"exclusive_duration_millis": 123000},
+				Attributes:          map[string]interface{}{},
 				Children: []internal.WantTraceSegment{
 					{
 						SegmentName:         "Custom/7",
@@ -898,7 +898,7 @@ func TestLongestTraceSaved(t *testing.T) {
 				SegmentName:         "WebTransaction/Go/5",
 				RelativeStartMillis: 0,
 				RelativeStopMillis:  5000,
-				Attributes:          map[string]interface{}{"exclusive_duration_millis": 5000},
+				Attributes:          map[string]interface{}{},
 				Children:            []internal.WantTraceSegment{},
 			}},
 		},
@@ -960,7 +960,7 @@ func TestTxnTraceStackTraceThreshold(t *testing.T) {
 					SegmentName:         "WebTransaction/Go/3",
 					RelativeStartMillis: 0,
 					RelativeStopMillis:  3000,
-					Attributes:          map[string]interface{}{"exclusive_duration_millis": 3000},
+					Attributes:          map[string]interface{}{},
 					Children: []internal.WantTraceSegment{
 						{
 							SegmentName:         "Custom/t1",
@@ -1071,7 +1071,7 @@ func TestTxnTraceSynthetics(t *testing.T) {
 					SegmentName:         "WebTransaction/Go/3",
 					RelativeStartMillis: 0,
 					RelativeStopMillis:  3000,
-					Attributes:          map[string]interface{}{"exclusive_duration_millis": 3000},
+					Attributes:          map[string]interface{}{},
 					Children:            []internal.WantTraceSegment{},
 				}},
 			},
@@ -1094,7 +1094,7 @@ func TestTxnTraceSynthetics(t *testing.T) {
 					SegmentName:         "WebTransaction/Go/5",
 					RelativeStartMillis: 0,
 					RelativeStopMillis:  5000,
-					Attributes:          map[string]interface{}{"exclusive_duration_millis": 5000},
+					Attributes:          map[string]interface{}{},
 					Children:            []internal.WantTraceSegment{},
 				}},
 			},
@@ -1117,7 +1117,7 @@ func TestTxnTraceSynthetics(t *testing.T) {
 					SegmentName:         "WebTransaction/Go/4",
 					RelativeStartMillis: 0,
 					RelativeStopMillis:  4000,
-					Attributes:          map[string]interface{}{"exclusive_duration_millis": 4000},
+					Attributes:          map[string]interface{}{},
 					Children:            []internal.WantTraceSegment{},
 				}},
 			},
@@ -1147,17 +1147,17 @@ func TestTraceJSON(t *testing.T) {
    "12345",
    [
       [
-         1417136460000000,
+         1.41713646e+12,
          3000,
          "WebTransaction/Go/trace",
          null,
-         [0,{},{},
+         [1.41713646e+12,{},{},
             [
                0,
                3000,
                "ROOT",
                {},
-               [[0,3000,"WebTransaction/Go/trace",{"exclusive_duration_millis":3000},[]]]
+               [[0,3000,"WebTransaction/Go/trace",{},[]]]
             ],
             {
                "agentAttributes":{},
@@ -1201,17 +1201,17 @@ func TestTraceCatGUID(t *testing.T) {
    "12345",
    [
       [
-         1417136460000000,
+         1.41713646e+12,
          3000,
          "WebTransaction/Go/trace",
          null,
-         [0,{},{},
+         [1.41713646e+12,{},{},
             [
                0,
                3000,
                "ROOT",
                {},
-               [[0,3000,"WebTransaction/Go/trace",{"exclusive_duration_millis":3000},[]]]
+               [[0,3000,"WebTransaction/Go/trace",{},[]]]
             ],
             {
                "agentAttributes":{},
@@ -1256,17 +1256,17 @@ func TestTraceDistributedTracingGUID(t *testing.T) {
    "12345",
    [
       [
-         1417136460000000,
+         1.41713646e+12,
          3000,
          "WebTransaction/Go/trace",
          null,
-         [0,{},{},
+         [1.41713646e+12,{},{},
             [
                0,
                3000,
                "ROOT",
                {},
-               [[0,3000,"WebTransaction/Go/trace",{"exclusive_duration_millis":3000},[]]]
+               [[0,3000,"WebTransaction/Go/trace",{},[]]]
             ],
             {
                "agentAttributes":{},


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

<!--
Any relevant links that will help reviewers.
-->

## Details
<!--
In-depth description of changes, other technical notes, etc.
-->
### Issue
**Transaction Traces**
- `backtrace` not showing properly in the UI because it was an array of objects
- `timestamp` showing as 0 always
- `exclusive_duration_millis` showing as null
### Goals
- `backtrace` shows up properly in the UI
- `timestamp` shows the proper timestamp
- `exclusive_duration_millis` not always null
### Implementation
- `backtrace` serialized into an array of string.  Please check the format as there is no standard format for the strings in the spec.
- `timestamp` populated by the trace start in milliseconds instead of hardcoded 0.0 value
- `exclusive_duration_millis` is set when async work is detected in a thread.  If that amount of asyncThreads is greater than 0, then `asyncWork` is set to true upon the creation of `harvestTrace` struct.  Additionally, when a node is witnessed (`witnessNode`), the exclusive duration for that node is set.  Later, if `asyncWork` is false, then all the exclusive duration are set to nil.  Otherwise, they are written as what was set in `witnessNode`.
### How to test
Run a database integration with a slow query.  I have been doing a Time.Sleep(5 * time.Second) within the segments in the pgx5 integration.