### PR TITLE
feat: support for nrecho-v5

### DIFF
--- a/v3/integrations/nrecho-v5/LICENSE.txt
+++ b/v3/integrations/nrecho-v5/LICENSE.txt
@@ -1,0 +1,206 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+Versions 3.8.0 and above for this project are licensed under Apache 2.0. For
+prior versions of this project, please see the LICENCE.txt file in the root
+directory of that version for more information.

--- a/v3/integrations/nrecho-v5/README.md
+++ b/v3/integrations/nrecho-v5/README.md
@@ -1,0 +1,10 @@
+# v3/integrations/nrecho-v5 [![GoDoc](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrecho-v5?status.svg)](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrecho-v5)
+
+Package `nrecho` instruments applications using  https://github.com/labstack/echo v5.
+
+```go
+import "github.com/newrelic/go-agent/v3/integrations/nrecho-v5"
+```
+
+For more information, see
+[godocs](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrecho-v5).

--- a/v3/integrations/nrecho-v5/example/main.go
+++ b/v3/integrations/nrecho-v5/example/main.go
@@ -1,0 +1,53 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/labstack/echo/v5"
+	nrecho "github.com/newrelic/go-agent/v3/integrations/nrecho-v5"
+	"github.com/newrelic/go-agent/v3/newrelic"
+)
+
+func getUser(c *echo.Context) error {
+	id := c.Param("id")
+
+	txn := nrecho.FromContext(c)
+	txn.AddAttribute("userId", id)
+
+	return c.String(http.StatusOK, id)
+}
+
+func main() {
+	app, err := newrelic.NewApplication(
+		newrelic.ConfigAppName("Echo App"),
+		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+		newrelic.ConfigDebugLogger(os.Stdout),
+	)
+	if nil != err {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// Echo instance
+	e := echo.New()
+
+	// The New Relic Middleware should be the first middleware registered
+	e.Use(nrecho.Middleware(app))
+
+	// Routes
+	e.GET("/home", func(c *echo.Context) error {
+		return c.String(http.StatusOK, "Hello, World!")
+	})
+
+	// Groups
+	g := e.Group("/user")
+	g.GET("/:id", getUser)
+
+	// Start server
+	e.Start(":8000")
+}

--- a/v3/integrations/nrecho-v5/go.mod
+++ b/v3/integrations/nrecho-v5/go.mod
@@ -1,0 +1,21 @@
+module github.com/newrelic/go-agent/v3/integrations/nrecho-v5
+
+// echo v5 requires Go 1.25:
+// https://github.com/labstack/echo/blob/v5/go.mod
+go 1.25.0
+
+require (
+	github.com/labstack/echo/v5 v5.3.1
+	github.com/newrelic/go-agent/v3 v3.44.1
+)
+
+require (
+	golang.org/x/net v0.57.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/text v0.40.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 // indirect
+	google.golang.org/grpc v1.80.0 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
+)
+
+replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nrecho-v5/nrecho.go
+++ b/v3/integrations/nrecho-v5/nrecho.go
@@ -1,0 +1,169 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package nrecho instruments applications using
+// https://github.com/labstack/echo v5.
+//
+// Use this package to instrument inbound requests handled by an echo.Echo
+// instance.
+//
+//	e := echo.New()
+//	// Add the nrecho middleware before other middlewares or routes:
+//	e.Use(nrecho.Middleware(app))
+//
+// Example: https://github.com/newrelic/go-agent/tree/master/v3/integrations/nrecho-v5/example/main.go
+package nrecho
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v5"
+	"github.com/newrelic/go-agent/v3/internal"
+	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+)
+
+func init() { internal.TrackUsage("integration", "framework", "echo") }
+
+// FromContext returns the Transaction from the context if present, and nil
+// otherwise.
+func FromContext(c *echo.Context) *newrelic.Transaction {
+	return newrelic.FromContext(c.Request().Context())
+}
+
+// echo v5 does not export a constant for the built-in 405 handler's route name
+// the way it does echo.NotFoundRouteName, so match the literal value.
+const methodNotAllowedRouteName = "echo_route_method_not_allowed_name"
+
+func transactionName(c *echo.Context) (name string, path string) {
+	ri := c.RouteInfo()
+
+	if ri.Name == echo.NotFoundRouteName {
+		return "NotFoundHandler", ""
+	}
+	if ri.Name == methodNotAllowedRouteName {
+		return "MethodNotAllowedHandler", ""
+	}
+
+	return c.Request().Method + " " + ri.Path, ri.Path
+}
+
+// Skipper defines a function to skip middleware. Returning true skips processing
+// the middleware.
+type Skipper func(c *echo.Context) bool
+
+// Config defines the config for the middleware.
+type Config struct {
+	// App contains newrelic application.
+	App *newrelic.Application
+
+	// Skipper defines a function to skip middleware.
+	Skipper Skipper
+}
+
+type ConfigOption func(*Config)
+
+func WithSkipper(skipper Skipper) ConfigOption {
+	return func(cfg *Config) { cfg.Skipper = skipper }
+}
+
+// Middleware creates Echo middleware with provided config that
+// instruments requests.
+//
+//	e := echo.New()
+//	// Add the nrecho middleware before other middlewares or routes:
+//	e.Use(nrecho.Middleware(app))
+func Middleware(app *newrelic.Application, opts ...ConfigOption) echo.MiddlewareFunc {
+	if app == nil {
+		return func(next echo.HandlerFunc) echo.HandlerFunc {
+			return next
+		}
+	}
+
+	config := Config{
+		App: app,
+	}
+
+	for _, opt := range opts {
+		opt(&config)
+	}
+
+	if config.Skipper == nil {
+		// set default skipper
+		config.Skipper = func(*echo.Context) bool {
+			return false
+		}
+	}
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) (err error) {
+			if config.Skipper(c) {
+				return next(c)
+			}
+
+			// echo v5 Context.Response() returns http.ResponseWriter; unwrap to
+			// the *echo.Response to reach its writer and Committed flag.
+			echoResp, unwrapErr := echo.UnwrapResponse(c.Response())
+			if unwrapErr != nil {
+				return next(c)
+			}
+
+			rw := echoResp.ResponseWriter
+			tname, path := transactionName(c)
+			txn := config.App.StartTransaction(tname)
+			defer txn.End()
+			if newrelic.IsSecurityAgentPresent() {
+				txn.SetCsecAttributes(newrelic.AttributeCsecRoute, path)
+			}
+			txn.SetWebRequestHTTP(c.Request())
+
+			echoResp.ResponseWriter = txn.SetWebResponse(rw)
+
+			// Add txn to c.Request().Context()
+			c.SetRequest(c.Request().WithContext(newrelic.NewContext(c.Request().Context(), txn)))
+
+			err = next(c)
+
+			// Record the response code. The response headers are not captured
+			// in this case because they are set after this middleware returns.
+			// Designed to mimic the logic in echo's default HTTP error handler.
+			if nil != err && !echoResp.Committed {
+
+				echoResp.ResponseWriter = rw
+
+				// echo v5 errors expose their status via HTTPStatusCoder rather
+				// than a *echo.HTTPError type assertion.
+				code := http.StatusInternalServerError
+				if sc, ok := err.(interface{ StatusCode() int }); ok {
+					code = sc.StatusCode()
+				}
+				txn.SetWebResponse(nil).WriteHeader(code)
+
+				if newrelic.IsSecurityAgentPresent() {
+					newrelic.GetSecurityAgentInterface().SendEvent("RESPONSE_HEADER", c.Response().Header(), txn.GetLinkingMetadata().TraceID)
+				}
+			}
+
+			return
+		}
+	}
+}
+
+// WrapRouter extracts API endpoints from the echo instance passed to it
+// which is used to detect application URL mapping(api-endpoints) for provable security.
+// In this version of the integration, this wrapper is only necessary if you are using the New Relic security agent integration [https://github.com/newrelic/go-agent/tree/master/v3/integrations/nrsecurityagent],
+// but it may be enhanced to provide additional functionality in future releases.
+//
+//	 e := echo.New()
+//	 ....
+//	 ....
+//	 ....
+//
+//	nrecho.WrapRouter(e)
+func WrapRouter(engine *echo.Echo) {
+	if engine != nil && newrelic.IsSecurityAgentPresent() {
+		// echo v5 removed Echo.Routes(); reach routes via Router().Routes().
+		for _, r := range engine.Router().Routes() {
+			newrelic.GetSecurityAgentInterface().SendEvent("API_END_POINTS", r.Path, r.Method, r.Name)
+		}
+	}
+}

