### PR TITLE
feat: External and Datastore segments

### DIFF
--- a/v3/integrations/nrotelhybrid/constants.go
+++ b/v3/integrations/nrotelhybrid/constants.go
@@ -26,12 +26,16 @@ const (
 	AttrHTTPRequestMethod      = "http.request.method"       // OTEL HTTP Client v1.23
 	AttrURLFull                = "url.full"                  // OTEL HTTP Client v1.23
 
-	AttrDBSystemName = "db.system.name" // OTEL DB Client v1.25 (DB/Redis/Mongo)
-	AttrDBNamespace  = "db.namespace"   // OTEL DB Client v1.25 (DB/Mongo)
+	AttrDBSystemName     = "db.system.name"     // OTEL DB Client v1.25 (DB/Redis/Mongo)
+	AttrDBNamespace      = "db.namespace"       // OTEL DB Client v1.25 (DB/Mongo)
+	AttrDBCollectionName = "db.collection.name" // OTEL DB Client v1.25 (DB/Redis/Mongo)
+	AttrDBOperationName  = "db.operation.name"  // OTEL DB Client v1.25 (DB/Redis/Mongo)
 
-	AttrDBSystem = "db.system" // OTEL DB Client v1.17 (DB/Redis/Mongo/Dynamo)
-	AttrDBName   = "db.name"   // OTEL DB Client v1.17 (DB/Redis/Mongo/Dynamo)
-
+	AttrDBSystem    = "db.system"    // OTEL DB Client v1.17 (DB/Redis/Mongo/Dynamo)
+	AttrDBName      = "db.name"      // OTEL DB Client v1.17 (DB/Redis/Mongo/Dynamo)
+	AttrDBSQLTable  = "db.sql.table" // OTEL DB Client v1.17 (SQL only)
+	AttrDBOperation = "db.operation" // OTEL DB Client v1.17 (DB/Redis/Mongo/Dynamo)
+	AttrDBStatement = "db.statement" // OTEL DB Client v1.17 and v1.25 (DB/Redis/Mongo)
 )
 
 // NR segment/transaction attribute keys used by this package.
