### PR TITLE
feat: Server Side Config support for AIM

### DIFF
--- a/v3/internal/connect_reply.go
+++ b/v3/internal/connect_reply.go
@@ -102,6 +102,9 @@ type ConnectReply struct {
 		ErrorCollectorIgnoreStatusCodes      []int       `json:"error_collector.ignore_status_codes"`
 		ErrorCollectorExpectStatusCodes      []int       `json:"error_collector.expected_status_codes"`
 		CrossApplicationTracerEnabled        *bool       `json:"cross_application_tracer.enabled"`
+		AIMonitoringEnabled                  *bool       `json:"ai_monitoring.enabled"`
+		AIMonitoringStreamingEnabled         *bool       `json:"ai_monitoring.streaming.enabled"`
+		AIMonitoringRecordContentEnabled     *bool       `json:"ai_monitoring.record_content.enabled"`
 	} `json:"agent_config"`
 
 	// Faster Event Harvest

--- a/v3/newrelic/app_run.go
+++ b/v3/newrelic/app_run.go
@@ -71,6 +71,15 @@ func newAppRun(config config, reply *internal.ConnectReply) *appRun {
 	if v := run.Reply.ServerSideConfig.CrossApplicationTracerEnabled; v != nil {
 		run.Config.CrossApplicationTracer.Enabled = *v
 	}
+	if v := run.Reply.ServerSideConfig.AIMonitoringEnabled; v != nil {
+		run.Config.AIMonitoring.Enabled = *v
+	}
+	if v := run.Reply.ServerSideConfig.AIMonitoringStreamingEnabled; v != nil {
+		run.Config.AIMonitoring.Streaming.Enabled = *v
+	}
+	if v := run.Reply.ServerSideConfig.AIMonitoringRecordContentEnabled; v != nil {
+		run.Config.AIMonitoring.RecordContent.Enabled = *v
+	}
 	if v := run.Reply.ServerSideConfig.TransactionTracerThreshold; v != nil {
 		switch val := v.(type) {
 		case float64:

--- a/v3/newrelic/app_run_test.go
+++ b/v3/newrelic/app_run_test.go
@@ -157,6 +157,102 @@ func TestTxnTraceThreshold(t *testing.T) {
 	}
 }
 
+func TestServerSideConfigAIMonitoringEnabled(t *testing.T) {
+	// Server-side config enables a locally disabled setting.
+	cfg := config{Config: defaultConfig()}
+	cfg.AIMonitoring.Enabled = false
+	reply := internal.ConnectReplyDefaults()
+	json.Unmarshal([]byte(`{"agent_config":{"ai_monitoring.enabled":true}}`), &reply)
+	run := newAppRun(cfg, reply)
+	if !run.Config.AIMonitoring.Enabled {
+		t.Error("AIMonitoring.Enabled not enabled by server-side config")
+	}
+
+	// Server-side config disables a locally enabled setting.
+	cfg = config{Config: defaultConfig()}
+	cfg.AIMonitoring.Enabled = true
+	reply = internal.ConnectReplyDefaults()
+	json.Unmarshal([]byte(`{"agent_config":{"ai_monitoring.enabled":false}}`), &reply)
+	run = newAppRun(cfg, reply)
+	if run.Config.AIMonitoring.Enabled {
+		t.Error("AIMonitoring.Enabled not disabled by server-side config")
+	}
+
+	// Absent server-side config leaves the local setting untouched.
+	cfg = config{Config: defaultConfig()}
+	cfg.AIMonitoring.Enabled = true
+	reply = internal.ConnectReplyDefaults()
+	json.Unmarshal([]byte(`{"agent_config":{}}`), &reply)
+	run = newAppRun(cfg, reply)
+	if !run.Config.AIMonitoring.Enabled {
+		t.Error("AIMonitoring.Enabled changed despite absent server-side config")
+	}
+}
+
+func TestServerSideConfigAIMonitoringStreamingEnabled(t *testing.T) {
+	// Server-side config enables a locally disabled setting.
+	cfg := config{Config: defaultConfig()}
+	cfg.AIMonitoring.Streaming.Enabled = false
+	reply := internal.ConnectReplyDefaults()
+	json.Unmarshal([]byte(`{"agent_config":{"ai_monitoring.streaming.enabled":true}}`), &reply)
+	run := newAppRun(cfg, reply)
+	if !run.Config.AIMonitoring.Streaming.Enabled {
+		t.Error("AIMonitoring.Streaming.Enabled not enabled by server-side config")
+	}
+
+	// Server-side config disables a locally enabled setting.
+	cfg = config{Config: defaultConfig()}
+	cfg.AIMonitoring.Streaming.Enabled = true
+	reply = internal.ConnectReplyDefaults()
+	json.Unmarshal([]byte(`{"agent_config":{"ai_monitoring.streaming.enabled":false}}`), &reply)
+	run = newAppRun(cfg, reply)
+	if run.Config.AIMonitoring.Streaming.Enabled {
+		t.Error("AIMonitoring.Streaming.Enabled not disabled by server-side config")
+	}
+
+	// Absent server-side config leaves the local setting untouched.
+	cfg = config{Config: defaultConfig()}
+	cfg.AIMonitoring.Streaming.Enabled = true
+	reply = internal.ConnectReplyDefaults()
+	json.Unmarshal([]byte(`{"agent_config":{}}`), &reply)
+	run = newAppRun(cfg, reply)
+	if !run.Config.AIMonitoring.Streaming.Enabled {
+		t.Error("AIMonitoring.Streaming.Enabled changed despite absent server-side config")
+	}
+}
+
+func TestServerSideConfigAIMonitoringRecordContentEnabled(t *testing.T) {
+	// Server-side config enables a locally disabled setting.
+	cfg := config{Config: defaultConfig()}
+	cfg.AIMonitoring.RecordContent.Enabled = false
+	reply := internal.ConnectReplyDefaults()
+	json.Unmarshal([]byte(`{"agent_config":{"ai_monitoring.record_content.enabled":true}}`), &reply)
+	run := newAppRun(cfg, reply)
+	if !run.Config.AIMonitoring.RecordContent.Enabled {
+		t.Error("AIMonitoring.RecordContent.Enabled not enabled by server-side config")
+	}
+
+	// Server-side config disables a locally enabled setting.
+	cfg = config{Config: defaultConfig()}
+	cfg.AIMonitoring.RecordContent.Enabled = true
+	reply = internal.ConnectReplyDefaults()
+	json.Unmarshal([]byte(`{"agent_config":{"ai_monitoring.record_content.enabled":false}}`), &reply)
+	run = newAppRun(cfg, reply)
+	if run.Config.AIMonitoring.RecordContent.Enabled {
+		t.Error("AIMonitoring.RecordContent.Enabled not disabled by server-side config")
+	}
+
+	// Absent server-side config leaves the local setting untouched.
+	cfg = config{Config: defaultConfig()}
+	cfg.AIMonitoring.RecordContent.Enabled = true
+	reply = internal.ConnectReplyDefaults()
+	json.Unmarshal([]byte(`{"agent_config":{}}`), &reply)
+	run = newAppRun(cfg, reply)
+	if !run.Config.AIMonitoring.RecordContent.Enabled {
+		t.Error("AIMonitoring.RecordContent.Enabled changed despite absent server-side config")
+	}
+}
+
 func TestEmptyReplyEventHarvestDefaults(t *testing.T) {
 	run := newAppRun(config{Config: defaultConfig()}, &internal.ConnectReply{})
 	assertHarvestConfig(t, run.harvestConfig, expectHarvestConfig{


### PR DESCRIPTION
## Summary

Adds support for AI Monitoring server-side config. The agent now honors `ai_monitoring.*` values set in the New Relic UI, overriding local config at connect time — matching existing behavior for transaction tracer, error collector, and CAT.

## Changes

- **`internal/connect_reply.go`** — add three `ServerSideConfig` fields: `AIMonitoringEnabled`, `AIMonitoringStreamingEnabled`, `AIMonitoringRecordContentEnabled`.
- **`newrelic/app_run.go`** — apply each value to `Config.AIMonitoring` when present.
- **`newrelic/app_run_test.go`** — per-flag tests: enable, disable, absent.