--- a/v3/integrations/nrecho-v5/nrecho_test.go
+++ b/v3/integrations/nrecho-v5/nrecho_test.go
@@ -1,0 +1,347 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nrecho
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+	"github.com/newrelic/go-agent/v3/internal"
+	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v3/newrelic/integrationsupport"
+)
+
+func TestBasicRoute(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigCodeLevelMetricsEnabled(false))
+
+	e := echo.New()
+	e.Use(Middleware(app.Application))
+	e.GET("/hello", func(c *echo.Context) error {
+		return c.Blob(http.StatusOK, "text/html", []byte("Hello, World!"))
+	})
+
+	response := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/hello?remove=me", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e.ServeHTTP(response, req)
+	if respBody := response.Body.String(); respBody != "Hello, World!" {
+		t.Error("wrong response body", respBody)
+	}
+	app.ExpectTxnMetrics(t, internal.WantTxn{
+		Name:          "GET /hello",
+		IsWeb:         true,
+		UnknownCaller: true,
+	})
+
+	app.ExpectTxnEvents(t, []internal.WantEvent{{
+		Intrinsics: map[string]interface{}{
+			"name":             "WebTransaction/Go/GET /hello",
+			"nr.apdexPerfZone": "S",
+			"sampled":          false,
+			// Note: "*" is a wildcard value
+			"guid":     "*",
+			"traceId":  "*",
+			"priority": "*",
+		},
+		AgentAttributes: map[string]interface{}{
+			"httpResponseCode":             "200",
+			"http.statusCode":              "200",
+			"request.method":               "GET",
+			"response.headers.contentType": "text/html",
+			"request.uri":                  "/hello",
+		},
+		UserAttributes: map[string]interface{}{},
+	}})
+}
+
+func TestSkipper(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigCodeLevelMetricsEnabled(false))
+
+	e := echo.New()
+	skipper := func(c *echo.Context) bool {
+		return c.RouteInfo().Path == "/health"
+	}
+	e.Use(Middleware(app.Application, WithSkipper(skipper)))
+	e.GET("/hello", func(c *echo.Context) error {
+		return c.Blob(http.StatusOK, "text/html", []byte("Hello, World!"))
+	})
+	e.GET("/health", func(c *echo.Context) error {
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	// call /hello endpoint (should be traced)
+	helloResp := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/hello?remove=me", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.ServeHTTP(helloResp, req)
+	if respBody := helloResp.Body.String(); respBody != "Hello, World!" {
+		t.Error("wrong response body", respBody)
+	}
+
+	// call /health endpoint (should NOT be traced)
+	healthResp := httptest.NewRecorder()
+	req, err = http.NewRequest("GET", "/health", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.ServeHTTP(healthResp, req)
+	if healthResp.Code != http.StatusNoContent {
+		t.Errorf("wrong response status code; expected: %d; got: %d",
+			http.StatusNoContent, healthResp.Code)
+	}
+
+	app.ExpectTxnMetrics(t, internal.WantTxn{
+		Name:          "GET /hello",
+		IsWeb:         true,
+		UnknownCaller: true,
+	})
+	app.ExpectTxnEvents(t, []internal.WantEvent{{
+		Intrinsics: map[string]interface{}{
+			"name":             "WebTransaction/Go/GET /hello",
+			"nr.apdexPerfZone": "S",
+			"sampled":          false,
+			// Note: "*" is a wildcard value
+			"guid":     "*",
+			"traceId":  "*",
+			"priority": "*",
+		},
+		AgentAttributes: map[string]interface{}{
+			"httpResponseCode":             "200",
+			"http.statusCode":              "200",
+			"request.method":               "GET",
+			"response.headers.contentType": "text/html",
+			"request.uri":                  "/hello",
+		},
+		UserAttributes: map[string]interface{}{},
+	}})
+}
+
+func TestNilApp(t *testing.T) {
+	e := echo.New()
+	e.Use(Middleware(nil))
+	e.GET("/hello", func(c *echo.Context) error {
+		return c.String(http.StatusOK, "Hello, World!")
+	})
+
+	response := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/hello?remove=me", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e.ServeHTTP(response, req)
+	if respBody := response.Body.String(); respBody != "Hello, World!" {
+		t.Error("wrong response body", respBody)
+	}
+}
+
+func TestTransactionContext(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigCodeLevelMetricsEnabled(false))
+
+	e := echo.New()
+	e.Use(Middleware(app.Application))
+	e.GET("/hello", func(c *echo.Context) error {
+		txn := FromContext(c)
+		txn.NoticeError(errors.New("ooops"))
+		return c.String(http.StatusOK, "Hello, World!")
+	})
+
+	response := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/hello?remove=me", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e.ServeHTTP(response, req)
+	if respBody := response.Body.String(); respBody != "Hello, World!" {
+		t.Error("wrong response body", respBody)
+	}
+	app.ExpectTxnMetrics(t, internal.WantTxn{
+		Name:          "GET /hello",
+		IsWeb:         true,
+		NumErrors:     1,
+		UnknownCaller: true,
+		ErrorByCaller: true,
+	})
+}
+
+func TestNotFoundHandler(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigCodeLevelMetricsEnabled(false))
+
+	e := echo.New()
+	e.Use(Middleware(app.Application))
+
+	response := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/hello?remove=me", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e.ServeHTTP(response, req)
+	app.ExpectTxnMetrics(t, internal.WantTxn{
+		Name:          "NotFoundHandler",
+		IsWeb:         true,
+		UnknownCaller: true,
+	})
+}
+
+func TestMethodNotAllowedHandler(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigCodeLevelMetricsEnabled(false))
+
+	e := echo.New()
+	e.Use(Middleware(app.Application))
+	e.GET("/hello", func(c *echo.Context) error {
+		return c.String(http.StatusOK, "Hello, World!")
+	})
+
+	response := httptest.NewRecorder()
+	req, err := http.NewRequest("POST", "/hello?remove=me", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e.ServeHTTP(response, req)
+	app.ExpectTxnMetrics(t, internal.WantTxn{
+		Name:          "MethodNotAllowedHandler",
+		IsWeb:         true,
+		NumErrors:     1,
+		UnknownCaller: true,
+		ErrorByCaller: true,
+	})
+}
+
+func TestReturnsHTTPError(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigCodeLevelMetricsEnabled(false))
+
+	e := echo.New()
+	e.Use(Middleware(app.Application))
+	e.GET("/hello", func(c *echo.Context) error {
+		return echo.NewHTTPError(http.StatusTeapot, "I'm a teapot!")
+	})
+
+	response := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/hello?remove=me", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e.ServeHTTP(response, req)
+	app.ExpectTxnMetrics(t, internal.WantTxn{
+		Name:          "GET /hello",
+		IsWeb:         true,
+		NumErrors:     1,
+		UnknownCaller: true,
+		ErrorByCaller: true,
+	})
+	app.ExpectTxnEvents(t, []internal.WantEvent{{
+		Intrinsics: map[string]interface{}{
+			"name":             "WebTransaction/Go/GET /hello",
+			"nr.apdexPerfZone": "F",
+			"sampled":          false,
+			"guid":             "*",
+			"traceId":          "*",
+			"priority":         "*",
+		},
+		AgentAttributes: map[string]interface{}{
+			"httpResponseCode": "418",
+			"http.statusCode":  "418",
+			"request.method":   "GET",
+			"request.uri":      "/hello",
+		},
+		UserAttributes: map[string]interface{}{},
+	}})
+}
+
+func TestReturnsError(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigCodeLevelMetricsEnabled(false))
+
+	e := echo.New()
+	e.Use(Middleware(app.Application))
+	e.GET("/hello", func(c *echo.Context) error {
+		return errors.New("ooooooooops")
+	})
+
+	response := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/hello?remove=me", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e.ServeHTTP(response, req)
+	app.ExpectTxnMetrics(t, internal.WantTxn{
+		Name:          "GET /hello",
+		IsWeb:         true,
+		NumErrors:     1,
+		UnknownCaller: true,
+		ErrorByCaller: true,
+	})
+	app.ExpectTxnEvents(t, []internal.WantEvent{{
+		Intrinsics: map[string]interface{}{
+			"name":             "WebTransaction/Go/GET /hello",
+			"nr.apdexPerfZone": "F",
+			"sampled":          false,
+			"guid":             "*",
+			"traceId":          "*",
+			"priority":         "*",
+		},
+		AgentAttributes: map[string]interface{}{
+			"httpResponseCode": "500",
+			"http.statusCode":  "500",
+			"request.method":   "GET",
+			"request.uri":      "/hello",
+		},
+		UserAttributes: map[string]interface{}{},
+	}})
+}
+
+func TestResponseCode(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigCodeLevelMetricsEnabled(false))
+
+	e := echo.New()
+	e.Use(Middleware(app.Application))
+	e.GET("/hello", func(c *echo.Context) error {
+		return c.Blob(http.StatusTeapot, "text/html", []byte("Hello, World!"))
+	})
+
+	response := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/hello?remove=me", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e.ServeHTTP(response, req)
+	app.ExpectTxnMetrics(t, internal.WantTxn{
+		Name:          "GET /hello",
+		IsWeb:         true,
+		NumErrors:     1,
+		UnknownCaller: true,
+		ErrorByCaller: true,
+	})
+	app.ExpectTxnEvents(t, []internal.WantEvent{{
+		Intrinsics: map[string]interface{}{
+			"name":             "WebTransaction/Go/GET /hello",
+			"nr.apdexPerfZone": "F",
+			"sampled":          false,
+			"guid":             "*",
+			"traceId":          "*",
+			"priority":         "*",
+		},
+		AgentAttributes: map[string]interface{}{
+			"httpResponseCode":             "418",
+			"http.statusCode":              "418",
+			"request.method":               "GET",
+			"response.headers.contentType": "text/html",
+			"request.uri":                  "/hello",
+		},
+		UserAttributes: map[string]interface{}{},
+	}})
+}


### PR DESCRIPTION
Addresses #1172 
## Summary

Adds `nrecho-v5`, a New Relic instrumentation integration for [labstack/echo v5](https://github.com/labstack/echo) (v5.3.1). Echo v5 is a breaking release, so this ships as a new module alongside the existing `nrecho-v3` and `nrecho-v4`.

## Changes

- New module `v3/integrations/nrecho-v5` (`go 1.25`, `github.com/labstack/echo/v5 v5.3.1`) — middleware, tests, README, and example ported from `nrecho-v4`.
- Added `nrecho-v5` to the integration test matrix in `integration-tests.mk`.

## Echo v5 breaking changes handled

- **`Context` interface → struct**: all signatures updated from `echo.Context` to `*echo.Context`.
- **Route identity**: v5 removed `Context.Handler()` and the `echo.NotFoundHandler` / `echo.MethodNotAllowedHandler` sentinels. Transaction naming now derives from `Context.RouteInfo()` 
- **Response type**: `Context.Response()` now returns `http.ResponseWriter`; uses `echo.UnwrapResponse()` to reach `*echo.Response` for the writer and `Committed` flag.
- **Router access**: `WrapRouter` uses `engine.Router().Routes()` (`Echo.Routes()` was removed).