### PR TITLE
feat: Basic Segments

### DIFF
--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -28,6 +28,7 @@ func NewHybridProcessor(app *newrelic.Application) *nrotelhybridProcessor {
 	return &nrotelhybridProcessor{
 		app:        app,
 		txnMap:     map[oteltrace.TraceID]txnMapEntry{},
+		segmentMap: map[oteltrace.SpanID]*newrelic.Segment{},
 		txnChecker: isWithinTransaction,
 	}
 }
@@ -42,31 +43,36 @@ func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSp
 	// should be a valid span context and be marked as remote
 	// this begins a transaction
 	if isTxn, isWeb := p.isTransaction(s.SpanKind(), s.SpanContext(), s.Parent()); isTxn {
-		txn := p.app.StartTransaction(s.Name())
-		if isWeb {
-			attrs := s.Attributes()
-			var fullURL string
-			for _, attr := range attrs {
-				if attr.Key == semconv.URLFullKey {
-					fullURL = attr.Value.AsString()
-				}
-			}
-			req := newrelic.WebRequest{}
-			nrURL, err := url.Parse(fullURL)
-			if err == nil {
-				req.URL = nrURL
-			}
-			txn.SetWebRequest(req)
-		}
-		p.txnMap[s.SpanContext().TraceID()] = txnMapEntry{txn, s.SpanContext().SpanID()}
+		p.startTransaction(s, isWeb)
 		return
 	}
 	// start the segment with the txn entry
-	entry, ok := p.txnMap[s.SpanContext().TraceID()]
-	if !ok {
-		// transaction does not exist do not create segment
-		return
+	if entry, ok := p.txnMap[s.SpanContext().TraceID()]; ok && entry.txn != nil {
+		p.startSegment(s, entry)
 	}
+}
+
+func (p *nrotelhybridProcessor) startTransaction(s trace.ReadWriteSpan, isWeb bool) {
+	txn := p.app.StartTransaction(s.Name())
+	if isWeb {
+		attrs := s.Attributes()
+		var fullURL string
+		for _, attr := range attrs {
+			if attr.Key == semconv.URLFullKey {
+				fullURL = attr.Value.AsString()
+			}
+		}
+		req := newrelic.WebRequest{}
+		nrURL, err := url.Parse(fullURL)
+		if err == nil {
+			req.URL = nrURL
+		}
+		txn.SetWebRequest(req)
+	}
+	p.txnMap[s.SpanContext().TraceID()] = txnMapEntry{txn, s.SpanContext().SpanID()}
+}
+
+func (p *nrotelhybridProcessor) startSegment(s trace.ReadWriteSpan, entry txnMapEntry) {
 	seg := entry.txn.StartSegment(s.Name())
 	p.segmentMap[s.SpanContext().SpanID()] = seg
 }
@@ -75,10 +81,11 @@ func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	// use the trace id from trace.ReadOnlySpan to end the transaction
+	traceID := s.SpanContext().TraceID()
 	if isTxn, _ := p.isTransaction(s.SpanKind(), s.SpanContext(), s.Parent()); isTxn {
-		if val, ok := p.txnMap[s.SpanContext().TraceID()]; ok && val.txn != nil {
-			val.txn.End()
-			delete(p.txnMap, s.SpanContext().TraceID())
+		if entry, ok := p.txnMap[traceID]; ok && entry.txn != nil {
+			entry.txn.End()
+			delete(p.txnMap, traceID)
 		}
 		return
 	}

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -19,7 +19,8 @@ type txnMapEntry struct {
 type nrotelhybridProcessor struct {
 	app        *newrelic.Application
 	mu         sync.Mutex
-	txnMap     map[oteltrace.TraceID]txnMapEntry // Trace ID -> Transaction
+	txnMap     map[oteltrace.TraceID]txnMapEntry      // Trace ID -> Transaction
+	segmentMap map[oteltrace.SpanID]*newrelic.Segment // SpanID -> Segment
 	txnChecker func(txnMap map[oteltrace.TraceID]txnMapEntry, traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool
 }
 
@@ -58,8 +59,16 @@ func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSp
 			txn.SetWebRequest(req)
 		}
 		p.txnMap[s.SpanContext().TraceID()] = txnMapEntry{txn, s.SpanContext().SpanID()}
+		return
 	}
-
+	// start the segment with the txn entry
+	entry, ok := p.txnMap[s.SpanContext().TraceID()]
+	if !ok {
+		// transaction does not exist do not create segment
+		return
+	}
+	seg := entry.txn.StartSegment(s.Name())
+	p.segmentMap[s.SpanContext().SpanID()] = seg
 }
 
 func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
@@ -71,7 +80,15 @@ func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
 			val.txn.End()
 			delete(p.txnMap, s.SpanContext().TraceID())
 		}
+		return
 	}
