### PR TITLE
feat: MessageProducer Segments

### DIFF
--- a/v3/integrations/nrotelhybrid/constants.go
+++ b/v3/integrations/nrotelhybrid/constants.go
@@ -36,6 +36,16 @@ const (
 	AttrDBSQLTable  = "db.sql.table" // OTEL DB Client v1.17 (SQL only)
 	AttrDBOperation = "db.operation" // OTEL DB Client v1.17 (DB/Redis/Mongo/Dynamo)
 	AttrDBStatement = "db.statement" // OTEL DB Client v1.17 and v1.25 (DB/Redis/Mongo)
+
+	AttrMessagingDestinationName    = "messaging.destination.name"                 // OTEL Messaging Consumer v1.24/v1.30, SQS Producer v1.17
+	AttrMessagingDestination        = "messaging.destination"                      // OTEL Messaging Consumer v1.17
+	AttrMessagingKafkaMessageKey    = "messaging.kafka.message.key"                // OTEL Messaging Producer/Consumer v1.24/v1.30
+	AttrMessagingRabbitMQRoutingKey = "messaging.rabbitmq.destination.routing_key" // OTEL Messaging Producer/Consumer v1.17/v1.24/v1.30
+	AttrMessagingConversationID     = "messaging.message.conversation_id"          // OTEL Messaging Producer v1.17/v1.24/v1.30
+	AttrMessagingSystem             = "messaging.system"                           // OTEL Messaging Producer v1.17/v1.24/v1.30
+	AttrMessagingDestinationKind    = "messaging.destination_kind"                 // OTEL Messaging Producer v1.17
+	AttrMessagingOperationType      = "messaging.operation.type"                   // OTEL Messaging Producer v1.30
+	AttrMessagingOperation          = "messaging.operation"                        // OTEL Messaging Producer v1.24
 )
 
 // NR segment/transaction attribute keys used by this package.
@@ -50,6 +60,11 @@ const (
 	NRProduct      = "product"
 	NRDatabaseName = "database_name"
 	NRPortPathOrID = "port_path_or_id"
+
+	NRMessageQueueName  = "message.queueName"
+	NRMessageRoutingKey = "message.routingKey"
+	NRRoutingKey        = "routingKey"
+	NRCorrelationID     = "correlation_id"
 )
 
 // OTELToNRHTTPAttributeMap maps OTel HTTP client/server attribute keys to their
@@ -86,4 +101,35 @@ var OTELToNRDBAttributeMap = map[string]string{
 	AttrDBName:      NRDatabaseName,
 	AttrNetPeerName: NRHost, // Not used by Dynamo
 	AttrNetPeerPort: NRPortPathOrID,
+}
+
+// OTELToNRMessagingConsumerAttributeMap maps OTel messaging consumer attribute
+// keys to their NR segment attribute equivalents (OTel Messaging Consumer
+// v1.17, v1.24, and v1.30).
+var OTELToNRMessagingConsumerAttributeMap = map[string]string{
+	// OTEL Messaging Consumer v1.24/v1.30
+	AttrMessagingDestinationName:    NRMessageQueueName,
+	AttrServerAddress:               NRHost,
+	AttrServerPort:                  NRPort,
+	AttrMessagingKafkaMessageKey:    NRMessageRoutingKey, // v1.30 only
+	AttrMessagingRabbitMQRoutingKey: NRMessageRoutingKey,
+	// OTEL Messaging Consumer v1.17
+	AttrMessagingDestination: NRMessageQueueName,
+	AttrNetPeerName:          NRHost,
+	AttrNetPeerPort:          NRPort,
+}
+
+// OTELToNRMessagingProducerAttributeMap maps OTel messaging producer attribute
+// keys to their NR segment attribute equivalents (OTel Messaging Producer
+// v1.17, v1.24, and v1.30).
+var OTELToNRMessagingProducerAttributeMap = map[string]string{
+	// OTEL Messaging Producer v1.24/v1.30
+	AttrServerAddress:               NRHost,
+	AttrServerPort:                  NRPort,
+	AttrMessagingKafkaMessageKey:    NRRoutingKey,
+	AttrMessagingRabbitMQRoutingKey: NRRoutingKey,
+	AttrMessagingConversationID:     NRCorrelationID,
+	// OTEL Messaging Producer v1.17
+	AttrNetPeerName: NRHost,
+	AttrNetPeerPort: NRPort,
 }

