### PR TITLE
test: Add case for new error string in Go 1.27

### DIFF
--- a/v3/newrelic/internal_txn_test.go
+++ b/v3/newrelic/internal_txn_test.go
@@ -5,6 +5,7 @@ package newrelic
 
 import (
 	"errors"
+	"go/version"
 	"net/http"
 	"reflect"
 	"runtime"
@@ -1022,11 +1023,15 @@ func TestPanicNilRecovery(t *testing.T) {
 		defer txn.End()
 		panic(nil)
 	}()
+	errorMessage := "panic called with nil argument"
+	if version.Compare(runtime.Version(), "go1.26.7") > 0 {
+		errorMessage = "runtime error: panic called with nil argument"
+	}
 	app.ExpectSpanEvents(t, []internal.WantEvent{
 		{
 			AgentAttributes: map[string]interface{}{
 				SpanAttributeErrorClass:   "panic",
-				SpanAttributeErrorMessage: "panic called with nil argument",
+				SpanAttributeErrorMessage: errorMessage,
 			},
 			Intrinsics: map[string]interface{}{
 				"category":         internal.MatchAnything,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry has been included.
* For new integration packages, follow the [Writing a New Integration
  Package](https://github.com/newrelic/go-agent/wiki/Writing-a-New-Integration-Package)
  checklist.

-->

## Links

<!--
Any relevant links that will help reviewers.
-->

## Details
### Issue
`TestPanicNilRecovery` fails on ubuntu-latest (pulling go1.27)
### Goals
`TestPanicNilRecovery` should pass
### Implementation
Check if Go version is greater than go1.26.7 and change the error dynamically to new string
<!--
In-depth description of changes, other technical notes, etc.
-->