+	// otherwise end segment
+	spanID := s.SpanContext().SpanID()
+	if seg, ok := p.segmentMap[spanID]; ok && seg != nil {
+		seg.End()
+		delete(p.segmentMap, spanID)
+	}
+
 }
 
 func (p *nrotelhybridProcessor) Shutdown(ctx context.Context) error {

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -17,11 +17,16 @@ type txnMapEntry struct {
 	spanID oteltrace.SpanID
 }
 
+type nrSegment interface {
+	End()
+	AddAttribute(key string, val interface{})
+}
+
 type nrotelhybridProcessor struct {
 	app        *newrelic.Application
 	mu         sync.Mutex
-	txnMap     map[oteltrace.TraceID]txnMapEntry      // Trace ID -> Transaction
-	segmentMap map[oteltrace.SpanID]*newrelic.Segment // SpanID -> Segment
+	txnMap     map[oteltrace.TraceID]txnMapEntry // Trace ID -> Transaction
+	segmentMap map[oteltrace.SpanID]nrSegment    // SpanID -> Segment
 	txnChecker func(txnMap map[oteltrace.TraceID]txnMapEntry, traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool
 }
 
@@ -29,7 +34,7 @@ func NewHybridProcessor(app *newrelic.Application) *nrotelhybridProcessor {
 	return &nrotelhybridProcessor{
 		app:        app,
 		txnMap:     map[oteltrace.TraceID]txnMapEntry{},
-		segmentMap: map[oteltrace.SpanID]*newrelic.Segment{},
+		segmentMap: map[oteltrace.SpanID]nrSegment{},
 		txnChecker: isWithinTransaction,
 	}
 }
@@ -95,7 +100,7 @@ func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
 	if seg, ok := p.segmentMap[spanID]; ok && seg != nil {
 		for _, attr := range s.Attributes() {
 			//  attr.Value.Type() switch on type
-			seg.AddAttribute(string(attr.Key), extractAttibuteValue(attr.Value))
+			seg.AddAttribute(string(attr.Key), extractAttributeValue(attr.Value))
 		}
 		seg.End()
 		delete(p.segmentMap, spanID)
@@ -103,7 +108,7 @@ func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
 
 }
 
-func extractAttibuteValue(val attribute.Value) any {
+func extractAttributeValue(val attribute.Value) any {
 
 	switch val.Type() {
 	case attribute.BOOL:

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/newrelic/go-agent/v3/newrelic"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -92,8 +93,41 @@ func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
 	// otherwise end segment
 	spanID := s.SpanContext().SpanID()
 	if seg, ok := p.segmentMap[spanID]; ok && seg != nil {
+		for _, attr := range s.Attributes() {
+			//  attr.Value.Type() switch on type
+			seg.AddAttribute(string(attr.Key), extractAttibuteValue(attr.Value))
+		}
 		seg.End()
 		delete(p.segmentMap, spanID)
+	}
+
+}
+
+func extractAttibuteValue(val attribute.Value) any {
+
+	switch val.Type() {
+	case attribute.BOOL:
+		return val.AsBool()
+	case attribute.INT64:
+		return val.AsInt64()
+	case attribute.FLOAT64:
+		return val.AsFloat64()
+	case attribute.STRING:
+		return val.AsString()
+	case attribute.BOOLSLICE:
+		return val.AsBoolSlice()
+	case attribute.INT64SLICE:
+		return val.AsInt64Slice()
+	case attribute.FLOAT64SLICE:
+		return val.AsFloat64Slice()
+	case attribute.STRINGSLICE:
+		return val.AsStringSlice()
+	case attribute.BYTESLICE:
+		return val.AsByteSlice()
+	case attribute.SLICE:
+		return val.AsSlice()
+	default:
+		return nil // EMPTY OR INVALID
 	}
 
 }

--- a/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
@@ -1,9 +1,12 @@
 package nrotelhybrid
 
 import (
+	"context"
 	"testing"
 
-	"go.opentelemetry.io/otel/trace"
+	"github.com/newrelic/go-agent/v3/newrelic/integrationsupport"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/trace"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -232,7 +235,7 @@ func Test_isTransaction(t *testing.T) {
 					return tt.txnCheck
 				},
 			}
-			gotTxn, gotWeb := p.isTransaction(tt.kind, trace.SpanContext{}, tt.parent)
+			gotTxn, gotWeb := p.isTransaction(tt.kind, oteltrace.SpanContext{}, tt.parent)
 			if gotTxn != tt.wantTxn || gotWeb != tt.wantWeb {
 				t.Errorf("isTransaction() = (%v, %v), want (%v, %v)", gotTxn, gotWeb, tt.wantTxn, tt.wantWeb)
 			}
@@ -323,6 +326,116 @@ func Test_nrotelhybridProcessor_isWithinTransaction(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("isWithinTransaction() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func Test_nrotelhybridProcessor(t *testing.T) {
+	app := integrationsupport.NewTestApp(
+		integrationsupport.SampleEverythingReplyFn,
+		integrationsupport.ConfigFullTraces,
+	)
+	//validTraceID := [16]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+
+	tests := []struct {
+		name                string
+		spanName            string
+		fn                  func(ctx context.Context, spanName string, tp *trace.TracerProvider) oteltrace.Span
+		expectTxnMapLen     int
+		expectSegmentMapLen int
+	}{
+		{
+			name:     "No txn or segment. Defaults to SpanKind.INTERNAL",
+			spanName: "transaction-a",
+			fn: func(ctx context.Context, spanName string, tp *trace.TracerProvider) oteltrace.Span {
+				tracer := otel.Tracer("test")
+				_, span := tracer.Start(ctx, spanName)
+				return span
+			},
+			expectTxnMapLen:     0,
+			expectSegmentMapLen: 0,
+		},
+		{
+			name:     "No txn or segment. Set to SpanKind.INTERNAL",
+			spanName: "transaction-a",
+			fn: func(ctx context.Context, spanName string, tp *trace.TracerProvider) oteltrace.Span {
+				tracer := otel.Tracer("test")
+				_, span := tracer.Start(ctx, spanName, oteltrace.WithSpanKind(oteltrace.SpanKindInternal))
+				return span
+			},
+			expectTxnMapLen:     0,
+			expectSegmentMapLen: 0,
+		},
+		{
+			name:     "Basic txn. Set to SpanKind.SERVER",
+			spanName: "transaction-a",
+			fn: func(ctx context.Context, spanName string, tp *trace.TracerProvider) oteltrace.Span {
+				tracer := otel.Tracer("test")
+				_, span := tracer.Start(ctx, spanName, oteltrace.WithSpanKind(oteltrace.SpanKindServer))
+				return span
+			},
+			expectTxnMapLen:     1,
+			expectSegmentMapLen: 0,
+		},
+		{
+			name:     "No txn or segment. Set to SpanKind.CLIENT",
+			spanName: "transaction-a",
+			fn: func(ctx context.Context, spanName string, tp *trace.TracerProvider) oteltrace.Span {
+				tracer := otel.Tracer("test")
+				_, span := tracer.Start(ctx, spanName, oteltrace.WithSpanKind(oteltrace.SpanKindClient))
+				return span
+			},
+			expectTxnMapLen:     0,
+			expectSegmentMapLen: 0,
+		},
+		{
+			name:     "Basic txn. Set to SpanKind.CONSUMER",
+			spanName: "transaction-a",
+			fn: func(ctx context.Context, spanName string, tp *trace.TracerProvider) oteltrace.Span {
+				tracer := otel.Tracer("test")
+				_, span := tracer.Start(ctx, spanName, oteltrace.WithSpanKind(oteltrace.SpanKindConsumer))
+				return span
+			},
+			expectTxnMapLen:     1,
+			expectSegmentMapLen: 0,
+		},
+		{
+			name:     "No txn or segment. Set to SpanKind.UNSPECIFIED",
+			spanName: "transaction-a",
+			fn: func(ctx context.Context, spanName string, tp *trace.TracerProvider) oteltrace.Span {
+				tracer := otel.Tracer("test")
+				_, span := tracer.Start(ctx, spanName, oteltrace.WithSpanKind(oteltrace.SpanKindUnspecified))
+				return span
+			},
+			expectTxnMapLen:     0,
+			expectSegmentMapLen: 0,
+		},
+		// {name: "empty span name", spanName: ""},
+		// {name: "duplicate segment name", spanName: "seg-a"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processor := NewHybridProcessor(app.Application)
+			tp := trace.NewTracerProvider(trace.WithSpanProcessor(processor))
+			shutdown := func(ctx context.Context) error {
+				err := tp.Shutdown(ctx)
+				return err
+			}
+			defer shutdown(context.Background())
+			otel.SetTracerProvider(tp)
+
+			span := tt.fn(context.Background(), tt.spanName, tp)
+
+			if len(processor.txnMap) != tt.expectTxnMapLen {
+				t.Errorf("Unexpected length of txnMap. Expected len =  %d, got len = %d", tt.expectTxnMapLen, len(processor.txnMap))
+			}
+			if len(processor.segmentMap) != tt.expectSegmentMapLen {
+				t.Errorf("Unexpected length of segmentMap. Expected len =  %d, got len = %d", tt.expectSegmentMapLen, len(processor.segmentMap))
+			}
+
+			span.End()
+
 		})
 	}
 }

--- a/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
@@ -335,7 +335,6 @@ func Test_nrotelhybridProcessor(t *testing.T) {
 		integrationsupport.SampleEverythingReplyFn,
 		integrationsupport.ConfigFullTraces,
 	)
-	//validTraceID := [16]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
 
 	tests := []struct {
 		name                string
@@ -410,8 +409,6 @@ func Test_nrotelhybridProcessor(t *testing.T) {
 			expectTxnMapLen:     0,
 			expectSegmentMapLen: 0,
 		},
-		// {name: "empty span name", spanName: ""},
-		// {name: "duplicate segment name", spanName: "seg-a"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

<!--
Any relevant links that will help reviewers.
-->

## Details

### Issue
We need to begin a segment in cases where we cannot begin transcations
### Goals
Begin Basic Segments.  This is meant to be a start for segments.  Other segment types will be added down the line.  We will also start with adding all attributes at segments end.
### Implementation
If a transaction is not started, then we start a basic segment.  Similarly to the `txnMap` we keep a map of segments. In the future, we will need to generalize the value portion of the map because of the different value types.


<!--
In-depth description of changes, other technical notes, etc.
-->