--- a/v3/integrations/nrotelhybrid/constants.go
+++ b/v3/integrations/nrotelhybrid/constants.go
@@ -107,12 +107,13 @@ var OTELToNRDBAttributeMap = map[string]string{
 // keys to their NR segment attribute equivalents (OTel Messaging Consumer
 // v1.17, v1.24, and v1.30).
 var OTELToNRMessagingConsumerAttributeMap = map[string]string{
-	// OTEL Messaging Consumer v1.24/v1.30
-	AttrMessagingDestinationName:    NRMessageQueueName,
-	AttrServerAddress:               NRHost,
-	AttrServerPort:                  NRPort,
-	AttrMessagingKafkaMessageKey:    NRMessageRoutingKey, // v1.30 only
+	// OTEL Messaging Consumer v1.17/v1.24/v1.30
 	AttrMessagingRabbitMQRoutingKey: NRMessageRoutingKey,
+	// OTEL Messaging Consumer v1.24/v1.30
+	AttrMessagingDestinationName: NRMessageQueueName,
+	AttrServerAddress:            NRHost,
+	AttrServerPort:               NRPort,
+	AttrMessagingKafkaMessageKey: NRMessageRoutingKey, // v1.30 only
 	// OTEL Messaging Consumer v1.17
 	AttrMessagingDestination: NRMessageQueueName,
 	AttrNetPeerName:          NRHost,

--- a/v3/integrations/nrotelhybrid/examples/tracing/main.go
+++ b/v3/integrations/nrotelhybrid/examples/tracing/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"sync"
 	"time"
 
@@ -20,16 +21,19 @@ import (
 	"github.com/uptrace/opentelemetry-go-extra/otelsql"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.43.0"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 type deps struct {
-	db      *sql.DB
-	amqpCh  *amqp.Channel
-	amqpMux sync.Mutex
+	db       *sql.DB
+	amqpConn *amqp.Connection
+	amqpCh   *amqp.Channel
+	amqpMux  sync.Mutex
 }
 
 func main() {
@@ -71,7 +75,7 @@ func run() (err error) {
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 
 	db, err := otelsql.Open("postgres", "host=localhost port=5432 user=postgres dbname=postgres password=docker sslmode=disable", otelsql.WithAttributes(
-		semconv.DBSystemPostgreSQL),
+		semconv.DBSystemNamePostgreSQL),
 		otelsql.WithDBName("secondTestDB"),
 		otelsql.WithTracerProvider(otel.GetTracerProvider()),
 	)
@@ -96,7 +100,7 @@ func run() (err error) {
 		return err
 	}
 
-	d := &deps{db: db, amqpCh: amqpCh}
+	d := &deps{db: db, amqpConn: amqpConn, amqpCh: amqpCh}
 
 	srv := &http.Server{
 		Addr:         ":8080",
@@ -174,10 +178,20 @@ func (d *deps) routeFive(w http.ResponseWriter, r *http.Request) {
 }
 
 func (d *deps) routeSix(w http.ResponseWriter, r *http.Request) {
+	key := "route-six-queue"
+	tracer := otel.Tracer("nrotel-example")
+	_, span := tracer.Start(r.Context(), "route-six", oteltrace.WithSpanKind(oteltrace.SpanKindProducer), oteltrace.WithAttributes(
+		attribute.String(string(semconv.MessagingDestinationNameKey), "MyTestQueue"),
+		attribute.String(string(semconv.MessagingRabbitMQDestinationRoutingKeyKey), key),
+		attribute.String(string(semconv.ServerAddressKey), d.amqpConn.RemoteAddr().String()),
+		attribute.String(string(semconv.ServerPortKey), strconv.Itoa(d.amqpConn.RemoteAddr().(*net.TCPAddr).Port)),
+	))
+	defer span.End()
+
 	d.amqpMux.Lock()
 	defer d.amqpMux.Unlock()
 
-	err := d.amqpCh.PublishWithContext(r.Context(), "", "route-six-queue", false, false, amqp.Publishing{
+	err := d.amqpCh.PublishWithContext(r.Context(), "", key, false, false, amqp.Publishing{
 		ContentType: "text/plain",
 		Body:        []byte("hello from routeSix"),
 	})

--- a/v3/integrations/nrotelhybrid/examples/tracing/main.go
+++ b/v3/integrations/nrotelhybrid/examples/tracing/main.go
@@ -2,15 +2,19 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"log"
 	"math/rand/v2"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"time"
 
 	_ "github.com/lib/pq"
+	amqp "github.com/rabbitmq/amqp091-go"
+
 	"github.com/newrelic/go-agent/v3/integrations/nrotelhybrid"
 	"github.com/newrelic/go-agent/v3/newrelic"
 	"github.com/uptrace/opentelemetry-go-extra/otelsql"
@@ -21,6 +25,12 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 )
+
+type deps struct {
+	db      *sql.DB
+	amqpCh  *amqp.Channel
+	amqpMux sync.Mutex
+}
 
 func main() {
 	// for pretty print to console
@@ -60,12 +70,40 @@ func run() (err error) {
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 
+	db, err := otelsql.Open("postgres", "host=localhost port=5432 user=postgres dbname=postgres password=docker sslmode=disable", otelsql.WithAttributes(
+		semconv.DBSystemPostgreSQL),
+		otelsql.WithDBName("secondTestDB"),
+		otelsql.WithTracerProvider(otel.GetTracerProvider()),
+	)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	amqpConn, err := amqp.Dial("amqp://guest:guest@localhost:5672/")
+	if err != nil {
+		return err
+	}
+	defer amqpConn.Close()
+
+	amqpCh, err := amqpConn.Channel()
+	if err != nil {
+		return err
+	}
+	defer amqpCh.Close()
+
+	if _, err := amqpCh.QueueDeclare("route-six-queue", false, false, false, false, nil); err != nil {
+		return err
+	}
+
+	d := &deps{db: db, amqpCh: amqpCh}
+
 	srv := &http.Server{
 		Addr:         ":8080",
 		BaseContext:  func(net.Listener) context.Context { return ctx },
 		ReadTimeout:  time.Second,
 		WriteTimeout: 10 * time.Second,
-		Handler:      newHttpHandler(),
+		Handler:      newHttpHandler(d),
 	}
 	srvErr := make(chan error, 1)
 	go func() {
@@ -83,14 +121,15 @@ func run() (err error) {
 	return err
 }
 
-func newHttpHandler() http.Handler {
+func newHttpHandler(d *deps) http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/routeone/", routeOne)
 	mux.HandleFunc("/routetwo/", routeTwo)
 	mux.HandleFunc("/routethree/", routeThree)
 	mux.HandleFunc("/routefour/", routeFour)
-	mux.HandleFunc("/routefive/", routeFive)
+	mux.HandleFunc("/routefive/", d.routeFive)
+	mux.HandleFunc("/routesix/", d.routeSix)
 
 	// Add HTTP instrumentation for the whole server.
 	handler := otelhttp.NewHandler(mux, "/")
@@ -130,17 +169,22 @@ func routeFour(w http.ResponseWriter, r *http.Request) {
 	time.Sleep(time.Duration(n) * time.Millisecond)
 }
 
-func routeFive(w http.ResponseWriter, r *http.Request) {
-	db, err := otelsql.Open("postgres", "host=localhost port=5432 user=postgres dbname=postgres password=docker sslmode=disable", otelsql.WithAttributes(
-		semconv.DBSystemPostgreSQL),
-		otelsql.WithDBName("secondTestDB"),
-		otelsql.WithTracerProvider(otel.GetTracerProvider()),
-	)
-	if err != nil {
-		panic(err)
-	}
-	db.QueryRowContext(r.Context(), "SELECT count(*) FROM pg_catalog.pg_tables")
+func (d *deps) routeFive(w http.ResponseWriter, r *http.Request) {
+	d.db.QueryRowContext(r.Context(), "SELECT count(*) FROM pg_catalog.pg_tables")
+}
 
+func (d *deps) routeSix(w http.ResponseWriter, r *http.Request) {
+	d.amqpMux.Lock()
+	defer d.amqpMux.Unlock()
+
+	err := d.amqpCh.PublishWithContext(r.Context(), "", "route-six-queue", false, false, amqp.Publishing{
+		ContentType: "text/plain",
+		Body:        []byte("hello from routeSix"),
+	})
+	if err != nil {
+		log.Println(err)
+		return
+	}
 }
 
 func nestedRouteOne(ctx context.Context) {

--- a/v3/integrations/nrotelhybrid/examples/tracing/main.go
+++ b/v3/integrations/nrotelhybrid/examples/tracing/main.go
@@ -134,6 +134,7 @@ func newHttpHandler(d *deps) http.Handler {
 	mux.HandleFunc("/routefour/", routeFour)
 	mux.HandleFunc("/routefive/", d.routeFive)
 	mux.HandleFunc("/routesix/", d.routeSix)
+	mux.HandleFunc("/routeseven/", d.routeSeven)
 
 	// Add HTTP instrumentation for the whole server.
 	handler := otelhttp.NewHandler(mux, "/")
@@ -199,6 +200,33 @@ func (d *deps) routeSix(w http.ResponseWriter, r *http.Request) {
 		log.Println(err)
 		return
 	}
+}
+
+func (d *deps) routeSeven(w http.ResponseWriter, r *http.Request) {
+	key := "route-six-queue"
+
+	tracer := otel.Tracer("nrotel-example")
+	_, span := tracer.Start(r.Context(), "route-seven", oteltrace.WithSpanKind(oteltrace.SpanKindConsumer), oteltrace.WithAttributes(
+		attribute.String(string(semconv.MessagingRabbitMQDestinationRoutingKeyKey), key),
+		attribute.String(string(semconv.ServerAddressKey), d.amqpConn.RemoteAddr().String()),
+		attribute.String(string(semconv.ServerPortKey), strconv.Itoa(d.amqpConn.RemoteAddr().(*net.TCPAddr).Port)),
+	))
+	defer span.End()
+
+	d.amqpMux.Lock()
+	defer d.amqpMux.Unlock()
+
+	msg, ok, err := d.amqpCh.Get(key, true)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	if !ok {
+		w.Write([]byte("no message available"))
+		return
+	}
+	w.Write(msg.Body)
 }
 
 func nestedRouteOne(ctx context.Context) {

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -48,13 +48,8 @@ func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSp
 	// should be a valid span context and be marked as remote
 	// this begins a transaction
 	if isTxn, isWeb := p.isTransaction(s.SpanKind(), s.SpanContext(), s.Parent()); isTxn {
-		switch s.SpanKind() {
-		case oteltrace.SpanKindProducer:
-			return
-		default:
-			p.startTransaction(s, isWeb)
-			return
-		}
+		p.startTransaction(s, isWeb)
+		return
 	}
 	// start the segment with the txn entry
 	if entries := p.txnMap[s.SpanContext().TraceID()]; len(entries) > 0 {
@@ -150,7 +145,9 @@ func (p *nrotelhybridProcessor) isTransaction(kind oteltrace.SpanKind, current o
 		return !p.txnChecker(p.txnMap, current.TraceID(), current.SpanID()), true
 	case oteltrace.SpanKindClient:
 		return false, true
-	case oteltrace.SpanKindConsumer, oteltrace.SpanKindProducer:
+	case oteltrace.SpanKindProducer:
+		return false, false
+	case oteltrace.SpanKindConsumer:
 		return !p.txnChecker(p.txnMap, current.TraceID(), current.SpanID()), false
 	default:
 		return false, false
@@ -191,9 +188,10 @@ func (p *nrotelhybridProcessor) switchSegmentType(spanID oteltrace.SpanID, attri
 		}
 		p.addSegmentAttributes(seg, attributes, OTELToNRMessagingProducerAttributeMap)
 		p.segmentMap[spanID] = seg
+	case oteltrace.SpanKindConsumer:
+		p.addSegmentAttributes(basicSegment, attributes, OTELToNRMessagingConsumerAttributeMap)
 	default:
 		p.addSegmentAttributes(basicSegment, attributes, nil)
-		return
 	}
 }
 

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -48,8 +48,13 @@ func (p *nrotelhybridProcessor) OnStart(ctx context.Context, s trace.ReadWriteSp
 	// should be a valid span context and be marked as remote
 	// this begins a transaction
 	if isTxn, isWeb := p.isTransaction(s.SpanKind(), s.SpanContext(), s.Parent()); isTxn {
-		p.startTransaction(s, isWeb)
-		return
+		switch s.SpanKind() {
+		case oteltrace.SpanKindProducer:
+			return
+		default:
+			p.startTransaction(s, isWeb)
+			return
+		}
 	}
 	// start the segment with the txn entry
 	if entries := p.txnMap[s.SpanContext().TraceID()]; len(entries) > 0 {
@@ -145,7 +150,7 @@ func (p *nrotelhybridProcessor) isTransaction(kind oteltrace.SpanKind, current o
 		return !p.txnChecker(p.txnMap, current.TraceID(), current.SpanID()), true
 	case oteltrace.SpanKindClient:
 		return false, true
-	case oteltrace.SpanKindConsumer:
+	case oteltrace.SpanKindConsumer, oteltrace.SpanKindProducer:
 		return !p.txnChecker(p.txnMap, current.TraceID(), current.SpanID()), false
 	default:
 		return false, false

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -185,6 +185,12 @@ func (p *nrotelhybridProcessor) switchSegmentType(spanID oteltrace.SpanID, attri
 		}
 		p.addSegmentAttributes(seg, attributes, OTELToNRHTTPAttributeMap)
 		p.segmentMap[spanID] = seg
+	case oteltrace.SpanKindProducer:
+		seg := &newrelic.MessageProducerSegment{
+			StartTime: basicSegment.StartTime,
+		}
+		p.addSegmentAttributes(seg, attributes, nil)
+		p.segmentMap[spanID] = seg
 	default:
 		p.addSegmentAttributes(basicSegment, attributes, nil)
 		return

--- a/v3/integrations/nrotelhybrid/nrotelhybrid.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid.go
@@ -189,7 +189,7 @@ func (p *nrotelhybridProcessor) switchSegmentType(spanID oteltrace.SpanID, attri
 		seg := &newrelic.MessageProducerSegment{
 			StartTime: basicSegment.StartTime,
 		}
-		p.addSegmentAttributes(seg, attributes, nil)
+		p.addSegmentAttributes(seg, attributes, OTELToNRMessagingProducerAttributeMap)
 		p.segmentMap[spanID] = seg
 	default:
 		p.addSegmentAttributes(basicSegment, attributes, nil)
@@ -230,6 +230,21 @@ func (p *nrotelhybridProcessor) addSegmentAttributes(seg nrSegment, attributes [
 				}
 				s.AddAttribute(string(attribute.Key), extractAttributeValue(attribute.Value))
 			}
+		}
+	case *newrelic.MessageProducerSegment:
+		for _, attribute := range attributes {
+			switch string(attribute.Key) {
+			case AttrMessagingSystem:
+				s.Library = attribute.Value.AsString()
+			case AttrMessagingDestinationName:
+				s.DestinationName = attribute.Value.AsString()
+			case AttrMessagingDestinationKind, AttrMessagingOperation, AttrMessagingOperationType:
+				// messaging.desingation_kind this is deprecated on the OTEL side but leaving it here for spec compatibility
+				s.DestinationType = newrelic.MessageDestinationType(attribute.Value.AsString())
+			default:
+				s.AddAttribute(string(attribute.Key), extractAttributeValue(attribute.Value))
+			}
+
 		}
 	default:
 		for _, attribute := range attributes {

--- a/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
+++ b/v3/integrations/nrotelhybrid/nrotelhybrid_test.go
@@ -725,6 +725,62 @@ func Test_nrotelhybridProcessor_switchSegmentType(t *testing.T) {
 			spanKind: oteltrace.SpanKindClient,
 			want:     &newrelic.DatastoreSegment{},
 		},
+		{
+			name:   "Segment is a basic segment upon type cast. SpanKind is PRODUCER. Should convert to Producer Segment.",
+			spanID: otherSpanID,
+			initialSegmentMap: map[oteltrace.SpanID]nrSegment{
+				otherSpanID: &newrelic.Segment{
+					StartTime: newrelic.SegmentStartTime{},
+					Name:      "Basic Segment",
+				},
+			},
+			spanKind: oteltrace.SpanKindProducer,
+			want:     &newrelic.MessageProducerSegment{},
+		},
+		{
+			name:   "Segment is a basic segment upon type cast. SpanKind is PRODUCER. Should convert to Producer Segment.  Has attributes for Messages.",
+			spanID: validSpanID,
+			initialSegmentMap: map[oteltrace.SpanID]nrSegment{
+				validSpanID: &newrelic.Segment{
+					StartTime: newrelic.SegmentStartTime{},
+					Name:      "Basic Segment",
+				},
+			},
+			attributes: []attribute.KeyValue{
+				{Key: attribute.Key(AttrServerAddress), Value: attribute.StringValue("address")},
+				{Key: attribute.Key(AttrServerPort), Value: attribute.StringValue("port")},
+			},
+			spanKind: oteltrace.SpanKindProducer,
+			want:     &newrelic.MessageProducerSegment{},
+		},
+		{
+			name:   "Segment is a basic segment upon type cast. SpanKind is CONSUMER. Should stay a basic segment.",
+			spanID: otherSpanID,
+			initialSegmentMap: map[oteltrace.SpanID]nrSegment{
+				otherSpanID: &newrelic.Segment{
+					StartTime: newrelic.SegmentStartTime{},
+					Name:      "Basic Segment",
+				},
+			},
+			spanKind: oteltrace.SpanKindConsumer,
+			want:     &newrelic.Segment{},
+		},
+		{
+			name:   "Segment is a basic segment upon type cast. SpanKind is CONSUMER. Should add attributes for Messages.",
+			spanID: validSpanID,
+			initialSegmentMap: map[oteltrace.SpanID]nrSegment{
+				validSpanID: &newrelic.Segment{
+					StartTime: newrelic.SegmentStartTime{},
+					Name:      "Basic Segment",
+				},
+			},
+			attributes: []attribute.KeyValue{
+				{Key: attribute.Key(AttrServerAddress), Value: attribute.StringValue("address")},
+				{Key: attribute.Key(AttrServerPort), Value: attribute.StringValue("port")},
+			},
+			spanKind: oteltrace.SpanKindConsumer,
+			want:     &newrelic.Segment{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -927,6 +983,69 @@ func Test_addSegmentAttributes_DatastoreSegment(t *testing.T) {
 			}
 			if seg.ParameterizedQuery != tt.wantQuery {
 				t.Errorf("ParameterizedQuery = %v, want %v", seg.ParameterizedQuery, tt.wantQuery)
+			}
+		})
+	}
+}
+
+func Test_addSegmentAttributes_MessageProducerSegment(t *testing.T) {
+	tests := []struct {
+		name         string
+		attributes   []attribute.KeyValue
+		wantLibrary  string
+		wantDestName string
+		wantDestType newrelic.MessageDestinationType
+	}{
+		{
+			name: "messaging.system sets Library.",
+			attributes: []attribute.KeyValue{
+				attribute.String(AttrMessagingSystem, "rabbitmq"),
+			},
+			wantLibrary: "rabbitmq",
+		},
+		{
+			name: "messaging.destination.name sets DestinationName.",
+			attributes: []attribute.KeyValue{
+				attribute.String(AttrMessagingDestinationName, "route-six-queue"),
+			},
+			wantDestName: "route-six-queue",
+		},
+		{
+			name: "messaging.destination_kind sets DestinationType.",
+			attributes: []attribute.KeyValue{
+				attribute.String(AttrMessagingDestinationKind, "queue"),
+			},
+			wantDestType: newrelic.MessageDestinationType("queue"),
+		},
+		{
+			name: "messaging.operation sets DestinationType.",
+			attributes: []attribute.KeyValue{
+				attribute.String(AttrMessagingOperation, "publish"),
+			},
+			wantDestType: newrelic.MessageDestinationType("publish"),
+		},
+		{
+			name: "messaging.operation.type sets DestinationType.",
+			attributes: []attribute.KeyValue{
+				attribute.String(AttrMessagingOperationType, "create"),
+			},
+			wantDestType: newrelic.MessageDestinationType("create"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewHybridProcessor(&newrelic.Application{})
+			seg := &newrelic.MessageProducerSegment{}
+			p.addSegmentAttributes(seg, tt.attributes, OTELToNRMessagingProducerAttributeMap)
+
+			if seg.Library != tt.wantLibrary {
+				t.Errorf("Library = %v, want %v", seg.Library, tt.wantLibrary)
+			}
+			if seg.DestinationName != tt.wantDestName {
+				t.Errorf("DestinationName = %v, want %v", seg.DestinationName, tt.wantDestName)
+			}
+			if seg.DestinationType != tt.wantDestType {
+				t.Errorf("DestinationType = %v, want %v", seg.DestinationType, tt.wantDestType)
 			}
 		})
 	}

--- a/v3/newrelic/segments.go
+++ b/v3/newrelic/segments.go
@@ -155,6 +155,13 @@ const (
 	MessageQueue    MessageDestinationType = "Queue"
 	MessageTopic    MessageDestinationType = "Topic"
 	MessageExchange MessageDestinationType = "Exchange"
+	MessageCreate   MessageDestinationType = "create"  // OTEL messaging.operation.type v1.30.0, messaging.operation v1.24.0
+	MessageProcess  MessageDestinationType = "process" // OTEL messaging.operation.type v1.30.0
+	MessageReceive  MessageDestinationType = "receive" // OTEL messaging.operation.type v1.30.0, messaging.operation v1.24.0
+	MessageSend     MessageDestinationType = "send"    // OTEL messaging.operation.type v1.30.0
+	MessageSettle   MessageDestinationType = "settle"  // OTEL messaging.operation.type v1.30.0
+	MessagePublish  MessageDestinationType = "publish" // OTEL messaging.operation v1.24.0
+	MessageDeliver  MessageDestinationType = "deliver" // OTEL messaging.operation v1.24.0
 )
 
 // AddAttribute adds a key value pair to the current segment.


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links
[OTEL messaging attributes](https://opentelemetry.io/docs/specs/semconv/registry/attributes/messaging/)
<!--
Any relevant links that will help reviewers.
-->

## Details
### Issue
No support for `SpanKind.PRODUCER` and `SpanKind.CONSUMER` spans
### Goals
Add support for `SpanKind.PRODUCER` and `SpanKind.CONSUMER` spans
### Implementation
#### SpanKind.PRODUCER
- Will begin a `MessageProducerSegment` if not a transaction (segment type is switched from basic segment at the end)
#### SpanKind.CONSUMER
- Will begin a `Segment` if not a transaction.
#### Attributes
- Added attributes from spec to both
- PLEASE NOTE: Updated the `MessageDestinationType` as this is mapped from values that can appear in `message.operation` and `message.operation.type` from OTEL.  Those possibilities of those values are linked above.
<!--
In-depth description of changes, other technical notes, etc.
-->