@@ -50,6 +54,7 @@ const (
 
 // OTELToNRHTTPAttributeMap maps OTel HTTP client/server attribute keys to their
 // NR segment attribute equivalents (OTel HTTP Client v1.17 and v1.23).
+// TODO: If it contains an attribute from both 1.17 and 1.23 it might overwrite.
 var OTELToNRHTTPAttributeMap = map[string]string{
 	// OTEL HTTP Client 1.17
 	AttrHTTPStatusCode: NRHTTPStatusCode,

--- a/v3/integrations/nrotelhybrid/constants.go
+++ b/v3/integrations/nrotelhybrid/constants.go
@@ -1,0 +1,24 @@
+package nrotelhybrid
+
+// OTel semantic convention attribute keys used by this package.
+//
+// These are hardcoded rather than imported from go.opentelemetry.io/otel/semconv
+// because the bridge spec (Tracing-API.md) requires mapping both the current
+// stable semantic convention and legacy "pinned" versions side by side, and a
+// single semconv/vX.Y.Z package only exposes one version's keys at a time.
+const (
+	AttrURLFull        = "url.full"        // OTel HTTP Client v1.23+
+	AttrDBSystemName   = "db.system.name"  // OTel DB Client v1.25+ (stable)
+	AttrDBSystem       = "db.system"       // OTel DB Client v1.17 (legacy)
+	AttrHTTPStatusCode = "http.status_code" // OTel HTTP Server/Client v1.20 (legacy)
+)
+
+// NR segment/transaction attribute keys used by this package.
+const (
+	NRHTTPStatusCode = "http.statusCode"
+)
+
+// OTELToNRAttributeMap maps OTel attribute keys to their NR segment attribute equivalents.
+var OTELToNRAttributeMap = map[string]string{
+	AttrHTTPStatusCode: NRHTTPStatusCode,
+}

--- a/v3/integrations/nrotelhybrid/constants.go
+++ b/v3/integrations/nrotelhybrid/constants.go
@@ -9,23 +9,28 @@ package nrotelhybrid
 const (
 	// shared attributes
 
+	AttrServerAddress = "server.address" // HTTP Client v1.17, DB Client v1.25 (DB/Redis/Mongo)
+	AttrServerPort    = "server.port"    // HTTP Client v1.17, DB Client v1.25 (DB/Redis/Mongo)
+	AttrNetPeerName   = "net.peer.name"  // HTTP Client v1.23, DB Client v1.17 (DB/Redis/Mongo)
+	AttrNetPeerPort   = "net.peer.port"  // HTTP Client v1.23, DB Client v1.17 (DB/Redis/Mongo/Dynamo)
+
 	// specific attributes
-	AttrDBSystemName = "db.system.name" // OTEL DB Client v1.25+ (stable)
-	AttrDBSystem     = "db.system"      // OTEL DB Client v1.17 (legacy)
 
-	AttrHTTPStatusCode = "http.status_code" // OTEL HTTP Client 1.17
-	AttrHTTPStatusText = "http.status_text" // OTEL HTTP Client 1.17
-	AttrHTTPMethod     = "http.method"      // OTEL HTTP Client 1.17
-	AttrHTTPURL        = "http.url"         // OTEL HTTP Client 1.17
-	AttrServerAddress  = "server.address"   // OTEL HTTP Client 1.17
-	AttrServerPort     = "server.port"      // OTEL HTTP Client 1.17
+	AttrHTTPStatusCode = "http.status_code" // OTEL HTTP Client v1.17
+	AttrHTTPStatusText = "http.status_text" // OTEL HTTP Client v1.17
+	AttrHTTPMethod     = "http.method"      // OTEL HTTP Client v1.17
+	AttrHTTPURL        = "http.url"         // OTEL HTTP Client v1.17
 
-	AttrHTTPResponseStatusCode = "http.response.status_code" // OTEL HTTP Client 1.23
-	AttrHTTPResponseStatusText = "http.response.status_text" // OTEL HTTP Client 1.23
-	AttrHTTPRequestMethod      = "http.request.method"       // OTEL HTTP Client 1.23
-	AttrURLFull                = "url.full"                  // OTEL HTTP Client 1.23
-	AttrNetPeerName            = "net.peer.name"             // OTEL HTTP Client 1.23
-	AttrNetPeerPort            = "net.peer.port"             // OTEL HTTP Client 1.23
+	AttrHTTPResponseStatusCode = "http.response.status_code" // OTEL HTTP Client v1.23
+	AttrHTTPResponseStatusText = "http.response.status_text" // OTEL HTTP Client v1.23
+	AttrHTTPRequestMethod      = "http.request.method"       // OTEL HTTP Client v1.23
+	AttrURLFull                = "url.full"                  // OTEL HTTP Client v1.23
+
+	AttrDBSystemName = "db.system.name" // OTEL DB Client v1.25 (DB/Redis/Mongo)
+	AttrDBNamespace  = "db.namespace"   // OTEL DB Client v1.25 (DB/Mongo)
+
+	AttrDBSystem = "db.system" // OTEL DB Client v1.17 (DB/Redis/Mongo/Dynamo)
+	AttrDBName   = "db.name"   // OTEL DB Client v1.17 (DB/Redis/Mongo/Dynamo)
 
 )
 
@@ -37,10 +42,15 @@ const (
 	NRHTTPUrl        = "http.url"
 	NRHost           = "host"
 	NRPort           = "port"
+
+	NRProduct      = "product"
+	NRDatabaseName = "database_name"
+	NRPortPathOrID = "port_path_or_id"
 )
 
-// OTELToNRAttributeMap maps OTel attribute keys to their NR segment attribute equivalents.
-var OTELToNRAttributeMap = map[string]string{
+// OTELToNRHTTPAttributeMap maps OTel HTTP client/server attribute keys to their
+// NR segment attribute equivalents (OTel HTTP Client v1.17 and v1.23).
+var OTELToNRHTTPAttributeMap = map[string]string{
 	// OTEL HTTP Client 1.17
 	AttrHTTPStatusCode: NRHTTPStatusCode,
 	AttrHTTPStatusText: NRHTTPStatusText,
@@ -55,4 +65,20 @@ var OTELToNRAttributeMap = map[string]string{
 	AttrURLFull:                NRHTTPUrl,
 	AttrNetPeerName:            NRHost,
 	AttrNetPeerPort:            NRPort,
+}
+
+// OTELToNRDBAttributeMap maps OTel DB client attribute keys to their NR
+// datastore segment attribute equivalents (OTel DB/Redis/Mongo/Dynamo Client
+// v1.17 and v1.25).
+var OTELToNRDBAttributeMap = map[string]string{
+	// OTEL DB Client v1.25 (DB/Redis/Mongo)
+	AttrDBSystemName:  NRProduct,
+	AttrDBNamespace:   NRDatabaseName, // Not used by Redis
+	AttrServerAddress: NRHost,
+	AttrServerPort:    NRPortPathOrID,
+	// OTEL DB Client v1.17 (DB/Redis/Mongo/Dynamo)
+	AttrDBSystem:    NRProduct,
+	AttrDBName:      NRDatabaseName,
+	AttrNetPeerName: NRHost, // Not used by Dynamo
+	AttrNetPeerPort: NRPortPathOrID,
 }

--- a/v3/integrations/nrotelhybrid/constants.go
+++ b/v3/integrations/nrotelhybrid/constants.go
@@ -7,18 +7,52 @@ package nrotelhybrid
 // stable semantic convention and legacy "pinned" versions side by side, and a
 // single semconv/vX.Y.Z package only exposes one version's keys at a time.
 const (
-	AttrURLFull        = "url.full"        // OTel HTTP Client v1.23+
-	AttrDBSystemName   = "db.system.name"  // OTel DB Client v1.25+ (stable)
-	AttrDBSystem       = "db.system"       // OTel DB Client v1.17 (legacy)
-	AttrHTTPStatusCode = "http.status_code" // OTel HTTP Server/Client v1.20 (legacy)
+	// shared attributes
+
+	// specific attributes
+	AttrDBSystemName = "db.system.name" // OTEL DB Client v1.25+ (stable)
+	AttrDBSystem     = "db.system"      // OTEL DB Client v1.17 (legacy)
+
+	AttrHTTPStatusCode = "http.status_code" // OTEL HTTP Client 1.17
+	AttrHTTPStatusText = "http.status_text" // OTEL HTTP Client 1.17
+	AttrHTTPMethod     = "http.method"      // OTEL HTTP Client 1.17
+	AttrHTTPURL        = "http.url"         // OTEL HTTP Client 1.17
+	AttrServerAddress  = "server.address"   // OTEL HTTP Client 1.17
+	AttrServerPort     = "server.port"      // OTEL HTTP Client 1.17
+
+	AttrHTTPResponseStatusCode = "http.response.status_code" // OTEL HTTP Client 1.23
+	AttrHTTPResponseStatusText = "http.response.status_text" // OTEL HTTP Client 1.23
+	AttrHTTPRequestMethod      = "http.request.method"       // OTEL HTTP Client 1.23
+	AttrURLFull                = "url.full"                  // OTEL HTTP Client 1.23
+	AttrNetPeerName            = "net.peer.name"             // OTEL HTTP Client 1.23
+	AttrNetPeerPort            = "net.peer.port"             // OTEL HTTP Client 1.23
+
 )
 
 // NR segment/transaction attribute keys used by this package.
 const (
 	NRHTTPStatusCode = "http.statusCode"
+	NRHTTPStatusText = "http.statusText"
+	NRProcedure      = "procedure"
+	NRHTTPUrl        = "http.url"
+	NRHost           = "host"
+	NRPort           = "port"
 )
 
 // OTELToNRAttributeMap maps OTel attribute keys to their NR segment attribute equivalents.
 var OTELToNRAttributeMap = map[string]string{
+	// OTEL HTTP Client 1.17
 	AttrHTTPStatusCode: NRHTTPStatusCode,
+	AttrHTTPStatusText: NRHTTPStatusText,
+	AttrHTTPMethod:     NRProcedure,
+	AttrHTTPURL:        NRHTTPUrl,
+	AttrServerAddress:  NRHost,
+	AttrServerPort:     NRPort,
+	// OTEL HTTP Client 1.23
+	AttrHTTPResponseStatusCode: NRHTTPStatusCode,
+	AttrHTTPResponseStatusText: NRHTTPStatusText,
+	AttrHTTPRequestMethod:      NRProcedure,
+	AttrURLFull:                NRHTTPUrl,
+	AttrNetPeerName:            NRHost,
+	AttrNetPeerPort:            NRPort,
 }

--- a/v3/integrations/nrotelhybrid/examples/tracing/main.go
+++ b/v3/integrations/nrotelhybrid/examples/tracing/main.go
@@ -10,13 +10,16 @@ import (
 	"os/signal"
 	"time"
 
+	_ "github.com/lib/pq"
 	"github.com/newrelic/go-agent/v3/integrations/nrotelhybrid"
 	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/uptrace/opentelemetry-go-extra/otelsql"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 )
 
 func main() {
@@ -87,6 +90,7 @@ func newHttpHandler() http.Handler {
 	mux.HandleFunc("/routetwo/", routeTwo)
 	mux.HandleFunc("/routethree/", routeThree)
 	mux.HandleFunc("/routefour/", routeFour)
+	mux.HandleFunc("/routefive/", routeFive)
 
 	// Add HTTP instrumentation for the whole server.
 	handler := otelhttp.NewHandler(mux, "/")
@@ -124,6 +128,19 @@ func routeFour(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 	n := rand.IntN(500)
 	time.Sleep(time.Duration(n) * time.Millisecond)
+}
+
+func routeFive(w http.ResponseWriter, r *http.Request) {
+	db, err := otelsql.Open("postgres", "host=localhost port=5432 user=postgres dbname=postgres password=docker sslmode=disable", otelsql.WithAttributes(
+		semconv.DBSystemPostgreSQL),
+		otelsql.WithDBName("secondTestDB"),
+		otelsql.WithTracerProvider(otel.GetTracerProvider()),
+	)
+	if err != nil {
+		panic(err)
+	}
+	db.QueryRowContext(r.Context(), "SELECT count(*) FROM pg_catalog.pg_tables")
+
 }
 
 func nestedRouteOne(ctx context.Context) {

--- a/v3/integrations/nrotelhybrid/examples/tracing/main.go
+++ b/v3/integrations/nrotelhybrid/examples/tracing/main.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -54,6 +55,7 @@ func run() (err error) {
 	defer shutdown(context.Background())
 
 	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
 
 	srv := &http.Server{
 		Addr:         ":8080",
@@ -83,6 +85,8 @@ func newHttpHandler() http.Handler {
 
 	mux.HandleFunc("/routeone/", routeOne)
 	mux.HandleFunc("/routetwo/", routeTwo)
+	mux.HandleFunc("/routethree/", routeThree)
+	mux.HandleFunc("/routefour/", routeFour)
 
 	// Add HTTP instrumentation for the whole server.
 	handler := otelhttp.NewHandler(mux, "/")
@@ -106,6 +110,22 @@ func routeTwo(w http.ResponseWriter, r *http.Request) {
 	nestedRouteTwo(ctx)
 }
 
+func routeThree(w http.ResponseWriter, r *http.Request) {
+	tracer := otel.Tracer("nrotel-example")
+	ctx, span := tracer.Start(r.Context(), "route-three")
+	defer span.End()
+
+	nestedRouteThree(ctx)
+}
+
+func routeFour(w http.ResponseWriter, r *http.Request) {
+	tracer := otel.Tracer("nrotel-example")
+	_, span := tracer.Start(r.Context(), "route-four")
+	defer span.End()
+	n := rand.IntN(500)
+	time.Sleep(time.Duration(n) * time.Millisecond)
+}
+
 func nestedRouteOne(ctx context.Context) {
 	_, span := otel.Tracer("nrotel-example").Start(ctx, "nested-route-two")
 	defer span.End()
@@ -116,6 +136,23 @@ func nestedRouteTwo(ctx context.Context) {
 	_, span := otel.Tracer("nrotel-example").Start(ctx, "nested-route-two")
 	defer span.End()
 	leafCall(ctx)
+}
+
+func nestedRouteThree(ctx context.Context) {
+	_, span := otel.Tracer("nrotel-example").Start(ctx, "nested-route-two")
+	defer span.End()
+	client := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://localhost:8080/routefour/", nil)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	resp.Body.Close()
 }
 
 func leafCall(ctx context.Context) {

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -25,15 +25,15 @@ type nrSegment interface {
 type nrotelhybridProcessor struct {
 	app        *newrelic.Application
 	mu         sync.Mutex
-	txnMap     map[oteltrace.TraceID]txnMapEntry // Trace ID -> Transaction
-	segmentMap map[oteltrace.SpanID]nrSegment    // SpanID -> Segment
-	txnChecker func(txnMap map[oteltrace.TraceID]txnMapEntry, traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool
+	txnMap     map[oteltrace.TraceID][]txnMapEntry // Trace ID -> stack of Transactions
+	segmentMap map[oteltrace.SpanID]nrSegment      // SpanID -> Segment
+	txnChecker func(txnMap map[oteltrace.TraceID][]txnMapEntry, traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool
 }
 
 func NewHybridProcessor(app *newrelic.Application) *nrotelhybridProcessor {
 	return &nrotelhybridProcessor{
 		app:        app,
-		txnMap:     map[oteltrace.TraceID]txnMapEntry{},
+		txnMap:     map[oteltrace.TraceID][]txnMapEntry{},
 		segmentMap: map[oteltrace.SpanID]nrSegment{},
 		txnChecker: isWithinTransaction,
 	}
@@ -53,8 +53,10 @@ func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSp
 		return
 	}
 	// start the segment with the txn entry
-	if entry, ok := p.txnMap[s.SpanContext().TraceID()]; ok && entry.txn != nil {
-		p.startSegment(s, entry)
+	if entries := p.txnMap[s.SpanContext().TraceID()]; len(entries) > 0 {
+		if entry := entries[len(entries)-1]; entry.txn != nil {
+			p.startSegment(s, entry)
+		}
 	}
 }
 
@@ -75,11 +77,12 @@ func (p *nrotelhybridProcessor) startTransaction(s trace.ReadWriteSpan, isWeb bo
 		}
 		txn.SetWebRequest(req)
 	}
-	p.txnMap[s.SpanContext().TraceID()] = txnMapEntry{txn, s.SpanContext().SpanID()}
+	traceID := s.SpanContext().TraceID()
+	p.txnMap[traceID] = append(p.txnMap[traceID], txnMapEntry{txn, s.SpanContext().SpanID()})
 }
 
 func (p *nrotelhybridProcessor) startSegment(s trace.ReadWriteSpan, entry txnMapEntry) {
-	seg := p.getSegmentType(s, entry)
+	seg := entry.txn.StartSegment(s.Name())
 	p.segmentMap[s.SpanContext().SpanID()] = seg
 }
 
@@ -89,14 +92,27 @@ func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
 	// use the trace id from trace.ReadOnlySpan to end the transaction
 	traceID := s.SpanContext().TraceID()
 	if isTxn, _ := p.isTransaction(s.SpanKind(), s.SpanContext(), s.Parent()); isTxn {
-		if entry, ok := p.txnMap[traceID]; ok && entry.txn != nil {
-			entry.txn.End()
+		spanID := s.SpanContext().SpanID()
+		entries := p.txnMap[traceID]
+		for i := len(entries) - 1; i >= 0; i-- {
+			if entries[i].spanID == spanID {
+				if entries[i].txn != nil {
+					entries[i].txn.End()
+				}
+				entries = append(entries[:i], entries[i+1:]...)
+				break
+			}
+		}
+		if len(entries) == 0 {
 			delete(p.txnMap, traceID)
+		} else {
+			p.txnMap[traceID] = entries
 		}
 		return
 	}
 	// otherwise end segment
 	spanID := s.SpanContext().SpanID()
+	p.switchSegmentType(s)
 	if seg, ok := p.segmentMap[spanID]; ok && seg != nil {
 		for _, attr := range s.Attributes() {
 			//  attr.Value.Type() switch on type
@@ -140,8 +156,16 @@ func (p *nrotelhybridProcessor) isTransaction(kind oteltrace.SpanKind, current o
 	}
 }
 
-func (p *nrotelhybridProcessor) getSegmentType(s trace.ReadWriteSpan, entry txnMapEntry) nrSegment {
+func (p *nrotelhybridProcessor) switchSegmentType(s trace.ReadOnlySpan) {
 	var fullURL = ""
+	segInterface, ok := p.segmentMap[s.SpanContext().SpanID()]
+	if !ok {
+		return
+	}
+	basicSegment, ok := segInterface.(*newrelic.Segment)
+	if !ok {
+		return
+	}
 	switch s.SpanKind() {
 	case oteltrace.SpanKindClient:
 		for _, attr := range s.Attributes() {
@@ -150,21 +174,23 @@ func (p *nrotelhybridProcessor) getSegmentType(s trace.ReadWriteSpan, entry txnM
 				fullURL = attr.Value.AsString()
 			}
 			if attr.Key == semconv.DBSystemNameKey || attr.Key == "db.system" {
-				return &newrelic.DatastoreSegment{}
+				return
 			}
 		}
-		seg := newrelic.StartExternalSegment(entry.txn, nil)
+		seg := &newrelic.ExternalSegment{
+			StartTime: basicSegment.StartTime,
+		}
 		seg.URL = fullURL
-		return seg
+		p.segmentMap[s.SpanContext().SpanID()] = seg
 	default:
-		return entry.txn.StartSegment(s.Name())
+		return
 	}
 }
 
-func isWithinTransaction(txnMap map[oteltrace.TraceID]txnMapEntry, traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool {
-	// if the transaction exists and is not the same span id, it is within an existing transaction
-	if val, ok := txnMap[traceID]; ok {
-		return val.spanID != spanID
+func isWithinTransaction(txnMap map[oteltrace.TraceID][]txnMapEntry, traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool {
+	// if the innermost active transaction exists and is not the same span id, it is within an existing transaction
+	if entries := txnMap[traceID]; len(entries) > 0 {
+		return entries[len(entries)-1].spanID != spanID
 	}
 	return false
 }

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -110,7 +110,7 @@ func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
 		return
 	}
 	// otherwise end segment if it exists in the map
-	p.switchSegmentType(s)
+	p.switchSegmentType(spanID, s.Attributes(), s.SpanKind())
 
 	if seg, ok := p.segmentMap[spanID]; ok && seg != nil {
 		// find type of segment to switch segment type and add attributes
@@ -152,8 +152,7 @@ func (p *nrotelhybridProcessor) isTransaction(kind oteltrace.SpanKind, current o
 	}
 }
 
-func (p *nrotelhybridProcessor) switchSegmentType(s trace.ReadOnlySpan) {
-	spanID := s.SpanContext().SpanID()
+func (p *nrotelhybridProcessor) switchSegmentType(spanID oteltrace.SpanID, attributes []attribute.KeyValue, spanKind oteltrace.SpanKind) {
 	segInterface, ok := p.segmentMap[spanID]
 	if !ok {
 		return
@@ -163,20 +162,15 @@ func (p *nrotelhybridProcessor) switchSegmentType(s trace.ReadOnlySpan) {
 		return
 	}
 
-	var fullURL = ""
-	attributes := s.Attributes()
-
-	switch s.SpanKind() {
+	switch spanKind {
 	case oteltrace.SpanKindClient:
 		for _, attr := range attributes {
-			if attr.Key == attribute.Key(AttrURLFull) {
-				fullURL = attr.Value.AsString()
-			}
+
 			if attr.Key == attribute.Key(AttrDBSystemName) || attr.Key == attribute.Key(AttrDBSystem) {
 				seg := &newrelic.DatastoreSegment{
 					StartTime: basicSegment.StartTime,
 				}
-				// map attribtues for db
+				// map attributes for db
 				p.addSegmentAttributes(seg, attributes, OTELToNRDBAttributeMap)
 				p.segmentMap[spanID] = seg
 				return
@@ -185,7 +179,6 @@ func (p *nrotelhybridProcessor) switchSegmentType(s trace.ReadOnlySpan) {
 		seg := &newrelic.ExternalSegment{
 			StartTime: basicSegment.StartTime,
 		}
-		seg.URL = fullURL
 		p.addSegmentAttributes(seg, attributes, OTELToNRHTTPAttributeMap)
 		p.segmentMap[spanID] = seg
 	default:

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -164,12 +164,7 @@ func (p *nrotelhybridProcessor) switchSegmentType(spanID oteltrace.SpanID, attri
 
 	switch spanKind {
 	case oteltrace.SpanKindClient:
-		var fullURL string
 		for _, attr := range attributes {
-			if attr.Key == attribute.Key(AttrURLFull) || attr.Key == attribute.Key(AttrHTTPURL) {
-				fullURL = attr.Value.AsString()
-			}
-
 			if attr.Key == attribute.Key(AttrDBSystemName) || attr.Key == attribute.Key(AttrDBSystem) {
 				seg := &newrelic.DatastoreSegment{
 					StartTime: basicSegment.StartTime,
@@ -182,7 +177,6 @@ func (p *nrotelhybridProcessor) switchSegmentType(spanID oteltrace.SpanID, attri
 		}
 		seg := &newrelic.ExternalSegment{
 			StartTime: basicSegment.StartTime,
-			URL:       fullURL,
 		}
 		p.addSegmentAttributes(seg, attributes, OTELToNRHTTPAttributeMap)
 		p.segmentMap[spanID] = seg
@@ -193,12 +187,47 @@ func (p *nrotelhybridProcessor) switchSegmentType(spanID oteltrace.SpanID, attri
 }
 
 func (p *nrotelhybridProcessor) addSegmentAttributes(seg nrSegment, attributes []attribute.KeyValue, attrMap map[string]string) {
-	for _, otelAttribute := range attributes {
-		if nrAttribute, ok := checkMap(otelAttribute.Key, attrMap); ok {
-			seg.AddAttribute(string(nrAttribute), extractAttributeValue(otelAttribute.Value))
-			continue
+	switch s := seg.(type) {
+	case *newrelic.DatastoreSegment:
+		for _, attribute := range attributes {
+			switch string(attribute.Key) {
+			case AttrDBCollectionName, AttrDBSQLTable:
+				s.Collection = attribute.Value.AsString()
+			case AttrDBOperationName, AttrDBOperation:
+				s.Operation = attribute.Value.AsString()
+			case AttrDBStatement:
+				s.ParameterizedQuery = attribute.Value.AsString()
+			case AttrDBSystem, AttrDBSystemName:
+				s.Product = newrelic.DatastoreProduct(attribute.Value.AsString())
+			default:
+				if nrAttribute, ok := checkMap(attribute.Key, attrMap); ok {
+					s.AddAttribute(string(nrAttribute), extractAttributeValue(attribute.Value))
+					continue
+				}
+				s.AddAttribute(string(attribute.Key), extractAttributeValue(attribute.Value))
+			}
 		}
-		seg.AddAttribute(string(otelAttribute.Key), extractAttributeValue(otelAttribute.Value))
+	case *newrelic.ExternalSegment:
+		for _, attribute := range attributes {
+			switch string(attribute.Key) {
+			case AttrURLFull, AttrHTTPURL:
+				s.URL = attribute.Value.AsString()
+			default:
+				if nrAttribute, ok := checkMap(attribute.Key, attrMap); ok {
+					s.AddAttribute(string(nrAttribute), extractAttributeValue(attribute.Value))
+					continue
+				}
+				s.AddAttribute(string(attribute.Key), extractAttributeValue(attribute.Value))
+			}
+		}
+	default:
+		for _, attribute := range attributes {
+			if nrAttribute, ok := checkMap(attribute.Key, attrMap); ok {
+				seg.AddAttribute(string(nrAttribute), extractAttributeValue(attribute.Value))
+				continue
+			}
+			seg.AddAttribute(string(attribute.Key), extractAttributeValue(attribute.Value))
+		}
 	}
 }
 

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -177,7 +177,7 @@ func (p *nrotelhybridProcessor) switchSegmentType(s trace.ReadOnlySpan) {
 					StartTime: basicSegment.StartTime,
 				}
 				// map attribtues for db
-				p.addSegmentAttributes(spanID, seg, attributes, OTELToNRDBAttributeMap)
+				p.addSegmentAttributes(seg, attributes, OTELToNRDBAttributeMap)
 				p.segmentMap[spanID] = seg
 				return
 			}
@@ -186,15 +186,15 @@ func (p *nrotelhybridProcessor) switchSegmentType(s trace.ReadOnlySpan) {
 			StartTime: basicSegment.StartTime,
 		}
 		seg.URL = fullURL
-		p.addSegmentAttributes(spanID, seg, attributes, OTELToNRHTTPAttributeMap)
+		p.addSegmentAttributes(seg, attributes, OTELToNRHTTPAttributeMap)
 		p.segmentMap[spanID] = seg
 	default:
-		p.addSegmentAttributes(spanID, basicSegment, attributes, nil)
+		p.addSegmentAttributes(basicSegment, attributes, nil)
 		return
 	}
 }
 
-func (p *nrotelhybridProcessor) addSegmentAttributes(spanID oteltrace.SpanID, seg nrSegment, attributes []attribute.KeyValue, attrMap map[string]string) {
+func (p *nrotelhybridProcessor) addSegmentAttributes(seg nrSegment, attributes []attribute.KeyValue, attrMap map[string]string) {
 	for _, otelAttribute := range attributes {
 		if nrAttribute, ok := checkMap(otelAttribute.Key, attrMap); ok {
 			seg.AddAttribute(string(nrAttribute), extractAttributeValue(otelAttribute.Value))

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -91,8 +91,9 @@ func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
 	defer p.mu.Unlock()
 	// use the trace id from trace.ReadOnlySpan to end the transaction
 	traceID := s.SpanContext().TraceID()
+	spanID := s.SpanContext().SpanID()
+
 	if isTxn, _ := p.isTransaction(s.SpanKind(), s.SpanContext(), s.Parent()); isTxn {
-		spanID := s.SpanContext().SpanID()
 		entries := p.txnMap[traceID]
 		for i := len(entries) - 1; i >= 0; i-- {
 			if entries[i].spanID == spanID {
@@ -111,7 +112,6 @@ func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
 		return
 	}
 	// otherwise end segment
-	spanID := s.SpanContext().SpanID()
 	p.switchSegmentType(s)
 	if seg, ok := p.segmentMap[spanID]; ok && seg != nil {
 		for _, attr := range s.Attributes() {
@@ -174,6 +174,11 @@ func (p *nrotelhybridProcessor) switchSegmentType(s trace.ReadOnlySpan) {
 				fullURL = attr.Value.AsString()
 			}
 			if attr.Key == semconv.DBSystemNameKey || attr.Key == "db.system" {
+				seg := &newrelic.DatastoreSegment{
+					StartTime: basicSegment.StartTime,
+				}
+				// map attribtues for db
+				p.segmentMap[s.SpanContext().SpanID()] = seg
 				return
 			}
 		}

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -8,7 +8,6 @@ import (
 	"github.com/newrelic/go-agent/v3/newrelic"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -66,7 +65,7 @@ func (p *nrotelhybridProcessor) startTransaction(s trace.ReadWriteSpan, isWeb bo
 		attrs := s.Attributes()
 		var fullURL string
 		for _, attr := range attrs {
-			if attr.Key == semconv.URLFullKey {
+			if attr.Key == attribute.Key(AttrURLFull) {
 				fullURL = attr.Value.AsString()
 			}
 		}
@@ -169,11 +168,10 @@ func (p *nrotelhybridProcessor) switchSegmentType(s trace.ReadOnlySpan) {
 	switch s.SpanKind() {
 	case oteltrace.SpanKindClient:
 		for _, attr := range s.Attributes() {
-			// db.system is not in current semconv package
-			if attr.Key == semconv.URLFullKey {
+			if attr.Key == attribute.Key(AttrURLFull) {
 				fullURL = attr.Value.AsString()
 			}
-			if attr.Key == semconv.DBSystemNameKey || attr.Key == "db.system" {
+			if attr.Key == attribute.Key(AttrDBSystemName) || attr.Key == attribute.Key(AttrDBSystem) {
 				seg := &newrelic.DatastoreSegment{
 					StartTime: basicSegment.StartTime,
 				}

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -62,9 +62,8 @@ func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSp
 func (p *nrotelhybridProcessor) startTransaction(s trace.ReadWriteSpan, isWeb bool) {
 	txn := p.app.StartTransaction(s.Name())
 	if isWeb {
-		attrs := s.Attributes()
 		var fullURL string
-		for _, attr := range attrs {
+		for _, attr := range s.Attributes() {
 			if attr.Key == attribute.Key(AttrURLFull) {
 				fullURL = attr.Value.AsString()
 			}
@@ -110,13 +109,11 @@ func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
 		}
 		return
 	}
-	// otherwise end segment
+	// otherwise end segment if it exists in the map
 	p.switchSegmentType(s)
+
 	if seg, ok := p.segmentMap[spanID]; ok && seg != nil {
-		for _, attr := range s.Attributes() {
-			//  attr.Value.Type() switch on type
-			seg.AddAttribute(string(attr.Key), extractAttributeValue(attr.Value))
-		}
+		// find type of segment to switch segment type and add attributes
 		seg.End()
 		delete(p.segmentMap, spanID)
 	}
@@ -156,8 +153,8 @@ func (p *nrotelhybridProcessor) isTransaction(kind oteltrace.SpanKind, current o
 }
 
 func (p *nrotelhybridProcessor) switchSegmentType(s trace.ReadOnlySpan) {
-	var fullURL = ""
-	segInterface, ok := p.segmentMap[s.SpanContext().SpanID()]
+	spanID := s.SpanContext().SpanID()
+	segInterface, ok := p.segmentMap[spanID]
 	if !ok {
 		return
 	}
@@ -165,9 +162,13 @@ func (p *nrotelhybridProcessor) switchSegmentType(s trace.ReadOnlySpan) {
 	if !ok {
 		return
 	}
+
+	var fullURL = ""
+	attributes := s.Attributes()
+
 	switch s.SpanKind() {
 	case oteltrace.SpanKindClient:
-		for _, attr := range s.Attributes() {
+		for _, attr := range attributes {
 			if attr.Key == attribute.Key(AttrURLFull) {
 				fullURL = attr.Value.AsString()
 			}
@@ -176,7 +177,8 @@ func (p *nrotelhybridProcessor) switchSegmentType(s trace.ReadOnlySpan) {
 					StartTime: basicSegment.StartTime,
 				}
 				// map attribtues for db
-				p.segmentMap[s.SpanContext().SpanID()] = seg
+				p.addSegmentAttributes(spanID, seg, attributes, OTELToNRDBAttributeMap)
+				p.segmentMap[spanID] = seg
 				return
 			}
 		}
@@ -184,10 +186,31 @@ func (p *nrotelhybridProcessor) switchSegmentType(s trace.ReadOnlySpan) {
 			StartTime: basicSegment.StartTime,
 		}
 		seg.URL = fullURL
-		p.segmentMap[s.SpanContext().SpanID()] = seg
+		p.addSegmentAttributes(spanID, seg, attributes, OTELToNRHTTPAttributeMap)
+		p.segmentMap[spanID] = seg
 	default:
+		p.addSegmentAttributes(spanID, basicSegment, attributes, nil)
 		return
 	}
+}
+
+func (p *nrotelhybridProcessor) addSegmentAttributes(spanID oteltrace.SpanID, seg nrSegment, attributes []attribute.KeyValue, attrMap map[string]string) {
+	for _, otelAttribute := range attributes {
+		if nrAttribute, ok := checkMap(otelAttribute.Key, attrMap); ok {
+			seg.AddAttribute(string(nrAttribute), extractAttributeValue(otelAttribute.Value))
+			continue
+		}
+		seg.AddAttribute(string(otelAttribute.Key), extractAttributeValue(otelAttribute.Value))
+	}
+}
+
+func checkMap(key attribute.Key, attrMap map[string]string) (string, bool) {
+	if attrMap == nil {
+		return "", false
+	}
+	nrAttribute, ok := attrMap[string(key)]
+	return nrAttribute, ok
+
 }
 
 func isWithinTransaction(txnMap map[oteltrace.TraceID][]txnMapEntry, traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool {

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -79,7 +79,7 @@ func (p *nrotelhybridProcessor) startTransaction(s trace.ReadWriteSpan, isWeb bo
 }
 
 func (p *nrotelhybridProcessor) startSegment(s trace.ReadWriteSpan, entry txnMapEntry) {
-	seg := entry.txn.StartSegment(s.Name())
+	seg := p.getSegmentType(s, entry)
 	p.segmentMap[s.SpanContext().SpanID()] = seg
 }
 
@@ -104,35 +104,6 @@ func (p *nrotelhybridProcessor) OnEnd(s trace.ReadOnlySpan) {
 		}
 		seg.End()
 		delete(p.segmentMap, spanID)
-	}
-
-}
-
-func extractAttributeValue(val attribute.Value) any {
-
-	switch val.Type() {
-	case attribute.BOOL:
-		return val.AsBool()
-	case attribute.INT64:
-		return val.AsInt64()
-	case attribute.FLOAT64:
-		return val.AsFloat64()
-	case attribute.STRING:
-		return val.AsString()
-	case attribute.BOOLSLICE:
-		return val.AsBoolSlice()
-	case attribute.INT64SLICE:
-		return val.AsInt64Slice()
-	case attribute.FLOAT64SLICE:
-		return val.AsFloat64Slice()
-	case attribute.STRINGSLICE:
-		return val.AsStringSlice()
-	case attribute.BYTESLICE:
-		return val.AsByteSlice()
-	case attribute.SLICE:
-		return val.AsSlice()
-	default:
-		return nil // EMPTY OR INVALID
 	}
 
 }
@@ -169,10 +140,60 @@ func (p *nrotelhybridProcessor) isTransaction(kind oteltrace.SpanKind, current o
 	}
 }
 
+func (p *nrotelhybridProcessor) getSegmentType(s trace.ReadWriteSpan, entry txnMapEntry) nrSegment {
+	var fullURL = ""
+	switch s.SpanKind() {
+	case oteltrace.SpanKindClient:
+		for _, attr := range s.Attributes() {
+			// db.system is not in current semconv package
+			if attr.Key == semconv.URLFullKey {
+				fullURL = attr.Value.AsString()
+			}
+			if attr.Key == semconv.DBSystemNameKey || attr.Key == "db.system" {
+				return &newrelic.DatastoreSegment{}
+			}
+		}
+		seg := newrelic.StartExternalSegment(entry.txn, nil)
+		seg.URL = fullURL
+		return seg
+	default:
+		return entry.txn.StartSegment(s.Name())
+	}
+}
+
 func isWithinTransaction(txnMap map[oteltrace.TraceID]txnMapEntry, traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool {
 	// if the transaction exists and is not the same span id, it is within an existing transaction
 	if val, ok := txnMap[traceID]; ok {
 		return val.spanID != spanID
 	}
 	return false
+}
+
+func extractAttributeValue(val attribute.Value) any {
+
+	switch val.Type() {
+	case attribute.BOOL:
+		return val.AsBool()
+	case attribute.INT64:
+		return val.AsInt64()
+	case attribute.FLOAT64:
+		return val.AsFloat64()
+	case attribute.STRING:
+		return val.AsString()
+	case attribute.BOOLSLICE:
+		return val.AsBoolSlice()
+	case attribute.INT64SLICE:
+		return val.AsInt64Slice()
+	case attribute.FLOAT64SLICE:
+		return val.AsFloat64Slice()
+	case attribute.STRINGSLICE:
+		return val.AsStringSlice()
+	case attribute.BYTESLICE:
+		return val.AsByteSlice()
+	case attribute.SLICE:
+		return val.AsSlice()
+	default:
+		return nil // EMPTY OR INVALID
+	}
+
 }

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -164,7 +164,11 @@ func (p *nrotelhybridProcessor) switchSegmentType(spanID oteltrace.SpanID, attri
 
 	switch spanKind {
 	case oteltrace.SpanKindClient:
+		var fullURL string
 		for _, attr := range attributes {
+			if attr.Key == attribute.Key(AttrURLFull) || attr.Key == attribute.Key(AttrHTTPURL) {
+				fullURL = attr.Value.AsString()
+			}
 
 			if attr.Key == attribute.Key(AttrDBSystemName) || attr.Key == attribute.Key(AttrDBSystem) {
 				seg := &newrelic.DatastoreSegment{
@@ -178,6 +182,7 @@ func (p *nrotelhybridProcessor) switchSegmentType(spanID oteltrace.SpanID, attri
 		}
 		seg := &newrelic.ExternalSegment{
 			StartTime: basicSegment.StartTime,
+			URL:       fullURL,
 		}
 		p.addSegmentAttributes(seg, attributes, OTELToNRHTTPAttributeMap)
 		p.segmentMap[spanID] = seg

--- a/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
@@ -231,7 +231,7 @@ func Test_isTransaction(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := nrotelhybridProcessor{
-				txnChecker: func(txnMap map[oteltrace.TraceID]txnMapEntry, traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool {
+				txnChecker: func(txnMap map[oteltrace.TraceID][]txnMapEntry, traceID oteltrace.TraceID, spanID oteltrace.SpanID) bool {
 					return tt.txnCheck
 				},
 			}
@@ -250,15 +250,32 @@ func Test_nrotelhybridProcessor_isWithinTransaction(t *testing.T) {
 	otherSpanID := [8]byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18}
 	missingTraceID := [16]byte{0x12, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20}
 
-	noEntriesMap := map[oteltrace.TraceID]txnMapEntry{}
+	noEntriesMap := map[oteltrace.TraceID][]txnMapEntry{}
 
-	singleEntryMap := map[oteltrace.TraceID]txnMapEntry{
-		validTraceID: {txn: nil, spanID: validSpanID},
+	singleEntryMap := map[oteltrace.TraceID][]txnMapEntry{
+		validTraceID: {{txn: nil, spanID: validSpanID}},
+	}
+	singleEntryMultipleTxnMapEntriesMap := map[oteltrace.TraceID][]txnMapEntry{
+		validTraceID: {
+			{txn: nil, spanID: validSpanID},
+			{txn: nil, spanID: otherSpanID},
+		},
 	}
 
-	multiEntryMap := map[oteltrace.TraceID]txnMapEntry{
-		validTraceID: {txn: nil, spanID: validSpanID},
-		otherTraceID: {txn: nil, spanID: otherSpanID},
+	multiEntryMap := map[oteltrace.TraceID][]txnMapEntry{
+		validTraceID: {{txn: nil, spanID: validSpanID}},
+		otherTraceID: {{txn: nil, spanID: otherSpanID}},
+	}
+
+	multiEntryMultipleTxnMapEntriesMap := map[oteltrace.TraceID][]txnMapEntry{
+		validTraceID: {
+			{txn: nil, spanID: validSpanID},
+			{txn: nil, spanID: otherSpanID},
+		},
+		otherTraceID: {
+			{txn: nil, spanID: otherSpanID},
+			{txn: nil, spanID: validSpanID},
+		},
 	}
 
 	tests := []struct {
@@ -266,7 +283,7 @@ func Test_nrotelhybridProcessor_isWithinTransaction(t *testing.T) {
 		// Named input parameters for target function.
 		traceID oteltrace.TraceID
 		spanID  oteltrace.SpanID
-		txnMap  map[oteltrace.TraceID]txnMapEntry
+		txnMap  map[oteltrace.TraceID][]txnMapEntry
 		want    bool
 	}{
 		{
@@ -316,6 +333,48 @@ func Test_nrotelhybridProcessor_isWithinTransaction(t *testing.T) {
 			traceID: missingTraceID,
 			spanID:  validSpanID,
 			txnMap:  multiEntryMap,
+			want:    false,
+		},
+		{
+			name:    "TraceID is within transaction map and is within an existing transaction.",
+			traceID: validTraceID,
+			spanID:  validSpanID,
+			txnMap:  singleEntryMultipleTxnMapEntriesMap,
+			want:    true,
+		},
+		{
+			name:    "TraceID is within transaction map and is not within an existing transaction.",
+			traceID: validTraceID,
+			spanID:  otherSpanID,
+			txnMap:  singleEntryMultipleTxnMapEntriesMap,
+			want:    false,
+		},
+		{
+			name:    "TraceID is within mutli entry transaction map is within an existing transaction.",
+			traceID: validTraceID,
+			spanID:  validSpanID,
+			txnMap:  multiEntryMultipleTxnMapEntriesMap,
+			want:    true,
+		},
+		{
+			name:    "TraceID is within mutli entry transaction map is within an existing transaction.",
+			traceID: validTraceID,
+			spanID:  otherSpanID,
+			txnMap:  multiEntryMultipleTxnMapEntriesMap,
+			want:    false,
+		},
+		{
+			name:    "TraceID is within mutli entry transaction map (different entry) is within an existing transaction.",
+			traceID: otherTraceID,
+			spanID:  otherSpanID,
+			txnMap:  multiEntryMultipleTxnMapEntriesMap,
+			want:    true,
+		},
+		{
+			name:    "TraceID is within mutli entry transaction map (different entry) is within an existing transaction.",
+			traceID: otherTraceID,
+			spanID:  validSpanID,
+			txnMap:  multiEntryMultipleTxnMapEntriesMap,
 			want:    false,
 		},
 	}

--- a/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
@@ -2,9 +2,11 @@ package nrotelhybrid
 
 import (
 	"context"
+	"maps"
 	"reflect"
 	"testing"
 
+	"github.com/newrelic/go-agent/v3/newrelic"
 	"github.com/newrelic/go-agent/v3/newrelic/integrationsupport"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -566,6 +568,186 @@ func Test_extractAttributeValue(t *testing.T) {
 			got := extractAttributeValue(tt.val)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("extractAttributeValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_nrotelhybridProcessor_switchSegmentType(t *testing.T) {
+	validSpanID := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	otherSpanID := [8]byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18}
+
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		initialSegmentMap map[oteltrace.SpanID]nrSegment
+		spanID            oteltrace.SpanID
+		attributes        []attribute.KeyValue
+		spanKind          oteltrace.SpanKind
+		want              nrSegment
+	}{
+		{
+			name:              "Segment does not exist in empty segment map.",
+			initialSegmentMap: map[oteltrace.SpanID]nrSegment{},
+			spanID:            validSpanID,
+			spanKind:          oteltrace.SpanKindClient,
+			want:              nil,
+		},
+		{
+			name: "Segment does not exist in segment map",
+			initialSegmentMap: map[oteltrace.SpanID]nrSegment{
+				otherSpanID: &newrelic.Segment{
+					StartTime: newrelic.SegmentStartTime{},
+					Name:      "Basic Segment",
+				},
+			},
+			spanID:   validSpanID,
+			spanKind: oteltrace.SpanKindConsumer,
+			want:     nil,
+		},
+		{
+			name:   "Segment is not a basic segment upon type cast. Should stay the same type.",
+			spanID: validSpanID,
+			initialSegmentMap: map[oteltrace.SpanID]nrSegment{
+				validSpanID: &newrelic.DatastoreSegment{
+					StartTime: newrelic.SegmentStartTime{},
+				},
+			},
+			spanKind: oteltrace.SpanKindInternal,
+			want:     &newrelic.DatastoreSegment{},
+		},
+		{
+			name:   "Segment is not a basic segment (different type) upon type cast. Should stay the same type.",
+			spanID: otherSpanID,
+			initialSegmentMap: map[oteltrace.SpanID]nrSegment{
+				otherSpanID: &newrelic.ExternalSegment{
+					StartTime: newrelic.SegmentStartTime{},
+				},
+			},
+			spanKind: oteltrace.SpanKindInternal,
+			want:     &newrelic.ExternalSegment{},
+		},
+		{
+			name:   "Segment is a basic segment upon type cast. SpanKind is INTERNAL. Should stay the same type.",
+			spanID: otherSpanID,
+			initialSegmentMap: map[oteltrace.SpanID]nrSegment{
+				otherSpanID: &newrelic.Segment{
+					StartTime: newrelic.SegmentStartTime{},
+					Name:      "Basic Segment",
+				},
+			},
+			spanKind: oteltrace.SpanKindInternal,
+			want:     &newrelic.Segment{},
+		},
+		{
+			name:   "Segment is a basic segment upon type cast. SpanKind is UNSPECIFIED. Should stay the same type.",
+			spanID: validSpanID,
+			initialSegmentMap: map[oteltrace.SpanID]nrSegment{
+				validSpanID: &newrelic.Segment{
+					StartTime: newrelic.SegmentStartTime{},
+					Name:      "Basic Segment",
+				},
+			},
+			spanKind: oteltrace.SpanKindUnspecified,
+			want:     &newrelic.Segment{},
+		},
+		{
+			name:   "Segment is a basic segment upon type cast. SpanKind is CLIENT. Should convert to External Segment.",
+			spanID: validSpanID,
+			initialSegmentMap: map[oteltrace.SpanID]nrSegment{
+				validSpanID: &newrelic.Segment{
+					StartTime: newrelic.SegmentStartTime{},
+					Name:      "Basic Segment",
+				},
+			},
+			attributes: []attribute.KeyValue{},
+			spanKind:   oteltrace.SpanKindClient,
+			want:       &newrelic.ExternalSegment{},
+		},
+		{
+			name:   "Segment is a basic segment upon type cast. SpanKind is CLIENT. Should convert to External Segment. Attributes are present.",
+			spanID: otherSpanID,
+			initialSegmentMap: map[oteltrace.SpanID]nrSegment{
+				otherSpanID: &newrelic.Segment{
+					StartTime: newrelic.SegmentStartTime{},
+					Name:      "Basic Segment",
+				},
+			},
+			attributes: []attribute.KeyValue{
+				{Key: attribute.Key(AttrURLFull), Value: attribute.StringValue("testURL")},
+			},
+			spanKind: oteltrace.SpanKindClient,
+			want:     &newrelic.ExternalSegment{},
+		},
+		{
+			name:   "Segment is a basic segment upon type cast. SpanKind is CLIENT. Should convert to Datastore Segment. Uses AttrDBSystem constant.",
+			spanID: validSpanID,
+			initialSegmentMap: map[oteltrace.SpanID]nrSegment{
+				validSpanID: &newrelic.Segment{
+					StartTime: newrelic.SegmentStartTime{},
+					Name:      "Basic Segment",
+				},
+			},
+			attributes: []attribute.KeyValue{
+				{Key: attribute.Key(AttrDBSystem), Value: attribute.StringValue("test-system")},
+			},
+			spanKind: oteltrace.SpanKindClient,
+			want:     &newrelic.DatastoreSegment{},
+		},
+		{
+			name:   "Segment is a basic segment upon type cast. SpanKind is CLIENT.Should convert to Datastore Segment. Uses AttrDBSystemName constant.",
+			spanID: otherSpanID,
+			initialSegmentMap: map[oteltrace.SpanID]nrSegment{
+				otherSpanID: &newrelic.Segment{
+					StartTime: newrelic.SegmentStartTime{},
+					Name:      "Basic Segment",
+				},
+			},
+			attributes: []attribute.KeyValue{
+				{Key: attribute.Key(AttrDBSystemName), Value: attribute.StringValue("test-system")},
+			},
+			spanKind: oteltrace.SpanKindClient,
+			want:     &newrelic.DatastoreSegment{},
+		},
+		{
+			name:   "Segment is a basic segment upon type cast. SpanKind is CLIENT.Should convert to Datastore Segment. Contains both DB constants.",
+			spanID: otherSpanID,
+			initialSegmentMap: map[oteltrace.SpanID]nrSegment{
+				otherSpanID: &newrelic.Segment{
+					StartTime: newrelic.SegmentStartTime{},
+					Name:      "Basic Segment",
+				},
+			},
+			attributes: []attribute.KeyValue{
+				{Key: attribute.Key(AttrDBSystemName), Value: attribute.StringValue("test-system")},
+				{Key: attribute.Key(AttrDBSystem), Value: attribute.StringValue("test-system")},
+			},
+			spanKind: oteltrace.SpanKindClient,
+			want:     &newrelic.DatastoreSegment{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewHybridProcessor(&newrelic.Application{})
+			maps.Copy(p.segmentMap, tt.initialSegmentMap)
+			p.switchSegmentType(tt.spanID, tt.attributes, tt.spanKind)
+
+			seg, ok := p.segmentMap[tt.spanID]
+
+			if tt.want == nil {
+				if ok {
+					t.Errorf("Expected no segment, got segment at spanID = %v", tt.spanID)
+				}
+				return
+			}
+
+			if !ok {
+				t.Errorf("Expected segment at spanID = %v, got nothing", tt.spanID)
+				return
+			}
+
+			if reflect.TypeOf(seg) != reflect.TypeOf(tt.want) {
+				t.Errorf("Expected segment type of %v, got %v", reflect.TypeOf(seg), reflect.TypeOf(tt.want))
 			}
 		})
 	}

--- a/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
@@ -796,3 +796,85 @@ func Test_checkMap(t *testing.T) {
 		})
 	}
 }
+
+type fakeSegment struct {
+	attrs map[string]interface{}
+}
+
+func (f *fakeSegment) End() {}
+
+func (f *fakeSegment) AddAttribute(key string, val interface{}) {
+	if f.attrs == nil {
+		f.attrs = map[string]interface{}{}
+	}
+	f.attrs[key] = val
+}
+
+func Test_nrotelhybridProcessor_addSegmentAttributes(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		attributes []attribute.KeyValue
+		attrMap    map[string]string
+		want       map[string]interface{}
+	}{
+		{
+			name:       "No attributes.",
+			attributes: []attribute.KeyValue{},
+			attrMap:    map[string]string{},
+			want:       map[string]interface{}{},
+		},
+		{
+			name: "Nil attrMap. Keys pass through unmapped.",
+			attributes: []attribute.KeyValue{
+				attribute.String("otel.key", "value"),
+			},
+			attrMap: nil,
+			want: map[string]interface{}{
+				"otel.key": "value",
+			},
+		},
+		{
+			name: "Key present in attrMap is renamed.",
+			attributes: []attribute.KeyValue{
+				attribute.String("otel.key", "value"),
+			},
+			attrMap: map[string]string{
+				"otel.key": "nr.key",
+			},
+			want: map[string]interface{}{
+				"nr.key": "value",
+			},
+		},
+		{
+			name: "Mix of mapped and unmapped keys, various value types.",
+			attributes: []attribute.KeyValue{
+				attribute.String("otel.mapped", "value"),
+				attribute.Int64("otel.unmapped", 42),
+				attribute.Bool("otel.bool", true),
+			},
+			attrMap: map[string]string{
+				"otel.mapped": "nr.mapped",
+			},
+			want: map[string]interface{}{
+				"nr.mapped":     "value",
+				"otel.unmapped": int64(42),
+				"otel.bool":     true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewHybridProcessor(&newrelic.Application{})
+			seg := &fakeSegment{}
+			p.addSegmentAttributes(seg, tt.attributes, tt.attrMap)
+
+			if seg.attrs == nil {
+				seg.attrs = map[string]interface{}{}
+			}
+			if !reflect.DeepEqual(seg.attrs, tt.want) {
+				t.Errorf("addSegmentAttributes() attrs = %v, want %v", seg.attrs, tt.want)
+			}
+		})
+	}
+}

--- a/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
@@ -878,3 +878,90 @@ func Test_nrotelhybridProcessor_addSegmentAttributes(t *testing.T) {
 		})
 	}
 }
+
+func Test_addSegmentAttributes_DatastoreSegment(t *testing.T) {
+	tests := []struct {
+		name           string
+		attributes     []attribute.KeyValue
+		wantCollection string
+		wantOperation  string
+		wantQuery      string
+	}{
+		{
+			name: "db.collection.name and db.operation.name set typed fields.",
+			attributes: []attribute.KeyValue{
+				attribute.String(AttrDBCollectionName, "users"),
+				attribute.String(AttrDBOperationName, "SELECT"),
+			},
+			wantCollection: "users",
+			wantOperation:  "SELECT",
+		},
+		{
+			name: "Legacy db.sql.table and db.operation set typed fields.",
+			attributes: []attribute.KeyValue{
+				attribute.String(AttrDBSQLTable, "orders"),
+				attribute.String(AttrDBOperation, "INSERT"),
+			},
+			wantCollection: "orders",
+			wantOperation:  "INSERT",
+		},
+		{
+			name: "db.statement sets ParameterizedQuery.",
+			attributes: []attribute.KeyValue{
+				attribute.String(AttrDBStatement, "SELECT count(*) FROM pg_catalog.pg_tables"),
+			},
+			wantQuery: "SELECT count(*) FROM pg_catalog.pg_tables",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewHybridProcessor(&newrelic.Application{})
+			seg := &newrelic.DatastoreSegment{}
+			p.addSegmentAttributes(seg, tt.attributes, OTELToNRDBAttributeMap)
+
+			if seg.Collection != tt.wantCollection {
+				t.Errorf("Collection = %v, want %v", seg.Collection, tt.wantCollection)
+			}
+			if seg.Operation != tt.wantOperation {
+				t.Errorf("Operation = %v, want %v", seg.Operation, tt.wantOperation)
+			}
+			if seg.ParameterizedQuery != tt.wantQuery {
+				t.Errorf("ParameterizedQuery = %v, want %v", seg.ParameterizedQuery, tt.wantQuery)
+			}
+		})
+	}
+}
+
+func Test_addSegmentAttributes_ExternalSegment(t *testing.T) {
+	tests := []struct {
+		name       string
+		attributes []attribute.KeyValue
+		wantURL    string
+	}{
+		{
+			name: "url.full sets URL.",
+			attributes: []attribute.KeyValue{
+				attribute.String(AttrURLFull, "http://example.com/path"),
+			},
+			wantURL: "http://example.com/path",
+		},
+		{
+			name: "Legacy http.url sets URL.",
+			attributes: []attribute.KeyValue{
+				attribute.String(AttrHTTPURL, "http://legacy.example.com/path"),
+			},
+			wantURL: "http://legacy.example.com/path",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewHybridProcessor(&newrelic.Application{})
+			seg := &newrelic.ExternalSegment{}
+			p.addSegmentAttributes(seg, tt.attributes, OTELToNRHTTPAttributeMap)
+
+			if seg.URL != tt.wantURL {
+				t.Errorf("URL = %v, want %v", seg.URL, tt.wantURL)
+			}
+		})
+	}
+}

--- a/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
@@ -752,3 +752,47 @@ func Test_nrotelhybridProcessor_switchSegmentType(t *testing.T) {
 		})
 	}
 }
+
+func Test_checkMap(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		key     attribute.Key
+		attrMap map[string]string
+		want    string
+		want2   bool
+	}{
+		{
+			name:    "Nil map",
+			key:     attribute.Key("some.key"),
+			attrMap: nil,
+			want:    "",
+			want2:   false,
+		},
+		{
+			name:    "Key present in map",
+			key:     attribute.Key("some.key"),
+			attrMap: map[string]string{"some.key": "nr.attribute"},
+			want:    "nr.attribute",
+			want2:   true,
+		},
+		{
+			name:    "Key not present in map",
+			key:     attribute.Key("missing.key"),
+			attrMap: map[string]string{"some.key": "nr.attribute"},
+			want:    "",
+			want2:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got2 := checkMap(tt.key, tt.attrMap)
+			if got != tt.want {
+				t.Errorf("checkMap() = %v, want %v", got, tt.want)
+			}
+			if got2 != tt.want2 {
+				t.Errorf("checkMap() = %v, want %v", got2, tt.want2)
+			}
+		})
+	}
+}

--- a/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
@@ -2,10 +2,12 @@ package nrotelhybrid
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/newrelic/go-agent/v3/newrelic/integrationsupport"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/trace"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
@@ -492,6 +494,79 @@ func Test_nrotelhybridProcessor(t *testing.T) {
 
 			span.End()
 
+		})
+	}
+}
+
+func Test_extractAttributeValue(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		val  attribute.Value
+		want any
+	}{
+		{
+			name: "Bool",
+			val:  attribute.BoolValue(true),
+			want: true,
+		},
+		{
+			name: "Int64",
+			val:  attribute.Int64Value(42),
+			want: int64(42),
+		},
+		{
+			name: "Float64",
+			val:  attribute.Float64Value(3.14),
+			want: 3.14,
+		},
+		{
+			name: "String",
+			val:  attribute.StringValue("hello"),
+			want: "hello",
+		},
+		{
+			name: "BoolSlice",
+			val:  attribute.BoolSliceValue([]bool{true, false}),
+			want: []bool{true, false},
+		},
+		{
+			name: "Int64Slice",
+			val:  attribute.Int64SliceValue([]int64{1, 2, 3}),
+			want: []int64{1, 2, 3},
+		},
+		{
+			name: "Float64Slice",
+			val:  attribute.Float64SliceValue([]float64{1.1, 2.2}),
+			want: []float64{1.1, 2.2},
+		},
+		{
+			name: "StringSlice",
+			val:  attribute.StringSliceValue([]string{"a", "b"}),
+			want: []string{"a", "b"},
+		},
+		{
+			name: "ByteSlice",
+			val:  attribute.ByteSliceValue([]byte{0x01, 0x02}),
+			want: []byte{0x01, 0x02},
+		},
+		{
+			name: "Slice",
+			val:  attribute.SliceValue(attribute.StringValue("a"), attribute.IntValue(1)),
+			want: []attribute.Value{attribute.StringValue("a"), attribute.IntValue(1)},
+		},
+		{
+			name: "Empty/invalid value",
+			val:  attribute.Value{},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractAttributeValue(tt.val)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractAttributeValue() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

<!--
Any relevant links that will help reviewers.
-->

## Details
### Issue
The `nrotelhybrid` package can only start Basic Segments.
### Goals
The `nrotelhybrid` package should be able to start External and Datastore Segments.
### Implementation
#### Transaction Changes
- `txn` now maps to a slice of `txnMapEntry`.  This is to prevent an issue of the same trace id overwriting a transaction and therefore never ending.  Uncommon, but can happen if an HTTP request is made to the same service.
- `OnEnd` now loops through entries for a given traceID. If the spanID matches, then that transaction is ended and removed from the entries.
#### Segment Changes
- `segmentMap` maps to a generic interface that covers all the segments that can be started by the Go Agent
- `OnEnd` calls `switchSegmentType` which will change the segment type based on certain parameters
- `DatastoreSegment` occurs when the `SpanKind` is `SpanKind.CLIENT` and the span contains an attribute of either `db.system` or `db.system.name`
- `ExternalSegment` occurs when the `SpanKind` is `SpanKind.CLIENT` and the above criteria is not met
- Default behavior is to not modify the segment type
- This `switchSegmentType` occurs at the end because it is based on attributes that may not exist at the beginning of a segments' lifecylce
- Attributes are added after segment type switch using maps in `constants.go`
### Example Changes
- Added `routethree` to call `routefour` and mimic HTTP call

<!--
In-depth description of changes, other technical notes, etc.
-->
