### PR TITLE
feat(nrgemini): Google GenAI Go SDK Integration

### DIFF
--- a/integration-tests.mk
+++ b/integration-tests.mk
@@ -56,4 +56,5 @@ GO_INTEGRATION_TESTS=$${INTEGRATION_TESTS:-\
 	nrzap \
 	nrzerolog \
 	nranthropic \
+	nrgemini \
 }

--- a/v3/integrations/nrgemini/examples/simple/main.go
+++ b/v3/integrations/nrgemini/examples/simple/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/newrelic/go-agent/v3/integrations/nrgemini"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"google.golang.org/genai"
+)
+
+func main() {
+	// Initialize New Relic
+	app, err := newrelic.NewApplication(
+		newrelic.ConfigAppName("Gemini Simple Example"),
+		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+		newrelic.ConfigDebugLogger(os.Stdout),
+		newrelic.ConfigAIMonitoringEnabled(true),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := app.WaitForConnection(5 * time.Second); err != nil {
+		log.Fatalf("New Relic failed to connect: %v", err)
+	}
+	defer app.Shutdown(10 * time.Second)
+
+	ctx := context.Background()
+	nrClient, err := nrgemini.NewClient(app, ctx, &genai.ClientConfig{
+		APIKey:  os.Getenv("GEMINI_API_KEY"),
+		Backend: genai.BackendGeminiAPI,
+	})
+	if err != nil {
+		log.Fatalf("Error creating Gemini client: %v", err)
+	}
+
+	// Send a message
+	prompt := "Write a haiku about programming in Go"
+	resp, err := nrClient.Models.GenerateContent(ctx, "gemini-2.5-flash", genai.Text(prompt), nil)
+	if err != nil {
+		log.Fatalf("Error generating content: %v", err)
+	}
+
+	fmt.Println("=== Simple Message Example ===")
+	fmt.Printf("Prompt: %s\n\n", prompt)
+	fmt.Printf("Response: %s\n", resp.Text())
+	if resp.UsageMetadata != nil {
+		fmt.Printf("\nInput tokens:  %d\n", resp.UsageMetadata.PromptTokenCount)
+		fmt.Printf("Output tokens: %d\n", resp.UsageMetadata.CandidatesTokenCount)
+	}
+}

--- a/v3/integrations/nrgemini/examples/streaming/main.go
+++ b/v3/integrations/nrgemini/examples/streaming/main.go
@@ -42,58 +42,22 @@ func main() {
 	}
 
 	prompt := "Explain the benefits of using Go for backend services in 3 points"
-
-	// Two ways to consume a stream. Each is scoped to its own function so that the
-	// deferred Close runs when that stream is done, not at the end of main.
-	streamManually(ctx, nrClient, prompt)
-	streamWithCallback(ctx, nrClient, prompt)
-}
-
-// printChunk writes whatever text a chunk carried.
-func printChunk(chunk *genai.GenerateContentResponse) {
-	if len(chunk.Candidates) == 0 || chunk.Candidates[0].Content == nil {
-		return
-	}
-	for _, part := range chunk.Candidates[0].Content.Parts {
-		if part != nil && part.Text != "" {
-			fmt.Print(part.Text)
-		}
-	}
-}
-
-// streamManually drives the SDK iterator itself, reporting each chunk to New
-// Relic. Close records the events, so defer it to cover an early return.
-func streamManually(ctx context.Context, nrClient *nrgemini.NRClient, prompt string) {
 	fmt.Println("=== Streaming Message Example ===")
 	fmt.Printf("Prompt: %s\n\n", prompt)
 	fmt.Print("Response: ")
 
-	stream := nrClient.Models.GenerateContentStream(ctx, "gemini-2.5-flash", genai.Text(prompt), nil)
-	defer stream.Close()
-
-	for chunk, err := range stream.Stream {
-		stream.RecordEvent(chunk, err)
+	for chunk, err := range nrClient.Models.GenerateContentStream(ctx, "gemini-2.5-flash", genai.Text(prompt), nil) {
 		if err != nil {
-			log.Printf("Stream error: %v", err)
-			break
+			log.Fatalf("Stream error: %v", err)
 		}
-		printChunk(chunk)
-	}
-	fmt.Println()
-}
-
-// streamWithCallback lets ProcessContentStream run the loop above for you.
-func streamWithCallback(ctx context.Context, nrClient *nrgemini.NRClient, prompt string) {
-	fmt.Println("\n=== Callback Example ===")
-	fmt.Print("Response: ")
-
-	err := nrClient.Models.ProcessContentStream(ctx, "gemini-2.5-flash", genai.Text(prompt), nil,
-		func(chunk *genai.GenerateContentResponse) error {
-			printChunk(chunk)
-			return nil
-		})
-	if err != nil {
-		log.Printf("Stream error: %v", err)
+		if len(chunk.Candidates) == 0 || chunk.Candidates[0].Content == nil {
+			continue
+		}
+		for _, part := range chunk.Candidates[0].Content.Parts {
+			if part != nil && part.Text != "" {
+				fmt.Print(part.Text)
+			}
+		}
 	}
 	fmt.Println()
 }

--- a/v3/integrations/nrgemini/examples/streaming/main.go
+++ b/v3/integrations/nrgemini/examples/streaming/main.go
@@ -42,33 +42,58 @@ func main() {
 	}
 
 	prompt := "Explain the benefits of using Go for backend services in 3 points"
+
+	// Two ways to consume a stream. Each is scoped to its own function so that the
+	// deferred Close runs when that stream is done, not at the end of main.
+	streamManually(ctx, nrClient, prompt)
+	streamWithCallback(ctx, nrClient, prompt)
+}
+
+// printChunk writes whatever text a chunk carried.
+func printChunk(chunk *genai.GenerateContentResponse) {
+	if len(chunk.Candidates) == 0 || chunk.Candidates[0].Content == nil {
+		return
+	}
+	for _, part := range chunk.Candidates[0].Content.Parts {
+		if part != nil && part.Text != "" {
+			fmt.Print(part.Text)
+		}
+	}
+}
+
+// streamManually drives the SDK iterator itself, reporting each chunk to New
+// Relic. Close records the events, so defer it to cover an early return.
+func streamManually(ctx context.Context, nrClient *nrgemini.NRClient, prompt string) {
 	fmt.Println("=== Streaming Message Example ===")
 	fmt.Printf("Prompt: %s\n\n", prompt)
 	fmt.Print("Response: ")
 
-	// Create a streaming message
 	stream := nrClient.Models.GenerateContentStream(ctx, "gemini-2.5-flash", genai.Text(prompt), nil)
+	defer stream.Close()
 
-	// Process stream chunks as they arrive
-	for stream.Next() {
-		chunk := stream.Current()
-		if chunk == nil || len(chunk.Candidates) == 0 || chunk.Candidates[0].Content == nil {
-			continue
+	for chunk, err := range stream.Stream {
+		stream.RecordEvent(chunk, err)
+		if err != nil {
+			log.Printf("Stream error: %v", err)
+			break
 		}
-		for _, part := range chunk.Candidates[0].Content.Parts {
-			if part != nil && part.Text != "" {
-				fmt.Print(part.Text)
-			}
-		}
+		printChunk(chunk)
 	}
+	fmt.Println()
+}
 
-	if err := stream.Err(); err != nil {
-		log.Fatalf("Stream error: %v", err)
+// streamWithCallback lets ProcessContentStream run the loop above for you.
+func streamWithCallback(ctx context.Context, nrClient *nrgemini.NRClient, prompt string) {
+	fmt.Println("\n=== Callback Example ===")
+	fmt.Print("Response: ")
+
+	err := nrClient.Models.ProcessContentStream(ctx, "gemini-2.5-flash", genai.Text(prompt), nil,
+		func(chunk *genai.GenerateContentResponse) error {
+			printChunk(chunk)
+			return nil
+		})
+	if err != nil {
+		log.Printf("Stream error: %v", err)
 	}
-
-	if err := stream.Close(); err != nil {
-		log.Fatalf("Stream close error: %v", err)
-	}
-
 	fmt.Println()
 }

--- a/v3/integrations/nrgemini/examples/streaming/main.go
+++ b/v3/integrations/nrgemini/examples/streaming/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/newrelic/go-agent/v3/integrations/nrgemini"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"google.golang.org/genai"
+)
+
+func main() {
+	// Initialize New Relic
+	app, err := newrelic.NewApplication(
+		newrelic.ConfigAppName("Gemini Streaming Example"),
+		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+		newrelic.ConfigDebugLogger(os.Stdout),
+		newrelic.ConfigAIMonitoringEnabled(true),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := app.WaitForConnection(5 * time.Second); err != nil {
+		log.Fatalf("New Relic failed to connect: %v", err)
+	}
+	defer app.Shutdown(10 * time.Second)
+
+	// Start a transaction
+	txn := app.StartTransaction("streaming-message")
+	defer txn.End()
+
+	ctx := newrelic.NewContext(context.Background(), txn)
+	nrClient, err := nrgemini.NewClient(app, ctx, &genai.ClientConfig{
+		APIKey:  os.Getenv("GEMINI_API_KEY"),
+		Backend: genai.BackendGeminiAPI,
+	})
+	if err != nil {
+		log.Fatalf("Error creating Gemini client: %v", err)
+	}
+
+	prompt := "Explain the benefits of using Go for backend services in 3 points"
+	fmt.Println("=== Streaming Message Example ===")
+	fmt.Printf("Prompt: %s\n\n", prompt)
+	fmt.Print("Response: ")
+
+	// Create a streaming message
+	stream := nrClient.Models.GenerateContentStream(ctx, "gemini-2.5-flash", genai.Text(prompt), nil)
+
+	// Process stream chunks as they arrive
+	for stream.Next() {
+		chunk := stream.Current()
+		if chunk == nil || len(chunk.Candidates) == 0 || chunk.Candidates[0].Content == nil {
+			continue
+		}
+		for _, part := range chunk.Candidates[0].Content.Parts {
+			if part != nil && part.Text != "" {
+				fmt.Print(part.Text)
+			}
+		}
+	}
+
+	if err := stream.Err(); err != nil {
+		log.Fatalf("Stream error: %v", err)
+	}
+
+	if err := stream.Close(); err != nil {
+		log.Fatalf("Stream close error: %v", err)
+	}
+
+	fmt.Println()
+}

--- a/v3/integrations/nrgemini/go.mod
+++ b/v3/integrations/nrgemini/go.mod
@@ -1,0 +1,30 @@
+module github.com/newrelic/go-agent/v3/integrations/nrgemini
+
+go 1.25
+
+require (
+	github.com/google/uuid v1.6.0
+	github.com/newrelic/go-agent/v3 v3.44.1
+	google.golang.org/genai v1.64.0
+)
+
+require (
+	cloud.google.com/go v0.116.0 // indirect
+	cloud.google.com/go/auth v0.9.3 // indirect
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/s2a-go v0.1.8 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
+	go.opencensus.io v0.24.0 // indirect
+	golang.org/x/crypto v0.47.0 // indirect
+	golang.org/x/net v0.49.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
+	golang.org/x/text v0.33.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 // indirect
+	google.golang.org/grpc v1.80.0 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
+)
+
+replace github.com/newrelic/go-agent/v3 => ../..

--- a/v3/integrations/nrgemini/nrgemini.go
+++ b/v3/integrations/nrgemini/nrgemini.go
@@ -522,21 +522,21 @@ type streamState struct {
 	text     []*strings.Builder
 	start    time.Time
 	consumed bool
-	// observed records whether anything was yielded at all, which a zero duration
-	// cannot express: a stream answered inside the same millisecond measures zero.
+	// observed says a chunk was seen and timings were stamped, which a zero
+	// duration cannot express: a stream answered inside one millisecond measures
+	// zero. Set only by stamp, alongside the timings it records.
 	observed bool
 }
 
 // observe folds one yielded chunk into the accumulated state.
 func (st *streamState) observe(txn *newrelic.Transaction, chunk *genai.GenerateContentResponse, err error) {
 	c := st.completion
-	st.observed = true
 
 	if err != nil {
 		// Keep the first; the SDK may yield more chunks after an error.
 		if c.err == nil {
 			c.err = err
-			c.duration = time.Since(st.start).Milliseconds()
+			st.stamp()
 			noticeError(txn, c.id, err)
 		}
 		return
@@ -544,42 +544,91 @@ func (st *streamState) observe(txn *newrelic.Transaction, chunk *genai.GenerateC
 	if chunk == nil {
 		return
 	}
-	if c.timeToFirstToken == nil {
-		elapsed := time.Since(st.start).Milliseconds()
-		c.timeToFirstToken = &elapsed
-	}
-	// Stamped per chunk so the recording, which happens after the caller's loop
-	// exits, does not stretch the duration past the last chunk.
-	c.duration = time.Since(st.start).Milliseconds()
+	st.stamp()
 
 	if c.resp == nil {
 		c.resp = &genai.GenerateContentResponse{}
 	}
-	resp := c.resp
+	st.mergeResponse(chunk)
+	st.mergeCandidates(chunk.Candidates)
+}
 
+// stamp records the timings a chunk supplies. duration is taken per chunk so the
+// recording, which happens after the caller's loop exits, does not stretch it
+// past the last chunk; timeToFirstToken is only ever set by the first.
+func (st *streamState) stamp() {
+	elapsed := time.Since(st.start).Milliseconds()
+	if st.completion.timeToFirstToken == nil {
+		first := elapsed
+		st.completion.timeToFirstToken = &first
+	}
+	st.completion.duration = elapsed
+	st.observed = true
+}
+
+// mergeResponse carries a chunk's response-level fields over, latest wins. Most
+// chunks repeat the same ResponseID and ModelVersion, but the usage totals appear
+// only on the final one, so the last write is the one that matters:
+//
+//	chunk 1  {ResponseID: "resp_abc", ModelVersion: "gemini-2.5-flash", UsageMetadata: nil}
+//	chunk 2  {ResponseID: "resp_abc", ModelVersion: "gemini-2.5-flash", UsageMetadata: nil}
+//	chunk 3  {ResponseID: "resp_abc", ModelVersion: "gemini-2.5-flash",
+//	          UsageMetadata: {PromptTokenCount: 9, CandidatesTokenCount: 12, TotalTokenCount: 21}}
+//
+// leaving the accumulated response with the ids from any chunk and the totals
+// from the last, which recordSummary reports as response.usage.*.
+func (st *streamState) mergeResponse(chunk *genai.GenerateContentResponse) {
+	resp := st.completion.resp
 	if chunk.ResponseID != "" {
 		resp.ResponseID = chunk.ResponseID
 	}
 	if chunk.ModelVersion != "" {
 		resp.ModelVersion = chunk.ModelVersion
 	}
-	// Usage arrives on the final chunk, so the latest wins.
 	if chunk.UsageMetadata != nil {
 		resp.UsageMetadata = chunk.UsageMetadata
 	}
 	if chunk.SDKHTTPResponse != nil {
 		resp.SDKHTTPResponse = chunk.SDKHTTPResponse
 	}
+}
 
-	// Each requested candidate streams its own deltas.
-	for len(resp.Candidates) < len(chunk.Candidates) {
+// mergeCandidates folds a chunk's candidates into the accumulated ones.
+//
+// Gemini streams each candidate's text as a run of deltas, one per chunk, and
+// reports the stop reason on the last. A request with CandidateCount: 2 arrives
+// roughly like this, where every chunk carries a slice position per candidate:
+//
+//	chunk 1  Candidates[0] = {Content: {Role: "model", Parts: [{Text: "Hel"}]}}
+//	         Candidates[1] = {Content: {Role: "model", Parts: [{Text: "Bon"}]}}
+//	chunk 2  Candidates[0] = {Content: {Role: "model", Parts: [{Text: "lo"}]}}
+//	         Candidates[1] = {Content: {Role: "model", Parts: [{Text: "jour"}]}}
+//	chunk 3  Candidates[0] = {Content: {Parts: [{Text: ""}]}, FinishReason: "STOP"}
+//	         Candidates[1] = {Content: {Parts: [{Text: ""}]}, FinishReason: "STOP"}
+//
+// Deltas go to st.text[i], one builder per candidate, so nothing is recopied as
+// the text grows. The stop reason and role are written straight onto the
+// accumulated candidate. finish then moves each builder into the response:
+//
+//	resp.Candidates[0] = {Content: {Role: "model", Parts: [{Text: "Hello"}]},   FinishReason: "STOP"}
+//	resp.Candidates[1] = {Content: {Role: "model", Parts: [{Text: "Bonjour"}]}, FinishReason: "STOP"}
+//
+// which is the shape GenerateContent returns in one piece, so recordMessages
+// emits one LlmChatCompletionMessage per candidate for either path. Keeping each
+// candidate's text in a single Part matters: contentText joins separate Parts with
+// a space, which would scatter spaces between the deltas.
+func (st *streamState) mergeCandidates(candidates []*genai.Candidate) {
+	resp := st.completion.resp
+
+	// Grow to match the widest chunk seen, a builder alongside each candidate.
+	for len(resp.Candidates) < len(candidates) {
 		resp.Candidates = append(resp.Candidates, &genai.Candidate{
 			Content: &genai.Content{Parts: []*genai.Part{{}}},
 		})
 		st.text = append(st.text, &strings.Builder{})
 	}
 
-	for i, src := range chunk.Candidates {
+	for i, src := range candidates {
 		if src == nil {
 			continue
 		}
@@ -601,7 +650,9 @@ func (st *streamState) observe(txn *newrelic.Transaction, chunk *genai.GenerateC
 	}
 }
 
-// finish materializes the accumulated text and returns the completion to report.
+// finish moves each candidate's builder into its Part and returns the completion
+// to report: st.text[i] becomes resp.Candidates[i].Content.Parts[0].Text. See
+// mergeCandidates for a worked example.
 func (st *streamState) finish() *completion {
 	c := st.completion
 

--- a/v3/integrations/nrgemini/nrgemini.go
+++ b/v3/integrations/nrgemini/nrgemini.go
@@ -1,21 +1,26 @@
 // Package nrgemini provides New Relic instrumentation for the Google GenAI Go
 // SDK (google.golang.org/genai).
 //
-// Wrap your GenAI client with NewClient, then use nrClient.Models.GenerateContent
-// in place of client.Models.GenerateContent to automatically record
-// LlmChatCompletionSummary and LlmChatCompletionMessage custom events and a
-// segment under the active transaction — mirroring the Python agent's
-// mlmodel_gemini instrumentation.
+// Wrap your GenAI client with NewClient, then use the wrapped service in place of
+// the SDK's own: GenerateContent, GenerateContentStream, and ProcessContentStream
+// record LlmChatCompletionSummary and LlmChatCompletionMessage events, and open a
+// segment under the active transaction.
 //
-// The New Relic transaction must be present in the context (via
-// newrelic.NewContext) for instrumentation to activate. AI monitoring must also
-// be enabled on the application (newrelic.ConfigAIMonitoringEnabled(true)).
+// AI monitoring must be enabled on the application
+// (newrelic.ConfigAIMonitoringEnabled(true)), plus
+// ConfigAIMonitoringStreamingEnabled(true) for streaming; otherwise calls are
+// forwarded to the SDK uninstrumented. A transaction in the context (via
+// newrelic.NewContext) is used if present, otherwise one is started for the
+// duration of the call.
 package nrgemini
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
+	"maps"
+	"net/http"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -27,6 +32,83 @@ import (
 	"github.com/newrelic/go-agent/v3/newrelic/integrationsupport"
 	"google.golang.org/genai"
 )
+
+const (
+	vendorGemini = "gemini"
+	ingestSource = "Go"
+	errorClass   = "GeminiError"
+
+	// roleAssistant is the spec's role for a response message with no vendor role.
+	roleAssistant = "assistant"
+)
+
+// requestIDHeaders hold the request ID, most specific first.
+var requestIDHeaders = []string{"X-Goog-Request-Id", "X-Request-Id"}
+
+// llmResponseHeaders maps a response header to its response.headers.<suffix>
+// attribute. Gemini documents no rate-limit headers today, so most are absent.
+var llmResponseHeaders = map[string]string{
+	"Llm-Version":                              "llmVersion",
+	"X-Ratelimit-Limit-Requests":               "ratelimitLimitRequests",
+	"X-Ratelimit-Limit-Tokens":                 "ratelimitLimitTokens",
+	"X-Ratelimit-Remaining-Requests":           "ratelimitRemainingRequests",
+	"X-Ratelimit-Remaining-Tokens":             "ratelimitRemainingTokens",
+	"X-Ratelimit-Reset-Requests":               "ratelimitResetRequests",
+	"X-Ratelimit-Reset-Tokens":                 "ratelimitResetTokens",
+	"X-Ratelimit-Limit-Tokens-Usage-Based":     "ratelimitLimitTokensUsageBased",
+	"X-Ratelimit-Remaining-Tokens-Usage-Based": "ratelimitRemainingTokensUsageBased",
+	"X-Ratelimit-Reset-Tokens-Usage-Based":     "ratelimitResetTokensUsageBased",
+}
+
+// organizationHeaders identify the serving account or project, most specific first.
+var organizationHeaders = []string{"X-Goog-User-Project", "X-Goog-Project-Id"}
+
+// lookupHeader returns the first of names present in hdr.
+func lookupHeader(hdr http.Header, names ...string) string {
+	for _, name := range names {
+		if v := hdr.Get(name); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// addHeaderAttrs adds response.organization and response.headers.<name>, skipping
+// headers the response did not carry.
+func addHeaderAttrs(data map[string]interface{}, hdr http.Header) {
+	if len(hdr) == 0 {
+		return
+	}
+	if org := lookupHeader(hdr, organizationHeaders...); org != "" {
+		data["response.organization"] = org
+	}
+	for header, suffix := range llmResponseHeaders {
+		if v := hdr.Get(header); v != "" {
+			data["response.headers."+suffix] = v
+		}
+	}
+}
+
+// noticeError reports a failed completion.
+func noticeError(txn *newrelic.Transaction, completionID string, err error) {
+	attrs := map[string]interface{}{"completion_id": completionID}
+
+	var apiErr genai.APIError
+	if errors.As(err, &apiErr) {
+		if apiErr.Code != 0 {
+			attrs["http.statusCode"] = apiErr.Code
+		}
+		if apiErr.Status != "" {
+			attrs["error.code"] = apiErr.Status
+		}
+	}
+
+	txn.NoticeError(newrelic.Error{
+		Message:    err.Error(),
+		Class:      errorClass,
+		Attributes: attrs,
+	})
+}
 
 var reportStreamingDisabled func()
 
@@ -84,14 +166,10 @@ func (c *NRClient) AddCustomAttributes(attrs map[string]interface{}) {
 	}
 }
 
-// GenerateContent wraps client.Models.GenerateContent with New Relic instrumentation.
-//
-// If ctx carries a New Relic transaction (via newrelic.NewContext) that
-// transaction is used and its lifecycle is left to the caller. If no
-// transaction is present a new one named "GeminiGenerateContent" is started and
-// ended automatically. AI monitoring must be enabled on the application
-// (newrelic.ConfigAIMonitoringEnabled(true)); otherwise the call is forwarded
-// to the underlying SDK without instrumentation.
+// GenerateContent wraps client.Models.GenerateContent with New Relic
+// instrumentation, recording LlmChatCompletionSummary and
+// LlmChatCompletionMessage events. A transaction in ctx is used as-is; otherwise
+// one named "GeminiGenerateContent" is started and ended here.
 func (s *NRModelsService) GenerateContent(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig) (*genai.GenerateContentResponse, error) {
 	cfg, _ := s.app.Config()
 	if !cfg.AIMonitoring.Enabled {
@@ -107,96 +185,179 @@ func (s *NRModelsService) GenerateContent(ctx context.Context, model string, con
 
 	integrationsupport.AddAgentAttribute(txn, "llm", "", true)
 
-	completionID := uuid.New().String()
-	spanID := txn.GetTraceMetadata().SpanID
-	traceID := txn.GetTraceMetadata().TraceID
+	md := txn.GetTraceMetadata()
+	c := &completion{
+		id:       uuid.New().String(),
+		spanID:   md.SpanID,
+		traceID:  md.TraceID,
+		model:    model,
+		contents: contents,
+		config:   config,
+	}
 
 	seg := txn.StartSegment("Llm/completion/Gemini/GenerateContent")
 	start := time.Now()
 	resp, err := s.models.GenerateContent(ctx, model, contents, config)
-	duration := time.Since(start).Milliseconds()
+	c.duration = time.Since(start).Milliseconds()
 	seg.End()
 
+	c.resp, c.err = resp, err
 	if err != nil {
-		txn.NoticeError(newrelic.Error{
-			Message: err.Error(),
-			Class:   "GeminiError",
-			Attributes: map[string]interface{}{
-				"completion_id": completionID,
-			},
-		})
-		s.recordSummary(completionID, spanID, traceID, model, config, contents, nil, duration, true)
-		s.recordMessages(completionID, spanID, traceID, model, contents, nil)
-		return resp, err
+		noticeError(txn, c.id, err)
 	}
 
-	s.recordSummary(completionID, spanID, traceID, model, config, contents, resp, duration, false)
-	s.recordMessages(completionID, spanID, traceID, model, contents, resp)
-	return resp, nil
+	s.recordCompletion(c)
+	return resp, err
 }
 
-func (s *NRModelsService) recordSummary(completionID, spanID, traceID, model string, config *genai.GenerateContentConfig, contents []*genai.Content, resp *genai.GenerateContentResponse, duration int64, isError bool) {
+// completion is the state one chat completion needs to report its events. The
+// streaming and non-streaming paths both fill one in, so both emit the same
+// attributes.
+type completion struct {
+	id       string
+	spanID   string
+	traceID  string
+	model    string
+	contents []*genai.Content
+	config   *genai.GenerateContentConfig
+
+	// resp is nil if the call failed; Gemini never returns both.
+	resp *genai.GenerateContentResponse
+	err  error
+
+	duration int64
+	// timeToFirstToken is streaming-only. A pointer, because a first chunk inside
+	// the same millisecond measures zero, unlike a stream that produced nothing.
+	timeToFirstToken *int64
+}
+
+// responseModel is the response's model, or the requested one if absent.
+func (c *completion) responseModel() string {
+	if c.resp != nil && c.resp.ModelVersion != "" {
+		return c.resp.ModelVersion
+	}
+	return c.model
+}
+
+func (c *completion) headers() http.Header {
+	if c.resp == nil || c.resp.SDKHTTPResponse == nil {
+		return nil
+	}
+	return c.resp.SDKHTTPResponse.Headers
+}
+
+// requestID comes from the response headers, falling back to the body's response ID.
+func (c *completion) requestID() string {
+	if id := lookupHeader(c.headers(), requestIDHeaders...); id != "" {
+		return id
+	}
+	if c.resp != nil {
+		return c.resp.ResponseID
+	}
+	return ""
+}
+
+// messageID is "<response id>-<sequence>", or a UUID if there is no response ID.
+func (c *completion) messageID(sequence int) string {
+	if c.resp != nil && c.resp.ResponseID != "" {
+		return fmt.Sprintf("%s-%d", c.resp.ResponseID, sequence)
+	}
+	return uuid.New().String()
+}
+
+// recordCompletion records the summary plus one message per request and response.
+func (s *NRModelsService) recordCompletion(c *completion) {
+	s.recordSummary(c)
+	s.recordMessages(c)
+}
+
+func (s *NRModelsService) recordSummary(c *completion) {
 	data := map[string]interface{}{
-		"id":            completionID,
-		"span_id":       spanID,
-		"trace_id":      traceID,
-		"request.model": model,
-		"vendor":        "gemini",
-		"ingest_source": "Go",
-		"duration":      duration,
+		"id":            c.id,
+		"span_id":       c.spanID,
+		"trace_id":      c.traceID,
+		"request.model": c.model,
+		"vendor":        vendorGemini,
+		"ingest_source": ingestSource,
+		"duration":      c.duration,
 	}
-
-	if config != nil {
-		if config.MaxOutputTokens != 0 {
-			data["request.max_tokens"] = config.MaxOutputTokens
+	if id := c.requestID(); id != "" {
+		data["request_id"] = id
+	}
+	if c.config != nil {
+		if c.config.MaxOutputTokens != 0 {
+			data["request.max_tokens"] = c.config.MaxOutputTokens
 		}
-		if config.Temperature != nil {
-			data["request.temperature"] = *config.Temperature
+		if c.config.Temperature != nil {
+			data["request.temperature"] = *c.config.Temperature
 		}
 	}
-
-	if isError {
+	if c.timeToFirstToken != nil {
+		data["time_to_first_token"] = *c.timeToFirstToken
+	}
+	if c.err != nil {
 		data["error"] = true
-		data["response.number_of_messages"] = len(contents)
-	} else if resp != nil {
-		if resp.ModelVersion != "" {
-			data["response.model"] = resp.ModelVersion
+	}
+
+	if c.resp == nil {
+		data["response.number_of_messages"] = len(c.contents)
+	} else {
+		if model := c.resp.ModelVersion; model != "" {
+			data["response.model"] = model
 		}
-		if len(resp.Candidates) > 0 && resp.Candidates[0].FinishReason != "" {
-			data["response.choices.finish_reason"] = string(resp.Candidates[0].FinishReason)
+		// The attribute is singular, so the first candidate reporting a reason wins.
+		for _, candidate := range c.resp.Candidates {
+			if candidate != nil && candidate.FinishReason != "" {
+				data["response.choices.finish_reason"] = string(candidate.FinishReason)
+				break
+			}
 		}
-		data["response.number_of_messages"] = len(contents) + 1
+		// Each candidate is a response message; CandidateCount can exceed 1.
+		data["response.number_of_messages"] = len(c.contents) + len(c.resp.Candidates)
+		if u := c.resp.UsageMetadata; u != nil {
+			if u.PromptTokenCount != 0 {
+				data["response.usage.prompt_tokens"] = u.PromptTokenCount
+			}
+			if u.CandidatesTokenCount != 0 {
+				data["response.usage.completion_tokens"] = u.CandidatesTokenCount
+			}
+			if u.TotalTokenCount != 0 {
+				data["response.usage.total_tokens"] = u.TotalTokenCount
+			}
+		}
+		addHeaderAttrs(data, c.headers())
 	}
 
 	s.appendCustomAttrs(data)
 	s.app.RecordCustomEvent("LlmChatCompletionSummary", data)
 }
 
-func (s *NRModelsService) recordMessages(completionID, spanID, traceID, model string, contents []*genai.Content, resp *genai.GenerateContentResponse) {
+func (s *NRModelsService) recordMessages(c *completion) {
 	cfg, _ := s.app.Config()
-	responseModel := model
-	if resp != nil && resp.ModelVersion != "" {
-		responseModel = resp.ModelVersion
-	}
+	recordContent := cfg.AIMonitoring.RecordContent.Enabled
+	responseModel := c.responseModel()
+	requestID := c.requestID()
 
-	for i, c := range contents {
-		text := extractContentText(c)
-		role := c.Role
-		if role == "" {
-			role = genai.RoleUser
-		}
+	sequence := 0
+	record := func(role, text string, skipped int, isResponse bool) {
 		data := map[string]interface{}{
-			"id":             uuid.New().String(),
-			"span_id":        spanID,
-			"trace_id":       traceID,
+			"id":             c.messageID(sequence),
+			"span_id":        c.spanID,
+			"trace_id":       c.traceID,
 			"role":           role,
-			"completion_id":  completionID,
-			"sequence":       i,
+			"completion_id":  c.id,
+			"sequence":       sequence,
 			"response.model": responseModel,
-			"vendor":         "gemini",
-			"ingest_source":  "Go",
+			"vendor":         vendorGemini,
+			"ingest_source":  ingestSource,
 		}
-		if cfg.AIMonitoring.RecordContent.Enabled && text != "" {
+		if requestID != "" {
+			data["request_id"] = requestID
+		}
+		if isResponse {
+			data["is_response"] = true
+		}
+		if recordContent && text != "" {
 			data["content"] = text
 		}
 		if tokens, ok := s.app.InvokeLLMTokenCountCallback(responseModel, text); ok {
@@ -204,105 +365,121 @@ func (s *NRModelsService) recordMessages(completionID, spanID, traceID, model st
 		}
 		s.appendCustomAttrs(data)
 		s.app.RecordCustomEvent("LlmChatCompletionMessage", data)
+
+		if skipped > 0 && cfg.Logger != nil && cfg.Logger.DebugEnabled() {
+			cfg.Logger.Debug("nrgemini: message parts omitted from content", map[string]interface{}{
+				"completion_id": c.id,
+				"sequence":      sequence,
+				"parts":         skipped,
+			})
+		}
+		sequence++
 	}
 
-	if resp == nil {
+	for _, content := range c.contents {
+		text, skipped := contentText(content)
+		record(contentRole(content), text, skipped, false)
+	}
+
+	if c.resp == nil {
 		return
 	}
-
-	responseText := extractResponseText(resp)
-	responseSeq := len(contents)
-	responseRole := genai.RoleModel
-	if len(resp.Candidates) > 0 && resp.Candidates[0].Content != nil && resp.Candidates[0].Content.Role != "" {
-		responseRole = resp.Candidates[0].Content.Role
+	for _, candidate := range c.resp.Candidates {
+		text, skipped := candidateText(candidate)
+		record(candidateRole(candidate), text, skipped, true)
 	}
-	data := map[string]interface{}{
-		"id":             fmt.Sprintf("%s-%d", resp.ResponseID, responseSeq),
-		"span_id":        spanID,
-		"trace_id":       traceID,
-		"role":           responseRole,
-		"completion_id":  completionID,
-		"sequence":       responseSeq,
-		"response.model": responseModel,
-		"vendor":         "gemini",
-		"ingest_source":  "Go",
-		"is_response":    true,
-	}
-	if cfg.AIMonitoring.RecordContent.Enabled && responseText != "" {
-		data["content"] = responseText
-	}
-	if tokens, ok := s.app.InvokeLLMTokenCountCallback(responseModel, responseText); ok {
-		data["token_count"] = tokens
-	}
-	s.appendCustomAttrs(data)
-	s.app.RecordCustomEvent("LlmChatCompletionMessage", data)
 }
 
 func (s *NRModelsService) appendCustomAttrs(data map[string]interface{}) {
-	for k, v := range s.customAttributes {
-		data[k] = v
-	}
+	maps.Copy(data, s.customAttributes)
 }
 
-func extractContentText(c *genai.Content) string {
+// contentRole defaults to "user" per the spec.
+func contentRole(c *genai.Content) string {
+	if c != nil && c.Role != "" {
+		return c.Role
+	}
+	return genai.RoleUser
+}
+
+// candidateRole passes Gemini's "model" through, defaulting to "assistant" per the spec.
+func candidateRole(c *genai.Candidate) string {
+	if c != nil && c.Content != nil && c.Content.Role != "" {
+		return c.Content.Role
+	}
+	return roleAssistant
+}
+
+// contentText joins a message's text parts. The count reports parts left out
+// because they carry data other than text: blobs, file references, function calls
+// or responses, executable code.
+func contentText(c *genai.Content) (text string, skipped int) {
 	if c == nil {
-		return ""
+		return "", 0
 	}
-	var parts []string
+	var texts []string
 	for _, p := range c.Parts {
-		if p != nil && p.Text != "" {
-			parts = append(parts, p.Text)
+		switch {
+		case p == nil:
+		case p.Text != "":
+			texts = append(texts, p.Text)
+		default:
+			skipped++
 		}
 	}
-	return strings.Join(parts, " ")
+	return strings.Join(texts, " "), skipped
 }
 
-func extractResponseText(resp *genai.GenerateContentResponse) string {
-	if resp == nil || len(resp.Candidates) == 0 || resp.Candidates[0].Content == nil {
-		return ""
+func candidateText(c *genai.Candidate) (string, int) {
+	if c == nil {
+		return "", 0
 	}
-	var parts []string
-	for _, p := range resp.Candidates[0].Content.Parts {
-		if p != nil && p.Text != "" {
-			parts = append(parts, p.Text)
-		}
-	}
-	return strings.Join(parts, " ")
+	return contentText(c.Content)
 }
 
-// NRGenerateContentStreamWrapper wraps a GenAI streaming iterator with New Relic
-// instrumentation. Call Next() to advance the stream, Current() to read the
-// current chunk, Err() to check for errors, and Close() to flush NR events and
-// release resources.
-type NRGenerateContentStreamWrapper struct {
-	next             func() (*genai.GenerateContentResponse, error, bool)
-	stop             func()
-	err              error
-	current          *genai.GenerateContentResponse
-	app              *newrelic.Application
-	txn              *newrelic.Transaction
-	txnOwned         bool
-	seg              *newrelic.Segment
-	customAttributes map[string]interface{}
-	model            string
-	contents         []*genai.Content
-	config           *genai.GenerateContentConfig
-	completionID     string
-	spanID           string
-	traceID          string
-	responseText     strings.Builder
-	responseID       string
-	responseModel    string
-	finishReason     string
-	responseRole     string
-	start            time.Time
-	closed           bool
+// NRGenerateContentStream tracks a streaming GenerateContent call until every
+// chunk has been processed. The SDK hands back an iter.Seq2, so your code drives
+// the loop and reports each chunk back:
+//
+//	stream := nrClient.Models.GenerateContentStream(ctx, model, contents, cfg)
+//	defer stream.Close()
+//	for chunk, err := range stream.Stream {
+//	    stream.RecordEvent(chunk, err)
+//	    if err != nil {
+//	        break
+//	    }
+//	    // ... consume chunk ...
+//	}
+//
+// Ranging over Stream is what releases the HTTP body; the SDK closes it when the
+// loop ends or breaks. Close only finishes the New Relic side, so it is safe to
+// defer. See ProcessContentStream for an easier alternative.
+type NRGenerateContentStream struct {
+	// Stream is the SDK's iterator. Range over it directly.
+	Stream iter.Seq2[*genai.GenerateContentResponse, error]
+
+	svc      *NRModelsService
+	txn      *newrelic.Transaction
+	seg      *newrelic.Segment
+	closeTxn bool
+	closed   bool
+
+	// completion holds what Close reports; its resp is accumulated chunk by chunk
+	// into the shape a non-streaming call returns.
+	completion *completion
+	// text collects each candidate's deltas. A Builder per candidate keeps the
+	// accumulation linear; concatenating onto the response recopies it every chunk.
+	text  []*strings.Builder
+	start time.Time
 }
 
 // GenerateContentStream wraps client.Models.GenerateContentStream with New Relic
-// instrumentation. The returned wrapper exposes Next/Current/Err/Close. Call
-// Close() after the stream is consumed to record NR events.
-func (s *NRModelsService) GenerateContentStream(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig) *NRGenerateContentStreamWrapper {
+// instrumentation. Report each chunk with RecordEvent and call Close when done;
+// see NRGenerateContentStream for an example. A transaction in ctx is used as-is,
+// otherwise one named "GeminiGenerateContentStream" is started and ended by
+// Close. With AI monitoring or streaming disabled, Stream is the untouched SDK
+// iterator and RecordEvent/Close do nothing.
+func (s *NRModelsService) GenerateContentStream(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig) *NRGenerateContentStream {
 	cfg, _ := s.app.Config()
 
 	if !cfg.AIMonitoring.Streaming.Enabled {
@@ -311,233 +488,193 @@ func (s *NRModelsService) GenerateContentStream(ctx context.Context, model strin
 		}
 	}
 
-	seq := s.models.GenerateContentStream(ctx, model, contents, config)
-	next, stop := iter.Pull2(seq)
-
-	if !cfg.AIMonitoring.Enabled || !cfg.AIMonitoring.Streaming.Enabled {
-		return &NRGenerateContentStreamWrapper{
-			app:      s.app,
+	stream := &NRGenerateContentStream{
+		svc:   s,
+		start: time.Now(),
+		completion: &completion{
 			model:    model,
 			contents: contents,
 			config:   config,
-			next:     next,
-			stop:     stop,
-			start:    time.Now(),
+		},
+	}
+
+	if cfg.AIMonitoring.Enabled && cfg.AIMonitoring.Streaming.Enabled {
+		stream.txn = newrelic.FromContext(ctx)
+		if stream.txn == nil {
+			stream.txn = s.app.StartTransaction("GeminiGenerateContentStream")
+			stream.closeTxn = true
+			ctx = newrelic.NewContext(ctx, stream.txn)
 		}
+		integrationsupport.AddAgentAttribute(stream.txn, "llm", "", true)
+
+		md := stream.txn.GetTraceMetadata()
+		stream.completion.id = uuid.New().String()
+		stream.completion.spanID = md.SpanID
+		stream.completion.traceID = md.TraceID
+		stream.seg = stream.txn.StartSegment("Llm/completion/Gemini/GenerateContentStream")
 	}
 
-	txn := newrelic.FromContext(ctx)
-	txnOwned := false
-	if txn == nil {
-		txn = s.app.StartTransaction("GeminiGenerateContentStream")
-		txnOwned = true
-		ctx = newrelic.NewContext(ctx, txn)
-	}
-
-	integrationsupport.AddAgentAttribute(txn, "llm", "", true)
-	seg := txn.StartSegment("Llm/completion/Gemini/GenerateContentStream")
-
-	return &NRGenerateContentStreamWrapper{
-		app:              s.app,
-		txn:              txn,
-		txnOwned:         txnOwned,
-		seg:              seg,
-		customAttributes: s.customAttributes,
-		model:            model,
-		contents:         contents,
-		config:           config,
-		completionID:     uuid.New().String(),
-		spanID:           txn.GetTraceMetadata().SpanID,
-		traceID:          txn.GetTraceMetadata().TraceID,
-		start:            time.Now(),
-		next:             next,
-		stop:             stop,
-	}
+	// Last, so the request sees the transaction added to ctx above.
+	stream.Stream = s.models.GenerateContentStream(ctx, model, contents, config)
+	return stream
 }
 
-// Next advances the stream to the next chunk and accumulates response state.
-func (w *NRGenerateContentStreamWrapper) Next() bool {
-	chunk, err, ok := w.next()
-	if !ok {
-		return false
+// RecordEvent reports one chunk from Stream. Pass the chunk and error exactly as
+// the iterator yielded them.
+func (w *NRGenerateContentStream) RecordEvent(chunk *genai.GenerateContentResponse, err error) {
+	if w == nil {
+		return
 	}
 	if err != nil {
-		w.err = err
-		return false
-	}
-	w.current = chunk
-	if chunk != nil {
-		if chunk.ResponseID != "" {
-			w.responseID = chunk.ResponseID
-		}
-		if chunk.ModelVersion != "" {
-			w.responseModel = chunk.ModelVersion
-		}
-		if len(chunk.Candidates) > 0 {
-			cand := chunk.Candidates[0]
-			if cand.Content != nil {
-				if cand.Content.Role != "" {
-					w.responseRole = cand.Content.Role
-				}
-				for _, p := range cand.Content.Parts {
-					if p != nil && p.Text != "" {
-						w.responseText.WriteString(p.Text)
-					}
-				}
-			}
-			if cand.FinishReason != "" {
-				w.finishReason = string(cand.FinishReason)
+		// Keep the first; the SDK may yield more chunks after an error.
+		if w.completion.err == nil {
+			w.completion.err = err
+			w.completion.duration = time.Since(w.start).Milliseconds()
+			if w.txn != nil {
+				noticeError(w.txn, w.completion.id, err)
 			}
 		}
+		return
 	}
-	return true
+	if w.txn == nil || chunk == nil {
+		return
+	}
+	if w.completion.timeToFirstToken == nil {
+		elapsed := time.Since(w.start).Milliseconds()
+		w.completion.timeToFirstToken = &elapsed
+	}
+	w.completion.duration = time.Since(w.start).Milliseconds()
+	w.accumulate(chunk)
 }
 
-// Current returns the most recent stream chunk.
-func (w *NRGenerateContentStreamWrapper) Current() *genai.GenerateContentResponse {
-	return w.current
+// accumulate folds a chunk into the response Close reports on. Deltas append to a
+// single Part, so no separator lands between them.
+func (w *NRGenerateContentStream) accumulate(chunk *genai.GenerateContentResponse) {
+	if w.completion.resp == nil {
+		w.completion.resp = &genai.GenerateContentResponse{}
+	}
+	resp := w.completion.resp
+
+	if chunk.ResponseID != "" {
+		resp.ResponseID = chunk.ResponseID
+	}
+	if chunk.ModelVersion != "" {
+		resp.ModelVersion = chunk.ModelVersion
+	}
+	// Usage arrives on the final chunk, so the latest wins.
+	if chunk.UsageMetadata != nil {
+		resp.UsageMetadata = chunk.UsageMetadata
+	}
+	if chunk.SDKHTTPResponse != nil {
+		resp.SDKHTTPResponse = chunk.SDKHTTPResponse
+	}
+
+	// Each requested candidate streams its own deltas.
+	for len(resp.Candidates) < len(chunk.Candidates) {
+		resp.Candidates = append(resp.Candidates, &genai.Candidate{
+			Content: &genai.Content{Parts: []*genai.Part{{}}},
+		})
+		w.text = append(w.text, &strings.Builder{})
+	}
+
+	for i, src := range chunk.Candidates {
+		if src == nil {
+			continue
+		}
+		dst := resp.Candidates[i]
+		if src.FinishReason != "" {
+			dst.FinishReason = src.FinishReason
+		}
+		if src.Content == nil {
+			continue
+		}
+		if src.Content.Role != "" {
+			dst.Content.Role = src.Content.Role
+		}
+		for _, p := range src.Content.Parts {
+			if p != nil && p.Text != "" {
+				w.text[i].WriteString(p.Text)
+			}
+		}
+	}
 }
 
-// Err returns any error encountered during streaming.
-func (w *NRGenerateContentStreamWrapper) Err() error {
-	return w.err
+// response writes the accumulated text into the response and returns it.
+func (w *NRGenerateContentStream) response() *genai.GenerateContentResponse {
+	resp := w.completion.resp
+	if resp == nil {
+		return nil
+	}
+	for i, b := range w.text {
+		if i < len(resp.Candidates) {
+			resp.Candidates[i].Content.Parts[0].Text = b.String()
+		}
+	}
+	return resp
 }
 
-// Close records LlmChatCompletionSummary and LlmChatCompletionMessage events,
-// ends the segment, ends the transaction if it was started by this wrapper,
-// and releases the underlying iterator.
-func (w *NRGenerateContentStreamWrapper) Close() error {
-	if w.closed {
+// Err returns the first error the stream yielded.
+func (w *NRGenerateContentStream) Err() error {
+	if w == nil {
+		return nil
+	}
+	return w.completion.err
+}
+
+// Close records the events, ends the segment, and ends the transaction if
+// GenerateContentStream started one. Idempotent, and a no-op when uninstrumented.
+func (w *NRGenerateContentStream) Close() error {
+	if w == nil || w.closed {
 		return nil
 	}
 	w.closed = true
-	w.recordCustomEvent()
-	if w.txnOwned {
-		w.txn.End()
-	}
-	w.stop()
-	return nil
-}
-
-func (w *NRGenerateContentStreamWrapper) recordCustomEvent() {
-	cfg, _ := w.app.Config()
-	if !cfg.AIMonitoring.Enabled || !cfg.AIMonitoring.Streaming.Enabled {
-		return
+	if w.txn == nil {
+		return nil
 	}
 
 	if w.seg != nil {
 		w.seg.End()
 	}
 
-	duration := time.Since(w.start).Milliseconds()
-	isError := w.err != nil
+	// A failed stream reports request messages only, like the non-streaming path.
+	if w.completion.err != nil {
+		w.completion.resp = nil
+	}
+	w.response()
+	// duration is stamped as chunks arrive, so a Close that runs much later — a
+	// deferred one, say — does not stretch it. Only a stream nothing was reported
+	// for needs it measured here.
+	if w.completion.duration == 0 {
+		w.completion.duration = time.Since(w.start).Milliseconds()
+	}
+	w.svc.recordCompletion(w.completion)
 
-	if isError {
-		w.txn.NoticeError(newrelic.Error{
-			Message: w.err.Error(),
-			Class:   "GeminiError",
-			Attributes: map[string]interface{}{
-				"completion_id": w.completionID,
-			},
-		})
+	if w.closeTxn {
+		w.txn.End()
 	}
-
-	model := w.model
-	if w.responseModel != "" {
-		model = w.responseModel
-	}
-
-	summaryData := map[string]interface{}{
-		"id":            w.completionID,
-		"span_id":       w.spanID,
-		"trace_id":      w.traceID,
-		"request.model": w.model,
-		"vendor":        "gemini",
-		"ingest_source": "Go",
-		"duration":      duration,
-	}
-	if w.config != nil {
-		if w.config.MaxOutputTokens != 0 {
-			summaryData["request.max_tokens"] = w.config.MaxOutputTokens
-		}
-		if w.config.Temperature != nil {
-			summaryData["request.temperature"] = *w.config.Temperature
-		}
-	}
-	if isError {
-		summaryData["error"] = true
-		summaryData["response.number_of_messages"] = len(w.contents)
-	} else {
-		summaryData["response.model"] = model
-		if w.finishReason != "" {
-			summaryData["response.choices.finish_reason"] = w.finishReason
-		}
-		summaryData["response.number_of_messages"] = len(w.contents) + 1
-	}
-	w.appendCustomAttrs(summaryData)
-	w.app.RecordCustomEvent("LlmChatCompletionSummary", summaryData)
-
-	for i, c := range w.contents {
-		text := extractContentText(c)
-		role := c.Role
-		if role == "" {
-			role = genai.RoleUser
-		}
-		msgData := map[string]interface{}{
-			"id":             uuid.New().String(),
-			"span_id":        w.spanID,
-			"trace_id":       w.traceID,
-			"role":           role,
-			"completion_id":  w.completionID,
-			"sequence":       i,
-			"response.model": model,
-			"vendor":         "gemini",
-			"ingest_source":  "Go",
-		}
-		if cfg.AIMonitoring.RecordContent.Enabled && text != "" {
-			msgData["content"] = text
-		}
-		if tokens, ok := w.app.InvokeLLMTokenCountCallback(model, text); ok {
-			msgData["token_count"] = tokens
-		}
-		w.appendCustomAttrs(msgData)
-		w.app.RecordCustomEvent("LlmChatCompletionMessage", msgData)
-	}
-
-	if isError {
-		return
-	}
-
-	responseText := w.responseText.String()
-	responseSeq := len(w.contents)
-	responseRole := w.responseRole
-	if responseRole == "" {
-		responseRole = genai.RoleModel
-	}
-	respData := map[string]interface{}{
-		"id":             fmt.Sprintf("%s-%d", w.responseID, responseSeq),
-		"span_id":        w.spanID,
-		"trace_id":       w.traceID,
-		"role":           responseRole,
-		"completion_id":  w.completionID,
-		"sequence":       responseSeq,
-		"response.model": model,
-		"vendor":         "gemini",
-		"ingest_source":  "Go",
-		"is_response":    true,
-	}
-	if cfg.AIMonitoring.RecordContent.Enabled && responseText != "" {
-		respData["content"] = responseText
-	}
-	if tokens, ok := w.app.InvokeLLMTokenCountCallback(model, responseText); ok {
-		respData["token_count"] = tokens
-	}
-	w.appendCustomAttrs(respData)
-	w.app.RecordCustomEvent("LlmChatCompletionMessage", respData)
+	return nil
 }
 
-func (w *NRGenerateContentStreamWrapper) appendCustomAttrs(data map[string]interface{}) {
-	for k, v := range w.customAttributes {
-		data[k] = v
+// ProcessContentStream is GenerateContentStream with the loop and Close handled
+// for you, invoking callback for each chunk. A callback error stops the stream and
+// is returned; otherwise the stream's own error is.
+func (s *NRModelsService) ProcessContentStream(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig, callback func(*genai.GenerateContentResponse) error) error {
+	stream := s.GenerateContentStream(ctx, model, contents, config)
+	defer stream.Close()
+
+	var userErr error
+	for chunk, err := range stream.Stream {
+		stream.RecordEvent(chunk, err)
+		if err != nil {
+			break
+		}
+		if userErr = callback(chunk); userErr != nil {
+			break
+		}
 	}
+
+	if userErr != nil {
+		return userErr
+	}
+	return stream.Err()
 }

--- a/v3/integrations/nrgemini/nrgemini.go
+++ b/v3/integrations/nrgemini/nrgemini.go
@@ -1,10 +1,11 @@
 // Package nrgemini provides New Relic instrumentation for the Google GenAI Go
 // SDK (google.golang.org/genai).
 //
-// Wrap your GenAI client with NewClient, then use the wrapped service in place of
-// the SDK's own: GenerateContent, GenerateContentStream, and ProcessContentStream
-// record LlmChatCompletionSummary and LlmChatCompletionMessage events, and open a
-// segment under the active transaction.
+// Wrap your GenAI client with NewClient, then use nrClient.Models in place of
+// client.Models. GenerateContent and GenerateContentStream keep the SDK's
+// signatures, so calling code does not otherwise change; both record
+// LlmChatCompletionSummary and LlmChatCompletionMessage events and open a segment
+// under the active transaction.
 //
 // AI monitoring must be enabled on the application
 // (newrelic.ConfigAIMonitoringEnabled(true)), plus
@@ -437,49 +438,19 @@ func candidateText(c *genai.Candidate) (string, int) {
 	return contentText(c.Content)
 }
 
-// NRGenerateContentStream tracks a streaming GenerateContent call until every
-// chunk has been processed. The SDK hands back an iter.Seq2, so your code drives
-// the loop and reports each chunk back:
+// GenerateContentStream wraps client.Models.GenerateContentStream with New Relic
+// instrumentation. It returns the same iter.Seq2 the SDK returns, so calling code
+// is unchanged apart from the receiver:
 //
-//	stream := nrClient.Models.GenerateContentStream(ctx, model, contents, cfg)
-//	defer stream.Close()
-//	for chunk, err := range stream.Stream {
-//	    stream.RecordEvent(chunk, err)
-//	    if err != nil {
-//	        break
-//	    }
+//	for chunk, err := range nrClient.Models.GenerateContentStream(ctx, model, contents, cfg) {
 //	    // ... consume chunk ...
 //	}
 //
-// Ranging over Stream is what releases the HTTP body; the SDK closes it when the
-// loop ends or breaks. Close only finishes the New Relic side, so it is safe to
-// defer. See ProcessContentStream for an easier alternative.
-type NRGenerateContentStream struct {
-	// Stream is the SDK's iterator. Range over it directly.
-	Stream iter.Seq2[*genai.GenerateContentResponse, error]
-
-	svc      *NRModelsService
-	txn      *newrelic.Transaction
-	seg      *newrelic.Segment
-	closeTxn bool
-	closed   bool
-
-	// completion holds what Close reports; its resp is accumulated chunk by chunk
-	// into the shape a non-streaming call returns.
-	completion *completion
-	// text collects each candidate's deltas. A Builder per candidate keeps the
-	// accumulation linear; concatenating onto the response recopies it every chunk.
-	text  []*strings.Builder
-	start time.Time
-}
-
-// GenerateContentStream wraps client.Models.GenerateContentStream with New Relic
-// instrumentation. Report each chunk with RecordEvent and call Close when done;
-// see NRGenerateContentStream for an example. A transaction in ctx is used as-is,
-// otherwise one named "GeminiGenerateContentStream" is started and ended by
-// Close. With AI monitoring or streaming disabled, Stream is the untouched SDK
-// iterator and RecordEvent/Close do nothing.
-func (s *NRModelsService) GenerateContentStream(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig) *NRGenerateContentStream {
+// Events are recorded once the loop finishes, whether it ran to completion, broke
+// early, or panicked. A transaction in ctx is used as-is; otherwise one named
+// "GeminiGenerateContentStream" is started and ended with the stream. With AI
+// monitoring or streaming disabled, the SDK iterator is returned untouched.
+func (s *NRModelsService) GenerateContentStream(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig) iter.Seq2[*genai.GenerateContentResponse, error] {
 	cfg, _ := s.app.Config()
 
 	if !cfg.AIMonitoring.Streaming.Enabled {
@@ -487,73 +458,104 @@ func (s *NRModelsService) GenerateContentStream(ctx context.Context, model strin
 			reportStreamingDisabled()
 		}
 	}
+	if !cfg.AIMonitoring.Enabled || !cfg.AIMonitoring.Streaming.Enabled {
+		return s.models.GenerateContentStream(ctx, model, contents, config)
+	}
 
-	stream := &NRGenerateContentStream{
-		svc:   s,
-		start: time.Now(),
+	txn := newrelic.FromContext(ctx)
+	closeTxn := false
+	if txn == nil {
+		txn = s.app.StartTransaction("GeminiGenerateContentStream")
+		closeTxn = true
+		ctx = newrelic.NewContext(ctx, txn)
+	}
+	integrationsupport.AddAgentAttribute(txn, "llm", "", true)
+
+	md := txn.GetTraceMetadata()
+	st := &streamState{
 		completion: &completion{
+			id:       uuid.New().String(),
+			spanID:   md.SpanID,
+			traceID:  md.TraceID,
 			model:    model,
 			contents: contents,
 			config:   config,
 		},
+		start: time.Now(),
 	}
+	seg := txn.StartSegment("Llm/completion/Gemini/GenerateContentStream")
 
-	if cfg.AIMonitoring.Enabled && cfg.AIMonitoring.Streaming.Enabled {
-		stream.txn = newrelic.FromContext(ctx)
-		if stream.txn == nil {
-			stream.txn = s.app.StartTransaction("GeminiGenerateContentStream")
-			stream.closeTxn = true
-			ctx = newrelic.NewContext(ctx, stream.txn)
+	// The SDK issues the request here, before returning its iterator, so the
+	// segment above covers the whole call. ctx already carries the transaction.
+	seq := s.models.GenerateContentStream(ctx, model, contents, config)
+
+	return func(yield func(*genai.GenerateContentResponse, error) bool) {
+		if st.consumed {
+			// The SDK iterator is single-use; a second range would report again.
+			return
 		}
-		integrationsupport.AddAgentAttribute(stream.txn, "llm", "", true)
+		st.consumed = true
 
-		md := stream.txn.GetTraceMetadata()
-		stream.completion.id = uuid.New().String()
-		stream.completion.spanID = md.SpanID
-		stream.completion.traceID = md.TraceID
-		stream.seg = stream.txn.StartSegment("Llm/completion/Gemini/GenerateContentStream")
-	}
+		defer func() {
+			seg.End()
+			s.recordCompletion(st.finish())
+			if closeTxn {
+				txn.End()
+			}
+		}()
 
-	// Last, so the request sees the transaction added to ctx above.
-	stream.Stream = s.models.GenerateContentStream(ctx, model, contents, config)
-	return stream
-}
-
-// RecordEvent reports one chunk from Stream. Pass the chunk and error exactly as
-// the iterator yielded them.
-func (w *NRGenerateContentStream) RecordEvent(chunk *genai.GenerateContentResponse, err error) {
-	if w == nil {
-		return
-	}
-	if err != nil {
-		// Keep the first; the SDK may yield more chunks after an error.
-		if w.completion.err == nil {
-			w.completion.err = err
-			w.completion.duration = time.Since(w.start).Milliseconds()
-			if w.txn != nil {
-				noticeError(w.txn, w.completion.id, err)
+		for chunk, err := range seq {
+			st.observe(txn, chunk, err)
+			if !yield(chunk, err) {
+				return
 			}
 		}
-		return
 	}
-	if w.txn == nil || chunk == nil {
-		return
-	}
-	if w.completion.timeToFirstToken == nil {
-		elapsed := time.Since(w.start).Milliseconds()
-		w.completion.timeToFirstToken = &elapsed
-	}
-	w.completion.duration = time.Since(w.start).Milliseconds()
-	w.accumulate(chunk)
 }
 
-// accumulate folds a chunk into the response Close reports on. Deltas append to a
-// single Part, so no separator lands between them.
-func (w *NRGenerateContentStream) accumulate(chunk *genai.GenerateContentResponse) {
-	if w.completion.resp == nil {
-		w.completion.resp = &genai.GenerateContentResponse{}
+// streamState accumulates a stream into the single response a non-streaming call
+// would have returned, so both paths report through recordCompletion.
+type streamState struct {
+	completion *completion
+	// text collects each candidate's deltas. A Builder per candidate keeps the
+	// accumulation linear; concatenating onto the response recopies it every chunk.
+	text     []*strings.Builder
+	start    time.Time
+	consumed bool
+	// observed records whether anything was yielded at all, which a zero duration
+	// cannot express: a stream answered inside the same millisecond measures zero.
+	observed bool
+}
+
+// observe folds one yielded chunk into the accumulated state.
+func (st *streamState) observe(txn *newrelic.Transaction, chunk *genai.GenerateContentResponse, err error) {
+	c := st.completion
+	st.observed = true
+
+	if err != nil {
+		// Keep the first; the SDK may yield more chunks after an error.
+		if c.err == nil {
+			c.err = err
+			c.duration = time.Since(st.start).Milliseconds()
+			noticeError(txn, c.id, err)
+		}
+		return
 	}
-	resp := w.completion.resp
+	if chunk == nil {
+		return
+	}
+	if c.timeToFirstToken == nil {
+		elapsed := time.Since(st.start).Milliseconds()
+		c.timeToFirstToken = &elapsed
+	}
+	// Stamped per chunk so the recording, which happens after the caller's loop
+	// exits, does not stretch the duration past the last chunk.
+	c.duration = time.Since(st.start).Milliseconds()
+
+	if c.resp == nil {
+		c.resp = &genai.GenerateContentResponse{}
+	}
+	resp := c.resp
 
 	if chunk.ResponseID != "" {
 		resp.ResponseID = chunk.ResponseID
@@ -574,7 +576,7 @@ func (w *NRGenerateContentStream) accumulate(chunk *genai.GenerateContentRespons
 		resp.Candidates = append(resp.Candidates, &genai.Candidate{
 			Content: &genai.Content{Parts: []*genai.Part{{}}},
 		})
-		w.text = append(w.text, &strings.Builder{})
+		st.text = append(st.text, &strings.Builder{})
 	}
 
 	for i, src := range chunk.Candidates {
@@ -593,88 +595,30 @@ func (w *NRGenerateContentStream) accumulate(chunk *genai.GenerateContentRespons
 		}
 		for _, p := range src.Content.Parts {
 			if p != nil && p.Text != "" {
-				w.text[i].WriteString(p.Text)
+				st.text[i].WriteString(p.Text)
 			}
 		}
 	}
 }
 
-// response writes the accumulated text into the response and returns it.
-func (w *NRGenerateContentStream) response() *genai.GenerateContentResponse {
-	resp := w.completion.resp
-	if resp == nil {
-		return nil
-	}
-	for i, b := range w.text {
-		if i < len(resp.Candidates) {
-			resp.Candidates[i].Content.Parts[0].Text = b.String()
-		}
-	}
-	return resp
-}
-
-// Err returns the first error the stream yielded.
-func (w *NRGenerateContentStream) Err() error {
-	if w == nil {
-		return nil
-	}
-	return w.completion.err
-}
-
-// Close records the events, ends the segment, and ends the transaction if
-// GenerateContentStream started one. Idempotent, and a no-op when uninstrumented.
-func (w *NRGenerateContentStream) Close() error {
-	if w == nil || w.closed {
-		return nil
-	}
-	w.closed = true
-	if w.txn == nil {
-		return nil
-	}
-
-	if w.seg != nil {
-		w.seg.End()
-	}
+// finish materializes the accumulated text and returns the completion to report.
+func (st *streamState) finish() *completion {
+	c := st.completion
 
 	// A failed stream reports request messages only, like the non-streaming path.
-	if w.completion.err != nil {
-		w.completion.resp = nil
+	if c.err != nil {
+		c.resp = nil
 	}
-	w.response()
-	// duration is stamped as chunks arrive, so a Close that runs much later — a
-	// deferred one, say — does not stretch it. Only a stream nothing was reported
-	// for needs it measured here.
-	if w.completion.duration == 0 {
-		w.completion.duration = time.Since(w.start).Milliseconds()
-	}
-	w.svc.recordCompletion(w.completion)
-
-	if w.closeTxn {
-		w.txn.End()
-	}
-	return nil
-}
-
-// ProcessContentStream is GenerateContentStream with the loop and Close handled
-// for you, invoking callback for each chunk. A callback error stops the stream and
-// is returned; otherwise the stream's own error is.
-func (s *NRModelsService) ProcessContentStream(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig, callback func(*genai.GenerateContentResponse) error) error {
-	stream := s.GenerateContentStream(ctx, model, contents, config)
-	defer stream.Close()
-
-	var userErr error
-	for chunk, err := range stream.Stream {
-		stream.RecordEvent(chunk, err)
-		if err != nil {
-			break
-		}
-		if userErr = callback(chunk); userErr != nil {
-			break
+	if c.resp != nil {
+		for i, b := range st.text {
+			if i < len(c.resp.Candidates) {
+				c.resp.Candidates[i].Content.Parts[0].Text = b.String()
+			}
 		}
 	}
-
-	if userErr != nil {
-		return userErr
+	// Only a stream that yielded nothing needs its duration measured here.
+	if !st.observed {
+		c.duration = time.Since(st.start).Milliseconds()
 	}
-	return stream.Err()
+	return c
 }

--- a/v3/integrations/nrgemini/nrgemini.go
+++ b/v3/integrations/nrgemini/nrgemini.go
@@ -1,0 +1,543 @@
+// Package nrgemini provides New Relic instrumentation for the Google GenAI Go
+// SDK (google.golang.org/genai).
+//
+// Wrap your GenAI client with NewClient, then use nrClient.Models.GenerateContent
+// in place of client.Models.GenerateContent to automatically record
+// LlmChatCompletionSummary and LlmChatCompletionMessage custom events and a
+// segment under the active transaction — mirroring the Python agent's
+// mlmodel_gemini instrumentation.
+//
+// The New Relic transaction must be present in the context (via
+// newrelic.NewContext) for instrumentation to activate. AI monitoring must also
+// be enabled on the application (newrelic.ConfigAIMonitoringEnabled(true)).
+package nrgemini
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/newrelic/go-agent/v3/internal"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v3/newrelic/integrationsupport"
+	"google.golang.org/genai"
+)
+
+var reportStreamingDisabled func()
+
+func init() {
+	reportStreamingDisabled = sync.OnceFunc(func() {
+		internal.TrackUsage("Go", "ML", "Streaming", "Disabled")
+	})
+	info, ok := debug.ReadBuildInfo()
+	if info != nil && ok {
+		for _, module := range info.Deps {
+			if module != nil && strings.Contains(module.Path, "google.golang.org/genai") {
+				internal.TrackUsage("Go", "ML", "Gemini", module.Version)
+				return
+			}
+		}
+	}
+	internal.TrackUsage("Go", "ML", "Gemini", "unknown")
+}
+
+// NRClient wraps a GenAI client with New Relic instrumentation.
+type NRClient struct {
+	Client *genai.Client
+	Models NRModelsService
+}
+
+// NRModelsService wraps the GenAI Models service with instrumentation.
+type NRModelsService struct {
+	models           *genai.Models
+	app              *newrelic.Application
+	customAttributes map[string]interface{}
+}
+
+// NewClient creates an NRClient wrapping a new GenAI client initialized with cfg.
+func NewClient(app *newrelic.Application, ctx context.Context, cfg *genai.ClientConfig) (*NRClient, error) {
+	client, err := genai.NewClient(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	nrc := &NRClient{Client: client}
+	nrc.Models = NRModelsService{
+		models:           client.Models,
+		app:              app,
+		customAttributes: make(map[string]interface{}),
+	}
+	return nrc, nil
+}
+
+// AddCustomAttributes attaches llm.* prefixed key-value pairs to all LLM events
+// recorded by this client.
+func (c *NRClient) AddCustomAttributes(attrs map[string]interface{}) {
+	for k, v := range attrs {
+		if strings.HasPrefix(k, "llm.") {
+			c.Models.customAttributes[k] = v
+		}
+	}
+}
+
+// GenerateContent wraps client.Models.GenerateContent with New Relic instrumentation.
+//
+// If ctx carries a New Relic transaction (via newrelic.NewContext) that
+// transaction is used and its lifecycle is left to the caller. If no
+// transaction is present a new one named "GeminiGenerateContent" is started and
+// ended automatically. AI monitoring must be enabled on the application
+// (newrelic.ConfigAIMonitoringEnabled(true)); otherwise the call is forwarded
+// to the underlying SDK without instrumentation.
+func (s *NRModelsService) GenerateContent(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig) (*genai.GenerateContentResponse, error) {
+	cfg, _ := s.app.Config()
+	if !cfg.AIMonitoring.Enabled {
+		return s.models.GenerateContent(ctx, model, contents, config)
+	}
+
+	txn := newrelic.FromContext(ctx)
+	if txn == nil {
+		txn = s.app.StartTransaction("GeminiGenerateContent")
+		defer txn.End()
+		ctx = newrelic.NewContext(ctx, txn)
+	}
+
+	integrationsupport.AddAgentAttribute(txn, "llm", "", true)
+
+	completionID := uuid.New().String()
+	spanID := txn.GetTraceMetadata().SpanID
+	traceID := txn.GetTraceMetadata().TraceID
+
+	seg := txn.StartSegment("Llm/completion/Gemini/GenerateContent")
+	start := time.Now()
+	resp, err := s.models.GenerateContent(ctx, model, contents, config)
+	duration := time.Since(start).Milliseconds()
+	seg.End()
+
+	if err != nil {
+		txn.NoticeError(newrelic.Error{
+			Message: err.Error(),
+			Class:   "GeminiError",
+			Attributes: map[string]interface{}{
+				"completion_id": completionID,
+			},
+		})
+		s.recordSummary(completionID, spanID, traceID, model, config, contents, nil, duration, true)
+		s.recordMessages(completionID, spanID, traceID, model, contents, nil)
+		return resp, err
+	}
+
+	s.recordSummary(completionID, spanID, traceID, model, config, contents, resp, duration, false)
+	s.recordMessages(completionID, spanID, traceID, model, contents, resp)
+	return resp, nil
+}
+
+func (s *NRModelsService) recordSummary(completionID, spanID, traceID, model string, config *genai.GenerateContentConfig, contents []*genai.Content, resp *genai.GenerateContentResponse, duration int64, isError bool) {
+	data := map[string]interface{}{
+		"id":            completionID,
+		"span_id":       spanID,
+		"trace_id":      traceID,
+		"request.model": model,
+		"vendor":        "gemini",
+		"ingest_source": "Go",
+		"duration":      duration,
+	}
+
+	if config != nil {
+		if config.MaxOutputTokens != 0 {
+			data["request.max_tokens"] = config.MaxOutputTokens
+		}
+		if config.Temperature != nil {
+			data["request.temperature"] = *config.Temperature
+		}
+	}
+
+	if isError {
+		data["error"] = true
+		data["response.number_of_messages"] = len(contents)
+	} else if resp != nil {
+		if resp.ModelVersion != "" {
+			data["response.model"] = resp.ModelVersion
+		}
+		if len(resp.Candidates) > 0 && resp.Candidates[0].FinishReason != "" {
+			data["response.choices.finish_reason"] = string(resp.Candidates[0].FinishReason)
+		}
+		data["response.number_of_messages"] = len(contents) + 1
+	}
+
+	s.appendCustomAttrs(data)
+	s.app.RecordCustomEvent("LlmChatCompletionSummary", data)
+}
+
+func (s *NRModelsService) recordMessages(completionID, spanID, traceID, model string, contents []*genai.Content, resp *genai.GenerateContentResponse) {
+	cfg, _ := s.app.Config()
+	responseModel := model
+	if resp != nil && resp.ModelVersion != "" {
+		responseModel = resp.ModelVersion
+	}
+
+	for i, c := range contents {
+		text := extractContentText(c)
+		role := c.Role
+		if role == "" {
+			role = genai.RoleUser
+		}
+		data := map[string]interface{}{
+			"id":             uuid.New().String(),
+			"span_id":        spanID,
+			"trace_id":       traceID,
+			"role":           role,
+			"completion_id":  completionID,
+			"sequence":       i,
+			"response.model": responseModel,
+			"vendor":         "gemini",
+			"ingest_source":  "Go",
+		}
+		if cfg.AIMonitoring.RecordContent.Enabled && text != "" {
+			data["content"] = text
+		}
+		if tokens, ok := s.app.InvokeLLMTokenCountCallback(responseModel, text); ok {
+			data["token_count"] = tokens
+		}
+		s.appendCustomAttrs(data)
+		s.app.RecordCustomEvent("LlmChatCompletionMessage", data)
+	}
+
+	if resp == nil {
+		return
+	}
+
+	responseText := extractResponseText(resp)
+	responseSeq := len(contents)
+	responseRole := genai.RoleModel
+	if len(resp.Candidates) > 0 && resp.Candidates[0].Content != nil && resp.Candidates[0].Content.Role != "" {
+		responseRole = resp.Candidates[0].Content.Role
+	}
+	data := map[string]interface{}{
+		"id":             fmt.Sprintf("%s-%d", resp.ResponseID, responseSeq),
+		"span_id":        spanID,
+		"trace_id":       traceID,
+		"role":           responseRole,
+		"completion_id":  completionID,
+		"sequence":       responseSeq,
+		"response.model": responseModel,
+		"vendor":         "gemini",
+		"ingest_source":  "Go",
+		"is_response":    true,
+	}
+	if cfg.AIMonitoring.RecordContent.Enabled && responseText != "" {
+		data["content"] = responseText
+	}
+	if tokens, ok := s.app.InvokeLLMTokenCountCallback(responseModel, responseText); ok {
+		data["token_count"] = tokens
+	}
+	s.appendCustomAttrs(data)
+	s.app.RecordCustomEvent("LlmChatCompletionMessage", data)
+}
+
+func (s *NRModelsService) appendCustomAttrs(data map[string]interface{}) {
+	for k, v := range s.customAttributes {
+		data[k] = v
+	}
+}
+
+func extractContentText(c *genai.Content) string {
+	if c == nil {
+		return ""
+	}
+	var parts []string
+	for _, p := range c.Parts {
+		if p != nil && p.Text != "" {
+			parts = append(parts, p.Text)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func extractResponseText(resp *genai.GenerateContentResponse) string {
+	if resp == nil || len(resp.Candidates) == 0 || resp.Candidates[0].Content == nil {
+		return ""
+	}
+	var parts []string
+	for _, p := range resp.Candidates[0].Content.Parts {
+		if p != nil && p.Text != "" {
+			parts = append(parts, p.Text)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// NRGenerateContentStreamWrapper wraps a GenAI streaming iterator with New Relic
+// instrumentation. Call Next() to advance the stream, Current() to read the
+// current chunk, Err() to check for errors, and Close() to flush NR events and
+// release resources.
+type NRGenerateContentStreamWrapper struct {
+	next             func() (*genai.GenerateContentResponse, error, bool)
+	stop             func()
+	err              error
+	current          *genai.GenerateContentResponse
+	app              *newrelic.Application
+	txn              *newrelic.Transaction
+	txnOwned         bool
+	seg              *newrelic.Segment
+	customAttributes map[string]interface{}
+	model            string
+	contents         []*genai.Content
+	config           *genai.GenerateContentConfig
+	completionID     string
+	spanID           string
+	traceID          string
+	responseText     strings.Builder
+	responseID       string
+	responseModel    string
+	finishReason     string
+	responseRole     string
+	start            time.Time
+	closed           bool
+}
+
+// GenerateContentStream wraps client.Models.GenerateContentStream with New Relic
+// instrumentation. The returned wrapper exposes Next/Current/Err/Close. Call
+// Close() after the stream is consumed to record NR events.
+func (s *NRModelsService) GenerateContentStream(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig) *NRGenerateContentStreamWrapper {
+	cfg, _ := s.app.Config()
+
+	if !cfg.AIMonitoring.Streaming.Enabled {
+		if reportStreamingDisabled != nil {
+			reportStreamingDisabled()
+		}
+	}
+
+	seq := s.models.GenerateContentStream(ctx, model, contents, config)
+	next, stop := iter.Pull2(seq)
+
+	if !cfg.AIMonitoring.Enabled || !cfg.AIMonitoring.Streaming.Enabled {
+		return &NRGenerateContentStreamWrapper{
+			app:      s.app,
+			model:    model,
+			contents: contents,
+			config:   config,
+			next:     next,
+			stop:     stop,
+			start:    time.Now(),
+		}
+	}
+
+	txn := newrelic.FromContext(ctx)
+	txnOwned := false
+	if txn == nil {
+		txn = s.app.StartTransaction("GeminiGenerateContentStream")
+		txnOwned = true
+		ctx = newrelic.NewContext(ctx, txn)
+	}
+
+	integrationsupport.AddAgentAttribute(txn, "llm", "", true)
+	seg := txn.StartSegment("Llm/completion/Gemini/GenerateContentStream")
+
+	return &NRGenerateContentStreamWrapper{
+		app:              s.app,
+		txn:              txn,
+		txnOwned:         txnOwned,
+		seg:              seg,
+		customAttributes: s.customAttributes,
+		model:            model,
+		contents:         contents,
+		config:           config,
+		completionID:     uuid.New().String(),
+		spanID:           txn.GetTraceMetadata().SpanID,
+		traceID:          txn.GetTraceMetadata().TraceID,
+		start:            time.Now(),
+		next:             next,
+		stop:             stop,
+	}
+}
+
+// Next advances the stream to the next chunk and accumulates response state.
+func (w *NRGenerateContentStreamWrapper) Next() bool {
+	chunk, err, ok := w.next()
+	if !ok {
+		return false
+	}
+	if err != nil {
+		w.err = err
+		return false
+	}
+	w.current = chunk
+	if chunk != nil {
+		if chunk.ResponseID != "" {
+			w.responseID = chunk.ResponseID
+		}
+		if chunk.ModelVersion != "" {
+			w.responseModel = chunk.ModelVersion
+		}
+		if len(chunk.Candidates) > 0 {
+			cand := chunk.Candidates[0]
+			if cand.Content != nil {
+				if cand.Content.Role != "" {
+					w.responseRole = cand.Content.Role
+				}
+				for _, p := range cand.Content.Parts {
+					if p != nil && p.Text != "" {
+						w.responseText.WriteString(p.Text)
+					}
+				}
+			}
+			if cand.FinishReason != "" {
+				w.finishReason = string(cand.FinishReason)
+			}
+		}
+	}
+	return true
+}
+
+// Current returns the most recent stream chunk.
+func (w *NRGenerateContentStreamWrapper) Current() *genai.GenerateContentResponse {
+	return w.current
+}
+
+// Err returns any error encountered during streaming.
+func (w *NRGenerateContentStreamWrapper) Err() error {
+	return w.err
+}
+
+// Close records LlmChatCompletionSummary and LlmChatCompletionMessage events,
+// ends the segment, ends the transaction if it was started by this wrapper,
+// and releases the underlying iterator.
+func (w *NRGenerateContentStreamWrapper) Close() error {
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+	w.recordCustomEvent()
+	if w.txnOwned {
+		w.txn.End()
+	}
+	w.stop()
+	return nil
+}
+
+func (w *NRGenerateContentStreamWrapper) recordCustomEvent() {
+	cfg, _ := w.app.Config()
+	if !cfg.AIMonitoring.Enabled || !cfg.AIMonitoring.Streaming.Enabled {
+		return
+	}
+
+	if w.seg != nil {
+		w.seg.End()
+	}
+
+	duration := time.Since(w.start).Milliseconds()
+	isError := w.err != nil
+
+	if isError {
+		w.txn.NoticeError(newrelic.Error{
+			Message: w.err.Error(),
+			Class:   "GeminiError",
+			Attributes: map[string]interface{}{
+				"completion_id": w.completionID,
+			},
+		})
+	}
+
+	model := w.model
+	if w.responseModel != "" {
+		model = w.responseModel
+	}
+
+	summaryData := map[string]interface{}{
+		"id":            w.completionID,
+		"span_id":       w.spanID,
+		"trace_id":      w.traceID,
+		"request.model": w.model,
+		"vendor":        "gemini",
+		"ingest_source": "Go",
+		"duration":      duration,
+	}
+	if w.config != nil {
+		if w.config.MaxOutputTokens != 0 {
+			summaryData["request.max_tokens"] = w.config.MaxOutputTokens
+		}
+		if w.config.Temperature != nil {
+			summaryData["request.temperature"] = *w.config.Temperature
+		}
+	}
+	if isError {
+		summaryData["error"] = true
+		summaryData["response.number_of_messages"] = len(w.contents)
+	} else {
+		summaryData["response.model"] = model
+		if w.finishReason != "" {
+			summaryData["response.choices.finish_reason"] = w.finishReason
+		}
+		summaryData["response.number_of_messages"] = len(w.contents) + 1
+	}
+	w.appendCustomAttrs(summaryData)
+	w.app.RecordCustomEvent("LlmChatCompletionSummary", summaryData)
+
+	for i, c := range w.contents {
+		text := extractContentText(c)
+		role := c.Role
+		if role == "" {
+			role = genai.RoleUser
+		}
+		msgData := map[string]interface{}{
+			"id":             uuid.New().String(),
+			"span_id":        w.spanID,
+			"trace_id":       w.traceID,
+			"role":           role,
+			"completion_id":  w.completionID,
+			"sequence":       i,
+			"response.model": model,
+			"vendor":         "gemini",
+			"ingest_source":  "Go",
+		}
+		if cfg.AIMonitoring.RecordContent.Enabled && text != "" {
+			msgData["content"] = text
+		}
+		if tokens, ok := w.app.InvokeLLMTokenCountCallback(model, text); ok {
+			msgData["token_count"] = tokens
+		}
+		w.appendCustomAttrs(msgData)
+		w.app.RecordCustomEvent("LlmChatCompletionMessage", msgData)
+	}
+
+	if isError {
+		return
+	}
+
+	responseText := w.responseText.String()
+	responseSeq := len(w.contents)
+	responseRole := w.responseRole
+	if responseRole == "" {
+		responseRole = genai.RoleModel
+	}
+	respData := map[string]interface{}{
+		"id":             fmt.Sprintf("%s-%d", w.responseID, responseSeq),
+		"span_id":        w.spanID,
+		"trace_id":       w.traceID,
+		"role":           responseRole,
+		"completion_id":  w.completionID,
+		"sequence":       responseSeq,
+		"response.model": model,
+		"vendor":         "gemini",
+		"ingest_source":  "Go",
+		"is_response":    true,
+	}
+	if cfg.AIMonitoring.RecordContent.Enabled && responseText != "" {
+		respData["content"] = responseText
+	}
+	if tokens, ok := w.app.InvokeLLMTokenCountCallback(model, responseText); ok {
+		respData["token_count"] = tokens
+	}
+	w.appendCustomAttrs(respData)
+	w.app.RecordCustomEvent("LlmChatCompletionMessage", respData)
+}
+
+func (w *NRGenerateContentStreamWrapper) appendCustomAttrs(data map[string]interface{}) {
+	for k, v := range w.customAttributes {
+		data[k] = v
+	}
+}

--- a/v3/integrations/nrgemini/nrgemini_test.go
+++ b/v3/integrations/nrgemini/nrgemini_test.go
@@ -3,11 +3,13 @@ package nrgemini
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/newrelic/go-agent/v3/internal"
 	"github.com/newrelic/go-agent/v3/newrelic"
@@ -20,6 +22,8 @@ const (
 	testPrompt    = "What is 8*5"
 	testResponse  = "Hello there, how may I assist you today?"
 	testMessageID = "resp_abc123"
+	testRequestID = "req_xyz789"
+	testProject   = "my-gcp-project"
 )
 
 // noCodeLevelMetrics disables CLM so code.* agent attributes don't appear in
@@ -123,6 +127,25 @@ func streamingHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// responseText is the text of a response's first candidate.
+func responseText(resp *genai.GenerateContentResponse) string {
+	if resp == nil || len(resp.Candidates) == 0 {
+		return ""
+	}
+	text, _ := candidateText(resp.Candidates[0])
+	return text
+}
+
+// drainStream consumes a stream the way calling code is expected to.
+func drainStream(stream *NRGenerateContentStream) {
+	for chunk, err := range stream.Stream {
+		stream.RecordEvent(chunk, err)
+		if err != nil {
+			break
+		}
+	}
+}
+
 func TestAddCustomAttributes(t *testing.T) {
 	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
 	nrClient := mockGeminiClient(t, app.Application, successHandler)
@@ -166,17 +189,21 @@ func TestGenerateContent(t *testing.T) {
 				"timestamp": internal.MatchAnything,
 			},
 			UserAttributes: map[string]interface{}{
-				"id":                             internal.MatchAnything,
-				"span_id":                        internal.MatchAnything,
-				"trace_id":                       internal.MatchAnything,
-				"request.model":                  testModel,
-				"request.max_tokens":             int32(150),
-				"vendor":                         "gemini",
-				"ingest_source":                  "Go",
-				"duration":                       internal.MatchAnything,
-				"response.model":                 testModel,
-				"response.choices.finish_reason": "STOP",
-				"response.number_of_messages":    2,
+				"id":                               internal.MatchAnything,
+				"span_id":                          internal.MatchAnything,
+				"trace_id":                         internal.MatchAnything,
+				"request_id":                       testMessageID,
+				"request.model":                    testModel,
+				"request.max_tokens":               int32(150),
+				"vendor":                           "gemini",
+				"ingest_source":                    "Go",
+				"duration":                         internal.MatchAnything,
+				"response.model":                   testModel,
+				"response.choices.finish_reason":   "STOP",
+				"response.number_of_messages":      2,
+				"response.usage.prompt_tokens":     int32(9),
+				"response.usage.completion_tokens": int32(12),
+				"response.usage.total_tokens":      int32(21),
 			},
 		},
 		{
@@ -188,6 +215,7 @@ func TestGenerateContent(t *testing.T) {
 				"id":             internal.MatchAnything,
 				"span_id":        internal.MatchAnything,
 				"trace_id":       internal.MatchAnything,
+				"request_id":     testMessageID,
 				"completion_id":  internal.MatchAnything,
 				"sequence":       0,
 				"role":           "user",
@@ -206,6 +234,7 @@ func TestGenerateContent(t *testing.T) {
 				"id":             internal.MatchAnything,
 				"span_id":        internal.MatchAnything,
 				"trace_id":       internal.MatchAnything,
+				"request_id":     testMessageID,
 				"completion_id":  internal.MatchAnything,
 				"sequence":       1,
 				"role":           "model",
@@ -295,6 +324,9 @@ func TestGenerateContentError(t *testing.T) {
 			},
 			UserAttributes: map[string]interface{}{
 				"completion_id": internal.MatchAnything,
+				// Read off the genai.APIError.
+				"http.statusCode": 400,
+				"error.code":      "INVALID_ARGUMENT",
 			},
 			AgentAttributes: map[string]interface{}{
 				"llm": true,
@@ -348,8 +380,7 @@ func TestGenerateContentStream(t *testing.T) {
 
 	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), &genai.GenerateContentConfig{MaxOutputTokens: 150})
 
-	for stream.Next() {
-	}
+	drainStream(stream)
 	if err := stream.Err(); err != nil {
 		t.Fatal(err)
 	}
@@ -367,11 +398,13 @@ func TestGenerateContentStream(t *testing.T) {
 				"id":                             internal.MatchAnything,
 				"span_id":                        internal.MatchAnything,
 				"trace_id":                       internal.MatchAnything,
+				"request_id":                     testMessageID,
 				"request.model":                  testModel,
 				"request.max_tokens":             int32(150),
 				"vendor":                         "gemini",
 				"ingest_source":                  "Go",
 				"duration":                       internal.MatchAnything,
+				"time_to_first_token":            internal.MatchAnything,
 				"response.model":                 testModel,
 				"response.choices.finish_reason": "STOP",
 				"response.number_of_messages":    2,
@@ -386,6 +419,7 @@ func TestGenerateContentStream(t *testing.T) {
 				"id":             internal.MatchAnything,
 				"span_id":        internal.MatchAnything,
 				"trace_id":       internal.MatchAnything,
+				"request_id":     testMessageID,
 				"completion_id":  internal.MatchAnything,
 				"sequence":       0,
 				"role":           "user",
@@ -404,6 +438,7 @@ func TestGenerateContentStream(t *testing.T) {
 				"id":             internal.MatchAnything,
 				"span_id":        internal.MatchAnything,
 				"trace_id":       internal.MatchAnything,
+				"request_id":     testMessageID,
 				"completion_id":  internal.MatchAnything,
 				"sequence":       1,
 				"role":           "model",
@@ -422,8 +457,7 @@ func TestGenerateContentStreamAIMonitoringNotEnabled(t *testing.T) {
 	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
 
 	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
-	for stream.Next() {
-	}
+	drainStream(stream)
 	if err := stream.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -445,12 +479,11 @@ func TestGenerateContentStreamDisabled(t *testing.T) {
 	if stream.txn != nil {
 		t.Error("expected txn to be nil when streaming is disabled, but it was set")
 	}
-	if stream.txnOwned {
-		t.Error("expected txnOwned=false when streaming is disabled")
+	if stream.closeTxn {
+		t.Error("expected closeTxn=false when streaming is disabled")
 	}
 
-	for stream.Next() {
-	}
+	drainStream(stream)
 	if err := stream.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -466,8 +499,7 @@ func TestGenerateContentStreamWithExistingTxn(t *testing.T) {
 	ctx := newrelic.NewContext(context.Background(), txn)
 
 	stream := nrClient.Models.GenerateContentStream(ctx, testModel, genai.Text(testPrompt), nil)
-	for stream.Next() {
-	}
+	drainStream(stream)
 	stream.Close()
 	txn.End()
 
@@ -492,9 +524,156 @@ func TestGenerateContentStreamWithExistingTxn(t *testing.T) {
 	})
 }
 
+func TestProcessContentStream(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	var got strings.Builder
+	err := nrClient.Models.ProcessContentStream(context.Background(), testModel, genai.Text(testPrompt), nil,
+		func(chunk *genai.GenerateContentResponse) error {
+			got.WriteString(responseText(chunk))
+			return nil
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.String() != testResponse {
+		t.Errorf("callback text: got %q, want %q", got.String(), testResponse)
+	}
+
+	// The same three events the manual loop produces.
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionSummary", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":                             internal.MatchAnything,
+				"span_id":                        internal.MatchAnything,
+				"trace_id":                       internal.MatchAnything,
+				"request_id":                     testMessageID,
+				"request.model":                  testModel,
+				"vendor":                         "gemini",
+				"ingest_source":                  "Go",
+				"duration":                       internal.MatchAnything,
+				"time_to_first_token":            internal.MatchAnything,
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "STOP",
+				"response.number_of_messages":    2,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionMessage", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"request_id":     testMessageID,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       0,
+				"role":           "user",
+				"content":        testPrompt,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionMessage", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"request_id":     testMessageID,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       1,
+				"role":           "model",
+				"content":        testResponse,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+				"is_response":    true,
+			},
+		},
+	})
+}
+
+// A callback error stops the stream and is returned, and events are still recorded.
+func TestProcessContentStreamCallbackError(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	calls := 0
+	wantErr := errors.New("caller bailed")
+	err := nrClient.Models.ProcessContentStream(context.Background(), testModel, genai.Text(testPrompt), nil,
+		func(chunk *genai.GenerateContentResponse) error {
+			calls++
+			return wantErr
+		})
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err: got %v, want %v", err, wantErr)
+	}
+	if calls != 1 {
+		t.Errorf("callback calls: got %d, want 1 (stream should stop on error)", calls)
+	}
+
+	// Events are still recorded, covering only the chunks seen before the bail.
+	// The stream itself did not fail, so there is no error attribute and no
+	// finish_reason (that arrives on the second chunk, which was never read).
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionSummary", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":                          internal.MatchAnything,
+				"span_id":                     internal.MatchAnything,
+				"trace_id":                    internal.MatchAnything,
+				"request_id":                  testMessageID,
+				"request.model":               testModel,
+				"vendor":                      "gemini",
+				"ingest_source":               "Go",
+				"duration":                    internal.MatchAnything,
+				"time_to_first_token":         internal.MatchAnything,
+				"response.model":              testModel,
+				"response.number_of_messages": 2,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionMessage", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"request_id":     testMessageID,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       0,
+				"role":           "user",
+				"content":        testPrompt,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionMessage", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"request_id":     testMessageID,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       1,
+				"role":           "model",
+				"content":        testResponse,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+				"is_response":    true,
+			},
+		},
+	})
+}
+
 // --- Pure helper function tests ---
 
-func TestExtractContentText(t *testing.T) {
+func TestContentText(t *testing.T) {
 	tests := []struct {
 		name string
 		in   *genai.Content
@@ -536,14 +715,14 @@ func TestExtractContentText(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := extractContentText(tc.in); got != tc.want {
+			if got, _ := contentText(tc.in); got != tc.want {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
 	}
 }
 
-func TestExtractResponseText(t *testing.T) {
+func TestResponseText(t *testing.T) {
 	tests := []struct {
 		name string
 		in   *genai.GenerateContentResponse
@@ -578,24 +757,24 @@ func TestExtractResponseText(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := extractResponseText(tc.in); got != tc.want {
+			if got := responseText(tc.in); got != tc.want {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
 	}
 }
 
-// --- NRGenerateContentStreamWrapper.appendCustomAttrs tests ---
+// --- NRModelsService.appendCustomAttrs tests ---
 
-func TestStreamWrapperAppendCustomAttrs(t *testing.T) {
-	w := &NRGenerateContentStreamWrapper{
+func TestAppendCustomAttrs(t *testing.T) {
+	s := &NRModelsService{
 		customAttributes: map[string]interface{}{
 			"llm.key1": "val1",
 			"llm.key2": 42,
 		},
 	}
 	data := map[string]interface{}{"existing": "preserved"}
-	w.appendCustomAttrs(data)
+	s.appendCustomAttrs(data)
 
 	if data["llm.key1"] != "val1" {
 		t.Errorf("llm.key1: got %v, want val1", data["llm.key1"])
@@ -608,10 +787,10 @@ func TestStreamWrapperAppendCustomAttrs(t *testing.T) {
 	}
 }
 
-func TestStreamWrapperAppendCustomAttrsEmpty(t *testing.T) {
-	w := &NRGenerateContentStreamWrapper{customAttributes: map[string]interface{}{}}
+func TestAppendCustomAttrsEmpty(t *testing.T) {
+	s := &NRModelsService{customAttributes: map[string]interface{}{}}
 	data := map[string]interface{}{"k": "v"}
-	w.appendCustomAttrs(data)
+	s.appendCustomAttrs(data)
 	if len(data) != 1 || data["k"] != "v" {
 		t.Errorf("data should be unchanged, got %v", data)
 	}
@@ -666,6 +845,23 @@ func baseConfig() *genai.GenerateContentConfig {
 	return &genai.GenerateContentConfig{MaxOutputTokens: 150}
 }
 
+var errTest = errors.New("test error")
+
+// newTestCompletion uses the fixed ids the event assertions expect.
+func newTestCompletion(config *genai.GenerateContentConfig, resp *genai.GenerateContentResponse, err error, duration int64) *completion {
+	return &completion{
+		id:       "cid",
+		spanID:   "sid",
+		traceID:  "tid",
+		model:    testModel,
+		contents: baseContents(),
+		config:   config,
+		resp:     resp,
+		err:      err,
+		duration: duration,
+	}
+}
+
 func TestRecordSummarySuccess(t *testing.T) {
 	svc, app := newTestService(t)
 	resp := &genai.GenerateContentResponse{
@@ -676,7 +872,7 @@ func TestRecordSummarySuccess(t *testing.T) {
 		},
 	}
 
-	svc.recordSummary("cid", "sid", "tid", testModel, baseConfig(), baseContents(), resp, 100, false)
+	svc.recordSummary(newTestCompletion(baseConfig(), resp, nil, 100))
 
 	app.ExpectCustomEvents(t, []internal.WantEvent{
 		{
@@ -688,6 +884,7 @@ func TestRecordSummarySuccess(t *testing.T) {
 				"id":                             "cid",
 				"span_id":                        "sid",
 				"trace_id":                       "tid",
+				"request_id":                     testMessageID,
 				"request.model":                  testModel,
 				"request.max_tokens":             int32(150),
 				"vendor":                         "gemini",
@@ -704,7 +901,7 @@ func TestRecordSummarySuccess(t *testing.T) {
 func TestRecordSummaryError(t *testing.T) {
 	svc, app := newTestService(t)
 
-	svc.recordSummary("cid", "sid", "tid", testModel, baseConfig(), baseContents(), nil, 50, true)
+	svc.recordSummary(newTestCompletion(baseConfig(), nil, errTest, 50))
 
 	app.ExpectCustomEvents(t, []internal.WantEvent{
 		{
@@ -743,7 +940,7 @@ func TestRecordSummaryWithTemperature(t *testing.T) {
 		},
 	}
 
-	svc.recordSummary("cid", "sid", "tid", testModel, config, baseContents(), resp, 10, false)
+	svc.recordSummary(newTestCompletion(config, resp, nil, 10))
 
 	app.ExpectCustomEvents(t, []internal.WantEvent{
 		{
@@ -755,6 +952,7 @@ func TestRecordSummaryWithTemperature(t *testing.T) {
 				"id":                             "cid",
 				"span_id":                        "sid",
 				"trace_id":                       "tid",
+				"request_id":                     testMessageID,
 				"request.model":                  testModel,
 				"request.max_tokens":             int32(150),
 				"request.temperature":            float32(0.5),
@@ -779,7 +977,7 @@ func TestRecordSummaryCustomAttrs(t *testing.T) {
 		},
 	}
 
-	svc.recordSummary("cid", "sid", "tid", testModel, baseConfig(), baseContents(), resp, 10, false)
+	svc.recordSummary(newTestCompletion(baseConfig(), resp, nil, 10))
 
 	app.ExpectCustomEvents(t, []internal.WantEvent{
 		{
@@ -814,7 +1012,7 @@ func TestRecordSummaryNilConfig(t *testing.T) {
 		},
 	}
 
-	svc.recordSummary("cid", "sid", "tid", testModel, nil, baseContents(), resp, 10, false)
+	svc.recordSummary(newTestCompletion(nil, resp, nil, 10))
 
 	// no request.max_tokens or request.temperature should be recorded when config is nil
 	app.ExpectCustomEvents(t, []internal.WantEvent{
@@ -854,7 +1052,7 @@ func TestRecordMessagesWithResp(t *testing.T) {
 		},
 	}
 
-	svc.recordMessages("cid", "sid", "tid", testModel, baseContents(), resp)
+	svc.recordMessages(newTestCompletion(nil, resp, nil, 0))
 
 	app.ExpectCustomEvents(t, []internal.WantEvent{
 		{
@@ -866,6 +1064,7 @@ func TestRecordMessagesWithResp(t *testing.T) {
 				"id":             internal.MatchAnything,
 				"span_id":        "sid",
 				"trace_id":       "tid",
+				"request_id":     testMessageID,
 				"role":           "user",
 				"completion_id":  "cid",
 				"sequence":       0,
@@ -884,6 +1083,7 @@ func TestRecordMessagesWithResp(t *testing.T) {
 				"id":             fmt.Sprintf("%s-%d", testMessageID, 1),
 				"span_id":        "sid",
 				"trace_id":       "tid",
+				"request_id":     testMessageID,
 				"role":           "model",
 				"completion_id":  "cid",
 				"sequence":       1,
@@ -900,7 +1100,7 @@ func TestRecordMessagesWithResp(t *testing.T) {
 func TestRecordMessagesNilResp(t *testing.T) {
 	svc, app := newTestService(t)
 
-	svc.recordMessages("cid", "sid", "tid", testModel, baseContents(), nil)
+	svc.recordMessages(newTestCompletion(nil, nil, nil, 0))
 
 	app.ExpectCustomEvents(t, []internal.WantEvent{
 		{
@@ -945,7 +1145,7 @@ func TestRecordMessagesContentDisabled(t *testing.T) {
 		},
 	}
 
-	svc.recordMessages("cid", "sid", "tid", testModel, baseContents(), resp)
+	svc.recordMessages(newTestCompletion(nil, resp, nil, 0))
 
 	app.ExpectCustomEvents(t, []internal.WantEvent{
 		{
@@ -957,6 +1157,7 @@ func TestRecordMessagesContentDisabled(t *testing.T) {
 				"id":             internal.MatchAnything,
 				"span_id":        "sid",
 				"trace_id":       "tid",
+				"request_id":     testMessageID,
 				"role":           "user",
 				"completion_id":  "cid",
 				"sequence":       0,
@@ -974,6 +1175,7 @@ func TestRecordMessagesContentDisabled(t *testing.T) {
 				"id":             fmt.Sprintf("%s-%d", testMessageID, 1),
 				"span_id":        "sid",
 				"trace_id":       "tid",
+				"request_id":     testMessageID,
 				"role":           "model",
 				"completion_id":  "cid",
 				"sequence":       1,
@@ -986,61 +1188,87 @@ func TestRecordMessagesContentDisabled(t *testing.T) {
 	})
 }
 
-// --- NRGenerateContentStreamWrapper.Next state accumulation ---
+// --- NRGenerateContentStream.RecordEvent state accumulation ---
 
-func TestStreamWrapperNextAccumulatesState(t *testing.T) {
+func TestStreamRecordEventAccumulatesState(t *testing.T) {
 	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
 	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
 
 	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
 
-	for stream.Next() {
-	}
+	drainStream(stream)
 	if err := stream.Err(); err != nil {
 		t.Fatal(err)
 	}
 
-	if stream.responseID != testMessageID {
-		t.Errorf("responseID: got %q, want %q", stream.responseID, testMessageID)
+	if stream.completion.resp == nil {
+		t.Fatal("expected accumulated response, got nil")
 	}
-	if stream.responseModel != testModel {
-		t.Errorf("responseModel: got %q, want %q", stream.responseModel, testModel)
+	if stream.completion.resp.ResponseID != testMessageID {
+		t.Errorf("ResponseID: got %q, want %q", stream.completion.resp.ResponseID, testMessageID)
 	}
-	if got := stream.responseText.String(); got != testResponse {
-		t.Errorf("responseText: got %q, want %q", got, testResponse)
+	if stream.completion.resp.ModelVersion != testModel {
+		t.Errorf("ModelVersion: got %q, want %q", stream.completion.resp.ModelVersion, testModel)
 	}
-	if stream.finishReason != "STOP" {
-		t.Errorf("finishReason: got %q, want %q", stream.finishReason, "STOP")
+	if got := responseText(stream.response()); got != testResponse {
+		t.Errorf("response text: got %q, want %q", got, testResponse)
 	}
-	if stream.responseRole != genai.RoleModel {
-		t.Errorf("responseRole: got %q, want %q", stream.responseRole, genai.RoleModel)
+	cand := stream.completion.resp.Candidates[0]
+	if cand.FinishReason != genai.FinishReasonStop {
+		t.Errorf("FinishReason: got %q, want %q", cand.FinishReason, genai.FinishReasonStop)
+	}
+	if cand.Content.Role != genai.RoleModel {
+		t.Errorf("Role: got %q, want %q", cand.Content.Role, genai.RoleModel)
 	}
 
 	stream.Close()
 }
 
-// --- NRGenerateContentStreamWrapper.Close tests ---
+// Deltas concatenate verbatim: extractResponseText joins separate Parts with a
+// space, so one Part is what keeps the content identical to what the caller saw.
+func TestStreamRecordEventConcatenatesDeltas(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	svc := &NRModelsService{app: app.Application, customAttributes: map[string]interface{}{}}
+	txn := app.StartTransaction("deltas")
+	w := &NRGenerateContentStream{svc: svc, txn: txn, completion: &completion{model: testModel}}
 
-func TestStreamWrapperCloseReturnsNilOnSuccess(t *testing.T) {
+	for _, delta := range []string{"Hel", "lo", " wor", "ld"} {
+		w.RecordEvent(&genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{{
+				Content: &genai.Content{
+					Role:  genai.RoleModel,
+					Parts: []*genai.Part{{Text: delta}},
+				},
+			}},
+		}, nil)
+	}
+
+	if got := responseText(w.response()); got != "Hello world" {
+		t.Errorf("response text: got %q, want %q", got, "Hello world")
+	}
+	txn.End()
+}
+
+// --- NRGenerateContentStream.Close tests ---
+
+func TestStreamCloseReturnsNilOnSuccess(t *testing.T) {
 	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
 	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
 
 	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
-	for stream.Next() {
-	}
+	drainStream(stream)
 
 	if err := stream.Close(); err != nil {
 		t.Errorf("Close() returned unexpected error: %v", err)
 	}
 }
 
-func TestStreamWrapperCloseIdempotent(t *testing.T) {
+func TestStreamCloseIdempotent(t *testing.T) {
 	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
 	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
 
 	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
-	for stream.Next() {
-	}
+	drainStream(stream)
 
 	if err := stream.Close(); err != nil {
 		t.Fatal(err)
@@ -1051,14 +1279,13 @@ func TestStreamWrapperCloseIdempotent(t *testing.T) {
 	}
 }
 
-func TestStreamWrapperCloseEndsTxnWhenOwned(t *testing.T) {
+func TestStreamCloseEndsTxnWhenOwned(t *testing.T) {
 	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
 	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
 
-	// No txn in context — wrapper creates and owns the transaction.
+	// No txn in context — the stream creates and owns the transaction.
 	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
-	for stream.Next() {
-	}
+	drainStream(stream)
 	stream.Close()
 
 	app.ExpectTxnEvents(t, []internal.WantEvent{
@@ -1080,20 +1307,19 @@ func TestStreamWrapperCloseEndsTxnWhenOwned(t *testing.T) {
 	})
 }
 
-func TestStreamWrapperCloseNoTxnEndWhenNotOwned(t *testing.T) {
+func TestStreamCloseNoTxnEndWhenNotOwned(t *testing.T) {
 	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
 	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
 
-	// Inject an existing txn — wrapper must NOT end it.
+	// Inject an existing txn — the stream must NOT end it.
 	txn := app.StartTransaction("caller-txn")
 	ctx := newrelic.NewContext(context.Background(), txn)
 
 	stream := nrClient.Models.GenerateContentStream(ctx, testModel, genai.Text(testPrompt), nil)
-	for stream.Next() {
-	}
+	drainStream(stream)
 	stream.Close()
 
-	// Txn is still open; end it explicitly and verify the name is caller-txn, not the wrapper name.
+	// Txn is still open; end it explicitly and verify the name is caller-txn.
 	txn.End()
 
 	app.ExpectTxnEvents(t, []internal.WantEvent{
@@ -1134,7 +1360,7 @@ func TestGenerateContentLongPromptNotTruncated(t *testing.T) {
 		},
 	}
 
-	svc.recordMessages("cid", "sid", "tid", testModel, genai.Text(longPrompt), resp)
+	svc.recordMessages(&completion{id: "cid", spanID: "sid", traceID: "tid", model: testModel, contents: genai.Text(longPrompt), resp: resp})
 
 	app.ExpectCustomEvents(t, []internal.WantEvent{
 		{
@@ -1146,6 +1372,7 @@ func TestGenerateContentLongPromptNotTruncated(t *testing.T) {
 				"id":             internal.MatchAnything,
 				"span_id":        "sid",
 				"trace_id":       "tid",
+				"request_id":     testMessageID,
 				"role":           "user",
 				"completion_id":  "cid",
 				"sequence":       0,
@@ -1164,6 +1391,7 @@ func TestGenerateContentLongPromptNotTruncated(t *testing.T) {
 				"id":             fmt.Sprintf("%s-%d", testMessageID, 1),
 				"span_id":        "sid",
 				"trace_id":       "tid",
+				"request_id":     testMessageID,
 				"role":           "model",
 				"completion_id":  "cid",
 				"sequence":       1,
@@ -1175,4 +1403,381 @@ func TestGenerateContentLongPromptNotTruncated(t *testing.T) {
 			},
 		},
 	})
+}
+
+// --- Multiple candidates ---
+
+// Each candidate is its own response message.
+func TestRecordMessagesMultipleCandidates(t *testing.T) {
+	svc, app := newTestService(t)
+	resp := &genai.GenerateContentResponse{
+		ResponseID:   testMessageID,
+		ModelVersion: testModel,
+		Candidates: []*genai.Candidate{
+			{Content: &genai.Content{Role: genai.RoleModel, Parts: []*genai.Part{{Text: "first"}}}},
+			{Content: &genai.Content{Role: genai.RoleModel, Parts: []*genai.Part{{Text: "second"}}}},
+		},
+	}
+	svc.recordMessages(newTestCompletion(nil, resp, nil, 0))
+
+	events := []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionMessage", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"request_id":     testMessageID,
+				"completion_id":  "cid",
+				"sequence":       0,
+				"role":           "user",
+				"content":        testPrompt,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+			},
+		},
+	}
+	for i, text := range []string{"first", "second"} {
+		events = append(events, internal.WantEvent{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionMessage", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":             fmt.Sprintf("%s-%d", testMessageID, i+1),
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"request_id":     testMessageID,
+				"completion_id":  "cid",
+				"sequence":       i + 1,
+				"role":           "model",
+				"content":        text,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+				"is_response":    true,
+			},
+		})
+	}
+	app.ExpectCustomEvents(t, events)
+}
+
+// number_of_messages counts every candidate.
+func TestRecordSummaryMultipleCandidates(t *testing.T) {
+	svc, app := newTestService(t)
+	resp := &genai.GenerateContentResponse{
+		ResponseID:   testMessageID,
+		ModelVersion: testModel,
+		Candidates: []*genai.Candidate{
+			// No reason here, so the summary takes the next candidate's.
+			{},
+			{FinishReason: genai.FinishReasonMaxTokens},
+		},
+	}
+	svc.recordSummary(newTestCompletion(nil, resp, nil, 10))
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionSummary", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":                             "cid",
+				"span_id":                        "sid",
+				"trace_id":                       "tid",
+				"request_id":                     testMessageID,
+				"request.model":                  testModel,
+				"vendor":                         "gemini",
+				"ingest_source":                  "Go",
+				"duration":                       10,
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "MAX_TOKENS",
+				"response.number_of_messages":    3,
+			},
+		},
+	})
+}
+
+// --- Roles ---
+
+func TestRoleDefaults(t *testing.T) {
+	// Requests default to "user".
+	if got := contentRole(&genai.Content{}); got != genai.RoleUser {
+		t.Errorf("contentRole with no role: got %q, want %q", got, genai.RoleUser)
+	}
+	if got := contentRole(nil); got != genai.RoleUser {
+		t.Errorf("contentRole(nil): got %q, want %q", got, genai.RoleUser)
+	}
+	// Responses default to "assistant".
+	if got := candidateRole(&genai.Candidate{Content: &genai.Content{}}); got != roleAssistant {
+		t.Errorf("candidateRole with no role: got %q, want %q", got, roleAssistant)
+	}
+	if got := candidateRole(nil); got != roleAssistant {
+		t.Errorf("candidateRole(nil): got %q, want %q", got, roleAssistant)
+	}
+	// Gemini's own role passes through.
+	if got := candidateRole(&genai.Candidate{Content: &genai.Content{Role: genai.RoleModel}}); got != genai.RoleModel {
+		t.Errorf("candidateRole: got %q, want %q", got, genai.RoleModel)
+	}
+}
+
+// --- Message ids ---
+
+func TestMessageID(t *testing.T) {
+	withID := &completion{resp: &genai.GenerateContentResponse{ResponseID: testMessageID}}
+	if got, want := withID.messageID(2), testMessageID+"-2"; got != want {
+		t.Errorf("messageID: got %q, want %q", got, want)
+	}
+
+	// No response ID means a UUID, never a bare "-<sequence>".
+	for _, c := range []*completion{
+		{resp: &genai.GenerateContentResponse{}},
+		{},
+	} {
+		got := c.messageID(0)
+		if strings.HasPrefix(got, "-") || got == "" {
+			t.Errorf("messageID fallback should be a UUID, got %q", got)
+		}
+		if len(got) != len("00000000-0000-0000-0000-000000000000") {
+			t.Errorf("messageID fallback is not UUID-shaped: %q", got)
+		}
+	}
+}
+
+// --- request_id and response headers ---
+
+func TestRequestIDPrefersHeaderOverResponseID(t *testing.T) {
+	hdr := http.Header{}
+	hdr.Set("X-Goog-Request-Id", testRequestID)
+	c := &completion{resp: &genai.GenerateContentResponse{
+		ResponseID:      testMessageID,
+		SDKHTTPResponse: &genai.HTTPResponse{Headers: hdr},
+	}}
+	if got := c.requestID(); got != testRequestID {
+		t.Errorf("requestID: got %q, want the header value %q", got, testRequestID)
+	}
+
+	// No header: the response ID stands in.
+	c.resp.SDKHTTPResponse = nil
+	if got := c.requestID(); got != testMessageID {
+		t.Errorf("requestID fallback: got %q, want %q", got, testMessageID)
+	}
+
+	// A failed call has neither.
+	if got := (&completion{}).requestID(); got != "" {
+		t.Errorf("requestID with no response: got %q, want empty", got)
+	}
+}
+
+func TestAddHeaderAttrs(t *testing.T) {
+	hdr := http.Header{}
+	hdr.Set("X-Goog-User-Project", testProject)
+	hdr.Set("X-Ratelimit-Limit-Requests", "200")
+	hdr.Set("X-Ratelimit-Reset-Tokens", "2ms")
+
+	data := map[string]interface{}{}
+	addHeaderAttrs(data, hdr)
+
+	want := map[string]interface{}{
+		"response.organization":                   testProject,
+		"response.headers.ratelimitLimitRequests": "200",
+		"response.headers.ratelimitResetTokens":   "2ms",
+	}
+	for k, v := range want {
+		if data[k] != v {
+			t.Errorf("%s: got %v, want %v", k, data[k], v)
+		}
+	}
+	// Absent headers are omitted.
+	if len(data) != len(want) {
+		t.Errorf("unexpected extra attributes: %v", data)
+	}
+
+	// No headers: event untouched.
+	empty := map[string]interface{}{}
+	addHeaderAttrs(empty, nil)
+	if len(empty) != 0 {
+		t.Errorf("expected no attributes, got %v", empty)
+	}
+}
+
+// --- time_to_first_token ---
+
+// Only the first chunk sets it. TestGenerateContent covers the other half: its
+// summary is asserted exactly and carries no such attribute.
+func TestTimeToFirstTokenSetOnceByFirstChunk(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
+	drainStream(stream)
+
+	if stream.completion.timeToFirstToken == nil {
+		t.Fatal("expected the first chunk to record a time to first token")
+	}
+	first := *stream.completion.timeToFirstToken
+	if first < 0 {
+		t.Errorf("timeToFirstToken: got %d, want >= 0", first)
+	}
+
+	// A later chunk must not move it.
+	stream.RecordEvent(&genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{{
+			Content: &genai.Content{Parts: []*genai.Part{{Text: "later"}}},
+		}},
+	}, nil)
+	if got := *stream.completion.timeToFirstToken; got != first {
+		t.Errorf("timeToFirstToken moved: got %d, want %d", got, first)
+	}
+
+	stream.Close()
+}
+
+// --- Non-text parts ---
+
+// Parts carrying data other than text hold no message content: they are left out
+// of the content attribute and counted so the caller can log them.
+func TestContentTextSkipsNonTextParts(t *testing.T) {
+	content := &genai.Content{
+		Role: genai.RoleUser,
+		Parts: []*genai.Part{
+			{Text: "look at this"},
+			{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte{1, 2, 3}}},
+			{FunctionCall: &genai.FunctionCall{Name: "get_weather"}},
+			nil,
+			{Text: "and this"},
+		},
+	}
+	text, skipped := contentText(content)
+	if want := "look at this and this"; text != want {
+		t.Errorf("text: got %q, want %q", text, want)
+	}
+	// The blob and the function call; the nil part is not a dropped part.
+	if skipped != 2 {
+		t.Errorf("skipped: got %d, want 2", skipped)
+	}
+
+	if _, skipped := contentText(&genai.Content{Parts: []*genai.Part{{Text: "all text"}}}); skipped != 0 {
+		t.Errorf("skipped: got %d, want 0", skipped)
+	}
+}
+
+// A message whose parts are all non-text still records, just without content.
+func TestRecordMessagesNonTextOnly(t *testing.T) {
+	svc, app := newTestService(t)
+	c := &completion{
+		id:      "cid",
+		spanID:  "sid",
+		traceID: "tid",
+		model:   testModel,
+		contents: []*genai.Content{{
+			Role:  genai.RoleUser,
+			Parts: []*genai.Part{{InlineData: &genai.Blob{MIMEType: "image/png"}}},
+		}},
+	}
+	svc.recordMessages(c)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionMessage", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"completion_id":  "cid",
+				"sequence":       0,
+				"role":           "user",
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+			},
+		},
+	})
+}
+
+// --- Delta accumulation ---
+
+// Deltas go into a strings.Builder per candidate, so a long stream stays linear
+// rather than recopying the accumulated text on every chunk.
+func TestStreamAccumulatesManyChunksLinearly(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	svc := &NRModelsService{app: app.Application, customAttributes: map[string]interface{}{}}
+	txn := app.StartTransaction("many-chunks")
+	w := &NRGenerateContentStream{svc: svc, txn: txn, completion: &completion{model: testModel}}
+
+	var want strings.Builder
+	for i := 0; i < 500; i++ {
+		delta := fmt.Sprintf("chunk%d ", i)
+		want.WriteString(delta)
+		w.RecordEvent(&genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{{
+				Content: &genai.Content{Role: genai.RoleModel, Parts: []*genai.Part{{Text: delta}}},
+			}},
+		}, nil)
+	}
+
+	if got := responseText(w.response()); got != want.String() {
+		t.Errorf("accumulated text mismatch: got %d bytes, want %d", len(got), want.Len())
+	}
+	txn.End()
+}
+
+// Each candidate accumulates its own deltas.
+func TestStreamAccumulatesPerCandidate(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	svc := &NRModelsService{app: app.Application, customAttributes: map[string]interface{}{}}
+	txn := app.StartTransaction("two-candidates")
+	w := &NRGenerateContentStream{svc: svc, txn: txn, completion: &completion{model: testModel}}
+
+	for _, deltas := range [][2]string{{"one ", "two "}, {"first", "second"}} {
+		chunk := &genai.GenerateContentResponse{}
+		for _, d := range deltas {
+			chunk.Candidates = append(chunk.Candidates, &genai.Candidate{
+				Content: &genai.Content{Role: genai.RoleModel, Parts: []*genai.Part{{Text: d}}},
+			})
+		}
+		w.RecordEvent(chunk, nil)
+	}
+
+	resp := w.response()
+	if len(resp.Candidates) != 2 {
+		t.Fatalf("candidates: got %d, want 2", len(resp.Candidates))
+	}
+	for i, want := range []string{"one first", "two second"} {
+		if got, _ := candidateText(resp.Candidates[i]); got != want {
+			t.Errorf("candidate %d: got %q, want %q", i, got, want)
+		}
+	}
+	txn.End()
+}
+
+// A Close that runs long after the stream finished — a deferred one, say — must
+// not stretch the reported duration past when the chunks actually arrived.
+func TestStreamDurationStampedAsChunksArrive(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
+	drainStream(stream)
+
+	atDrain := stream.completion.duration
+	time.Sleep(25 * time.Millisecond)
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if stream.completion.duration != atDrain {
+		t.Errorf("duration moved after the delay: got %d, want %d",
+			stream.completion.duration, atDrain)
+	}
+}
+
+// A stream nothing was ever reported for still gets a duration measured at Close.
+func TestStreamDurationWhenNothingRecorded(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
+	time.Sleep(5 * time.Millisecond)
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if stream.completion.duration <= 0 {
+		t.Errorf("duration: got %d, want > 0", stream.completion.duration)
+	}
 }

--- a/v3/integrations/nrgemini/nrgemini_test.go
+++ b/v3/integrations/nrgemini/nrgemini_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"iter"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -137,15 +138,6 @@ func responseText(resp *genai.GenerateContentResponse) string {
 }
 
 // drainStream consumes a stream the way calling code is expected to.
-func drainStream(stream *NRGenerateContentStream) {
-	for chunk, err := range stream.Stream {
-		stream.RecordEvent(chunk, err)
-		if err != nil {
-			break
-		}
-	}
-}
-
 func TestAddCustomAttributes(t *testing.T) {
 	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
 	nrClient := mockGeminiClient(t, app.Application, successHandler)
@@ -373,305 +365,6 @@ func TestGenerateContentWithExistingTxn(t *testing.T) {
 		},
 	})
 }
-
-func TestGenerateContentStream(t *testing.T) {
-	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
-
-	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), &genai.GenerateContentConfig{MaxOutputTokens: 150})
-
-	drainStream(stream)
-	if err := stream.Err(); err != nil {
-		t.Fatal(err)
-	}
-	if err := stream.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	app.ExpectCustomEvents(t, []internal.WantEvent{
-		{
-			Intrinsics: map[string]interface{}{
-				"type":      "LlmChatCompletionSummary",
-				"timestamp": internal.MatchAnything,
-			},
-			UserAttributes: map[string]interface{}{
-				"id":                             internal.MatchAnything,
-				"span_id":                        internal.MatchAnything,
-				"trace_id":                       internal.MatchAnything,
-				"request_id":                     testMessageID,
-				"request.model":                  testModel,
-				"request.max_tokens":             int32(150),
-				"vendor":                         "gemini",
-				"ingest_source":                  "Go",
-				"duration":                       internal.MatchAnything,
-				"time_to_first_token":            internal.MatchAnything,
-				"response.model":                 testModel,
-				"response.choices.finish_reason": "STOP",
-				"response.number_of_messages":    2,
-			},
-		},
-		{
-			Intrinsics: map[string]interface{}{
-				"type":      "LlmChatCompletionMessage",
-				"timestamp": internal.MatchAnything,
-			},
-			UserAttributes: map[string]interface{}{
-				"id":             internal.MatchAnything,
-				"span_id":        internal.MatchAnything,
-				"trace_id":       internal.MatchAnything,
-				"request_id":     testMessageID,
-				"completion_id":  internal.MatchAnything,
-				"sequence":       0,
-				"role":           "user",
-				"content":        testPrompt,
-				"vendor":         "gemini",
-				"ingest_source":  "Go",
-				"response.model": testModel,
-			},
-		},
-		{
-			Intrinsics: map[string]interface{}{
-				"type":      "LlmChatCompletionMessage",
-				"timestamp": internal.MatchAnything,
-			},
-			UserAttributes: map[string]interface{}{
-				"id":             internal.MatchAnything,
-				"span_id":        internal.MatchAnything,
-				"trace_id":       internal.MatchAnything,
-				"request_id":     testMessageID,
-				"completion_id":  internal.MatchAnything,
-				"sequence":       1,
-				"role":           "model",
-				"content":        testResponse,
-				"vendor":         "gemini",
-				"ingest_source":  "Go",
-				"response.model": testModel,
-				"is_response":    true,
-			},
-		},
-	})
-}
-
-func TestGenerateContentStreamAIMonitoringNotEnabled(t *testing.T) {
-	app := integrationsupport.NewTestApp(nil) // AI monitoring NOT enabled
-	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
-
-	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
-	drainStream(stream)
-	if err := stream.Close(); err != nil {
-		t.Fatal(err)
-	}
-	app.ExpectCustomEvents(t, []internal.WantEvent{})
-	app.ExpectTxnEvents(t, []internal.WantEvent{})
-}
-
-func TestGenerateContentStreamDisabled(t *testing.T) {
-	// AI monitoring enabled but streaming specifically disabled — no txn should be started.
-	app := integrationsupport.NewTestApp(nil,
-		newrelic.ConfigAIMonitoringEnabled(true),
-		func(cfg *newrelic.Config) { cfg.AIMonitoring.Streaming.Enabled = false },
-		noCodeLevelMetrics,
-	)
-	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
-
-	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
-
-	if stream.txn != nil {
-		t.Error("expected txn to be nil when streaming is disabled, but it was set")
-	}
-	if stream.closeTxn {
-		t.Error("expected closeTxn=false when streaming is disabled")
-	}
-
-	drainStream(stream)
-	if err := stream.Close(); err != nil {
-		t.Fatal(err)
-	}
-	app.ExpectCustomEvents(t, []internal.WantEvent{})
-	app.ExpectTxnEvents(t, []internal.WantEvent{})
-}
-
-func TestGenerateContentStreamWithExistingTxn(t *testing.T) {
-	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
-
-	txn := app.StartTransaction("my-existing-streaming-txn")
-	ctx := newrelic.NewContext(context.Background(), txn)
-
-	stream := nrClient.Models.GenerateContentStream(ctx, testModel, genai.Text(testPrompt), nil)
-	drainStream(stream)
-	stream.Close()
-	txn.End()
-
-	app.ExpectTxnEvents(t, []internal.WantEvent{
-		{
-			Intrinsics: map[string]interface{}{
-				"type":      "Transaction",
-				"name":      "OtherTransaction/Go/my-existing-streaming-txn",
-				"guid":      internal.MatchAnything,
-				"priority":  internal.MatchAnything,
-				"sampled":   internal.MatchAnything,
-				"traceId":   internal.MatchAnything,
-				"timestamp": internal.MatchAnything,
-				"duration":  internal.MatchAnything,
-				"totalTime": internal.MatchAnything,
-			},
-			UserAttributes: map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{
-				"llm": true,
-			},
-		},
-	})
-}
-
-func TestProcessContentStream(t *testing.T) {
-	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
-
-	var got strings.Builder
-	err := nrClient.Models.ProcessContentStream(context.Background(), testModel, genai.Text(testPrompt), nil,
-		func(chunk *genai.GenerateContentResponse) error {
-			got.WriteString(responseText(chunk))
-			return nil
-		})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.String() != testResponse {
-		t.Errorf("callback text: got %q, want %q", got.String(), testResponse)
-	}
-
-	// The same three events the manual loop produces.
-	app.ExpectCustomEvents(t, []internal.WantEvent{
-		{
-			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionSummary", "timestamp": internal.MatchAnything},
-			UserAttributes: map[string]interface{}{
-				"id":                             internal.MatchAnything,
-				"span_id":                        internal.MatchAnything,
-				"trace_id":                       internal.MatchAnything,
-				"request_id":                     testMessageID,
-				"request.model":                  testModel,
-				"vendor":                         "gemini",
-				"ingest_source":                  "Go",
-				"duration":                       internal.MatchAnything,
-				"time_to_first_token":            internal.MatchAnything,
-				"response.model":                 testModel,
-				"response.choices.finish_reason": "STOP",
-				"response.number_of_messages":    2,
-			},
-		},
-		{
-			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionMessage", "timestamp": internal.MatchAnything},
-			UserAttributes: map[string]interface{}{
-				"id":             internal.MatchAnything,
-				"span_id":        internal.MatchAnything,
-				"trace_id":       internal.MatchAnything,
-				"request_id":     testMessageID,
-				"completion_id":  internal.MatchAnything,
-				"sequence":       0,
-				"role":           "user",
-				"content":        testPrompt,
-				"vendor":         "gemini",
-				"ingest_source":  "Go",
-				"response.model": testModel,
-			},
-		},
-		{
-			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionMessage", "timestamp": internal.MatchAnything},
-			UserAttributes: map[string]interface{}{
-				"id":             internal.MatchAnything,
-				"span_id":        internal.MatchAnything,
-				"trace_id":       internal.MatchAnything,
-				"request_id":     testMessageID,
-				"completion_id":  internal.MatchAnything,
-				"sequence":       1,
-				"role":           "model",
-				"content":        testResponse,
-				"vendor":         "gemini",
-				"ingest_source":  "Go",
-				"response.model": testModel,
-				"is_response":    true,
-			},
-		},
-	})
-}
-
-// A callback error stops the stream and is returned, and events are still recorded.
-func TestProcessContentStreamCallbackError(t *testing.T) {
-	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
-
-	calls := 0
-	wantErr := errors.New("caller bailed")
-	err := nrClient.Models.ProcessContentStream(context.Background(), testModel, genai.Text(testPrompt), nil,
-		func(chunk *genai.GenerateContentResponse) error {
-			calls++
-			return wantErr
-		})
-	if !errors.Is(err, wantErr) {
-		t.Errorf("err: got %v, want %v", err, wantErr)
-	}
-	if calls != 1 {
-		t.Errorf("callback calls: got %d, want 1 (stream should stop on error)", calls)
-	}
-
-	// Events are still recorded, covering only the chunks seen before the bail.
-	// The stream itself did not fail, so there is no error attribute and no
-	// finish_reason (that arrives on the second chunk, which was never read).
-	app.ExpectCustomEvents(t, []internal.WantEvent{
-		{
-			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionSummary", "timestamp": internal.MatchAnything},
-			UserAttributes: map[string]interface{}{
-				"id":                          internal.MatchAnything,
-				"span_id":                     internal.MatchAnything,
-				"trace_id":                    internal.MatchAnything,
-				"request_id":                  testMessageID,
-				"request.model":               testModel,
-				"vendor":                      "gemini",
-				"ingest_source":               "Go",
-				"duration":                    internal.MatchAnything,
-				"time_to_first_token":         internal.MatchAnything,
-				"response.model":              testModel,
-				"response.number_of_messages": 2,
-			},
-		},
-		{
-			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionMessage", "timestamp": internal.MatchAnything},
-			UserAttributes: map[string]interface{}{
-				"id":             internal.MatchAnything,
-				"span_id":        internal.MatchAnything,
-				"trace_id":       internal.MatchAnything,
-				"request_id":     testMessageID,
-				"completion_id":  internal.MatchAnything,
-				"sequence":       0,
-				"role":           "user",
-				"content":        testPrompt,
-				"vendor":         "gemini",
-				"ingest_source":  "Go",
-				"response.model": testModel,
-			},
-		},
-		{
-			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionMessage", "timestamp": internal.MatchAnything},
-			UserAttributes: map[string]interface{}{
-				"id":             internal.MatchAnything,
-				"span_id":        internal.MatchAnything,
-				"trace_id":       internal.MatchAnything,
-				"request_id":     testMessageID,
-				"completion_id":  internal.MatchAnything,
-				"sequence":       1,
-				"role":           "model",
-				"content":        testResponse,
-				"vendor":         "gemini",
-				"ingest_source":  "Go",
-				"response.model": testModel,
-				"is_response":    true,
-			},
-		},
-	})
-}
-
-// --- Pure helper function tests ---
 
 func TestContentText(t *testing.T) {
 	tests := []struct {
@@ -1188,164 +881,6 @@ func TestRecordMessagesContentDisabled(t *testing.T) {
 	})
 }
 
-// --- NRGenerateContentStream.RecordEvent state accumulation ---
-
-func TestStreamRecordEventAccumulatesState(t *testing.T) {
-	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
-
-	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
-
-	drainStream(stream)
-	if err := stream.Err(); err != nil {
-		t.Fatal(err)
-	}
-
-	if stream.completion.resp == nil {
-		t.Fatal("expected accumulated response, got nil")
-	}
-	if stream.completion.resp.ResponseID != testMessageID {
-		t.Errorf("ResponseID: got %q, want %q", stream.completion.resp.ResponseID, testMessageID)
-	}
-	if stream.completion.resp.ModelVersion != testModel {
-		t.Errorf("ModelVersion: got %q, want %q", stream.completion.resp.ModelVersion, testModel)
-	}
-	if got := responseText(stream.response()); got != testResponse {
-		t.Errorf("response text: got %q, want %q", got, testResponse)
-	}
-	cand := stream.completion.resp.Candidates[0]
-	if cand.FinishReason != genai.FinishReasonStop {
-		t.Errorf("FinishReason: got %q, want %q", cand.FinishReason, genai.FinishReasonStop)
-	}
-	if cand.Content.Role != genai.RoleModel {
-		t.Errorf("Role: got %q, want %q", cand.Content.Role, genai.RoleModel)
-	}
-
-	stream.Close()
-}
-
-// Deltas concatenate verbatim: extractResponseText joins separate Parts with a
-// space, so one Part is what keeps the content identical to what the caller saw.
-func TestStreamRecordEventConcatenatesDeltas(t *testing.T) {
-	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	svc := &NRModelsService{app: app.Application, customAttributes: map[string]interface{}{}}
-	txn := app.StartTransaction("deltas")
-	w := &NRGenerateContentStream{svc: svc, txn: txn, completion: &completion{model: testModel}}
-
-	for _, delta := range []string{"Hel", "lo", " wor", "ld"} {
-		w.RecordEvent(&genai.GenerateContentResponse{
-			Candidates: []*genai.Candidate{{
-				Content: &genai.Content{
-					Role:  genai.RoleModel,
-					Parts: []*genai.Part{{Text: delta}},
-				},
-			}},
-		}, nil)
-	}
-
-	if got := responseText(w.response()); got != "Hello world" {
-		t.Errorf("response text: got %q, want %q", got, "Hello world")
-	}
-	txn.End()
-}
-
-// --- NRGenerateContentStream.Close tests ---
-
-func TestStreamCloseReturnsNilOnSuccess(t *testing.T) {
-	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
-
-	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
-	drainStream(stream)
-
-	if err := stream.Close(); err != nil {
-		t.Errorf("Close() returned unexpected error: %v", err)
-	}
-}
-
-func TestStreamCloseIdempotent(t *testing.T) {
-	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
-
-	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
-	drainStream(stream)
-
-	if err := stream.Close(); err != nil {
-		t.Fatal(err)
-	}
-	// Second Close should be a no-op (return nil, no double-flush of events).
-	if err := stream.Close(); err != nil {
-		t.Errorf("second Close() should be nil, got: %v", err)
-	}
-}
-
-func TestStreamCloseEndsTxnWhenOwned(t *testing.T) {
-	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
-
-	// No txn in context — the stream creates and owns the transaction.
-	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
-	drainStream(stream)
-	stream.Close()
-
-	app.ExpectTxnEvents(t, []internal.WantEvent{
-		{
-			Intrinsics: map[string]interface{}{
-				"type":      "Transaction",
-				"name":      "OtherTransaction/Go/GeminiGenerateContentStream",
-				"guid":      internal.MatchAnything,
-				"priority":  internal.MatchAnything,
-				"sampled":   internal.MatchAnything,
-				"traceId":   internal.MatchAnything,
-				"timestamp": internal.MatchAnything,
-				"duration":  internal.MatchAnything,
-				"totalTime": internal.MatchAnything,
-			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{"llm": true},
-		},
-	})
-}
-
-func TestStreamCloseNoTxnEndWhenNotOwned(t *testing.T) {
-	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
-
-	// Inject an existing txn — the stream must NOT end it.
-	txn := app.StartTransaction("caller-txn")
-	ctx := newrelic.NewContext(context.Background(), txn)
-
-	stream := nrClient.Models.GenerateContentStream(ctx, testModel, genai.Text(testPrompt), nil)
-	drainStream(stream)
-	stream.Close()
-
-	// Txn is still open; end it explicitly and verify the name is caller-txn.
-	txn.End()
-
-	app.ExpectTxnEvents(t, []internal.WantEvent{
-		{
-			Intrinsics: map[string]interface{}{
-				"type":      "Transaction",
-				"name":      "OtherTransaction/Go/caller-txn",
-				"guid":      internal.MatchAnything,
-				"priority":  internal.MatchAnything,
-				"sampled":   internal.MatchAnything,
-				"traceId":   internal.MatchAnything,
-				"timestamp": internal.MatchAnything,
-				"duration":  internal.MatchAnything,
-				"totalTime": internal.MatchAnything,
-			},
-			UserAttributes:  map[string]interface{}{},
-			AgentAttributes: map[string]interface{}{"llm": true},
-		},
-	})
-}
-
-// --- LLM content spec check: full content survives to serialized event ---
-
-// The LLM spec requires that LlmChatCompletionMessage.content is NOT truncated
-// at any stage. This test drives a long (>256-byte) prompt through the sync
-// integration and verifies the recorded event carries the full content.
 func TestGenerateContentLongPromptNotTruncated(t *testing.T) {
 	svc, app := newTestService(t)
 	longPrompt := strings.Repeat("a", 1024)
@@ -1597,42 +1132,8 @@ func TestAddHeaderAttrs(t *testing.T) {
 	}
 }
 
-// --- time_to_first_token ---
-
 // Only the first chunk sets it. TestGenerateContent covers the other half: its
 // summary is asserted exactly and carries no such attribute.
-func TestTimeToFirstTokenSetOnceByFirstChunk(t *testing.T) {
-	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
-
-	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
-	drainStream(stream)
-
-	if stream.completion.timeToFirstToken == nil {
-		t.Fatal("expected the first chunk to record a time to first token")
-	}
-	first := *stream.completion.timeToFirstToken
-	if first < 0 {
-		t.Errorf("timeToFirstToken: got %d, want >= 0", first)
-	}
-
-	// A later chunk must not move it.
-	stream.RecordEvent(&genai.GenerateContentResponse{
-		Candidates: []*genai.Candidate{{
-			Content: &genai.Content{Parts: []*genai.Part{{Text: "later"}}},
-		}},
-	}, nil)
-	if got := *stream.completion.timeToFirstToken; got != first {
-		t.Errorf("timeToFirstToken moved: got %d, want %d", got, first)
-	}
-
-	stream.Close()
-}
-
-// --- Non-text parts ---
-
-// Parts carrying data other than text hold no message content: they are left out
-// of the content attribute and counted so the caller can log them.
 func TestContentTextSkipsNonTextParts(t *testing.T) {
 	content := &genai.Content{
 		Role: genai.RoleUser,
@@ -1691,51 +1192,407 @@ func TestRecordMessagesNonTextOnly(t *testing.T) {
 	})
 }
 
-// --- Delta accumulation ---
-
 // Deltas go into a strings.Builder per candidate, so a long stream stays linear
 // rather than recopying the accumulated text on every chunk.
-func TestStreamAccumulatesManyChunksLinearly(t *testing.T) {
-	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	svc := &NRModelsService{app: app.Application, customAttributes: map[string]interface{}{}}
-	txn := app.StartTransaction("many-chunks")
-	w := &NRGenerateContentStream{svc: svc, txn: txn, completion: &completion{model: testModel}}
 
+// --- Streaming ---
+
+func drainStream(seq iter.Seq2[*genai.GenerateContentResponse, error]) error {
+	for _, err := range seq {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// The wrapper returns the SDK's own iter.Seq2, so a caller ranges over it exactly
+// as they would the unwrapped client, and the events land when the loop ends.
+func TestGenerateContentStream(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	var got strings.Builder
+	for chunk, err := range nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), &genai.GenerateContentConfig{MaxOutputTokens: 150}) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		got.WriteString(responseText(chunk))
+	}
+	if got.String() != testResponse {
+		t.Errorf("streamed text: got %q, want %q", got.String(), testResponse)
+	}
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionSummary", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":                             internal.MatchAnything,
+				"span_id":                        internal.MatchAnything,
+				"trace_id":                       internal.MatchAnything,
+				"request_id":                     testMessageID,
+				"request.model":                  testModel,
+				"request.max_tokens":             int32(150),
+				"vendor":                         "gemini",
+				"ingest_source":                  "Go",
+				"duration":                       internal.MatchAnything,
+				"time_to_first_token":            internal.MatchAnything,
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "STOP",
+				"response.number_of_messages":    2,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionMessage", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"request_id":     testMessageID,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       0,
+				"role":           "user",
+				"content":        testPrompt,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionMessage", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"request_id":     testMessageID,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       1,
+				"role":           "model",
+				"content":        testResponse,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+				"is_response":    true,
+			},
+		},
+	})
+}
+
+// Breaking out of the loop early still records, covering the chunks seen so far.
+// finish_reason is absent because it arrives on the last chunk.
+func TestGenerateContentStreamEarlyBreak(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	chunks := 0
+	for range nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil) {
+		chunks++
+		break
+	}
+	if chunks != 1 {
+		t.Fatalf("chunks: got %d, want 1", chunks)
+	}
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionSummary", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":                          internal.MatchAnything,
+				"span_id":                     internal.MatchAnything,
+				"trace_id":                    internal.MatchAnything,
+				"request_id":                  testMessageID,
+				"request.model":               testModel,
+				"vendor":                      "gemini",
+				"ingest_source":               "Go",
+				"duration":                    internal.MatchAnything,
+				"time_to_first_token":         internal.MatchAnything,
+				"response.model":              testModel,
+				"response.number_of_messages": 2,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionMessage", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"request_id":     testMessageID,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       0,
+				"role":           "user",
+				"content":        testPrompt,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionMessage", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"request_id":     testMessageID,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       1,
+				"role":           "model",
+				"content":        testResponse,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+				"is_response":    true,
+			},
+		},
+	})
+}
+
+func TestGenerateContentStreamAIMonitoringNotEnabled(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil) // AI monitoring NOT enabled
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	if err := drainStream(nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)); err != nil {
+		t.Fatal(err)
+	}
+	app.ExpectCustomEvents(t, []internal.WantEvent{})
+	app.ExpectTxnEvents(t, []internal.WantEvent{})
+}
+
+// AI monitoring on, streaming off: the SDK iterator passes through untouched, so
+// no transaction is started and nothing is recorded.
+func TestGenerateContentStreamDisabled(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil,
+		newrelic.ConfigAIMonitoringEnabled(true),
+		func(cfg *newrelic.Config) { cfg.AIMonitoring.Streaming.Enabled = false },
+		noCodeLevelMetrics,
+	)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	if err := drainStream(nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)); err != nil {
+		t.Fatal(err)
+	}
+	app.ExpectCustomEvents(t, []internal.WantEvent{})
+	app.ExpectTxnEvents(t, []internal.WantEvent{})
+}
+
+// A caller-supplied transaction is left for the caller to end.
+func TestGenerateContentStreamWithExistingTxn(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	txn := app.StartTransaction("my-existing-streaming-txn")
+	ctx := newrelic.NewContext(context.Background(), txn)
+	if err := drainStream(nrClient.Models.GenerateContentStream(ctx, testModel, genai.Text(testPrompt), nil)); err != nil {
+		t.Fatal(err)
+	}
+	txn.End()
+
+	app.ExpectTxnEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "Transaction",
+				"name":      "OtherTransaction/Go/my-existing-streaming-txn",
+				"guid":      internal.MatchAnything,
+				"priority":  internal.MatchAnything,
+				"sampled":   internal.MatchAnything,
+				"traceId":   internal.MatchAnything,
+				"timestamp": internal.MatchAnything,
+				"duration":  internal.MatchAnything,
+				"totalTime": internal.MatchAnything,
+			},
+			UserAttributes:  map[string]interface{}{},
+			AgentAttributes: map[string]interface{}{"llm": true},
+		},
+	})
+}
+
+// With no transaction in the context the stream starts and ends its own.
+func TestGenerateContentStreamStartsOwnTxn(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	if err := drainStream(nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)); err != nil {
+		t.Fatal(err)
+	}
+
+	app.ExpectTxnEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "Transaction",
+				"name":      "OtherTransaction/Go/GeminiGenerateContentStream",
+				"guid":      internal.MatchAnything,
+				"priority":  internal.MatchAnything,
+				"sampled":   internal.MatchAnything,
+				"traceId":   internal.MatchAnything,
+				"timestamp": internal.MatchAnything,
+				"duration":  internal.MatchAnything,
+				"totalTime": internal.MatchAnything,
+			},
+			UserAttributes:  map[string]interface{}{},
+			AgentAttributes: map[string]interface{}{"llm": true},
+		},
+	})
+}
+
+// Ranging a second time must not report the completion twice.
+func TestGenerateContentStreamSingleUse(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	seq := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
+	if err := drainStream(seq); err != nil {
+		t.Fatal(err)
+	}
+	for range seq {
+		t.Error("second range yielded a chunk")
+	}
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionSummary", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":                             internal.MatchAnything,
+				"span_id":                        internal.MatchAnything,
+				"trace_id":                       internal.MatchAnything,
+				"request_id":                     testMessageID,
+				"request.model":                  testModel,
+				"vendor":                         "gemini",
+				"ingest_source":                  "Go",
+				"duration":                       internal.MatchAnything,
+				"time_to_first_token":            internal.MatchAnything,
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "STOP",
+				"response.number_of_messages":    2,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionMessage", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"request_id":     testMessageID,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       0,
+				"role":           "user",
+				"content":        testPrompt,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{"type": "LlmChatCompletionMessage", "timestamp": internal.MatchAnything},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"request_id":     testMessageID,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       1,
+				"role":           "model",
+				"content":        testResponse,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+				"is_response":    true,
+			},
+		},
+	})
+}
+
+func newTestStreamState() *streamState {
+	return &streamState{completion: &completion{model: testModel}, start: time.Now()}
+}
+
+// textChunk builds a chunk carrying one text delta per candidate.
+func textChunk(deltas ...string) *genai.GenerateContentResponse {
+	chunk := &genai.GenerateContentResponse{}
+	for _, d := range deltas {
+		chunk.Candidates = append(chunk.Candidates, &genai.Candidate{
+			Content: &genai.Content{Role: genai.RoleModel, Parts: []*genai.Part{{Text: d}}},
+		})
+	}
+	return chunk
+}
+
+func TestStreamStateAccumulates(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	txn := app.StartTransaction("accumulate")
+	defer txn.End()
+
+	st := newTestStreamState()
+	st.observe(txn, &genai.GenerateContentResponse{
+		ResponseID:   testMessageID,
+		ModelVersion: testModel,
+		Candidates: []*genai.Candidate{{
+			Content: &genai.Content{Role: genai.RoleModel, Parts: []*genai.Part{{Text: testResponse}}},
+		}},
+	}, nil)
+	st.observe(txn, &genai.GenerateContentResponse{
+		Candidates:    []*genai.Candidate{{FinishReason: genai.FinishReasonStop}},
+		UsageMetadata: &genai.GenerateContentResponseUsageMetadata{TotalTokenCount: 21},
+	}, nil)
+
+	resp := st.finish().resp
+	if resp.ResponseID != testMessageID {
+		t.Errorf("ResponseID: got %q, want %q", resp.ResponseID, testMessageID)
+	}
+	if resp.ModelVersion != testModel {
+		t.Errorf("ModelVersion: got %q, want %q", resp.ModelVersion, testModel)
+	}
+	if got := responseText(resp); got != testResponse {
+		t.Errorf("text: got %q, want %q", got, testResponse)
+	}
+	if resp.Candidates[0].FinishReason != genai.FinishReasonStop {
+		t.Errorf("FinishReason: got %q, want STOP", resp.Candidates[0].FinishReason)
+	}
+	if resp.UsageMetadata == nil || resp.UsageMetadata.TotalTokenCount != 21 {
+		t.Errorf("usage not carried from the final chunk: %+v", resp.UsageMetadata)
+	}
+}
+
+func TestStreamStateConcatenatesDeltas(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	txn := app.StartTransaction("deltas")
+	defer txn.End()
+
+	st := newTestStreamState()
+	for _, delta := range []string{"Hel", "lo", " wor", "ld"} {
+		st.observe(txn, textChunk(delta), nil)
+	}
+	if got := responseText(st.finish().resp); got != "Hello world" {
+		t.Errorf("text: got %q, want %q", got, "Hello world")
+	}
+}
+
+func TestStreamStateManyChunks(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	txn := app.StartTransaction("many-chunks")
+	defer txn.End()
+
+	st := newTestStreamState()
 	var want strings.Builder
 	for i := 0; i < 500; i++ {
 		delta := fmt.Sprintf("chunk%d ", i)
 		want.WriteString(delta)
-		w.RecordEvent(&genai.GenerateContentResponse{
-			Candidates: []*genai.Candidate{{
-				Content: &genai.Content{Role: genai.RoleModel, Parts: []*genai.Part{{Text: delta}}},
-			}},
-		}, nil)
+		st.observe(txn, textChunk(delta), nil)
 	}
-
-	if got := responseText(w.response()); got != want.String() {
+	if got := responseText(st.finish().resp); got != want.String() {
 		t.Errorf("accumulated text mismatch: got %d bytes, want %d", len(got), want.Len())
 	}
-	txn.End()
 }
 
 // Each candidate accumulates its own deltas.
-func TestStreamAccumulatesPerCandidate(t *testing.T) {
+func TestStreamStatePerCandidate(t *testing.T) {
 	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	svc := &NRModelsService{app: app.Application, customAttributes: map[string]interface{}{}}
 	txn := app.StartTransaction("two-candidates")
-	w := &NRGenerateContentStream{svc: svc, txn: txn, completion: &completion{model: testModel}}
+	defer txn.End()
 
-	for _, deltas := range [][2]string{{"one ", "two "}, {"first", "second"}} {
-		chunk := &genai.GenerateContentResponse{}
-		for _, d := range deltas {
-			chunk.Candidates = append(chunk.Candidates, &genai.Candidate{
-				Content: &genai.Content{Role: genai.RoleModel, Parts: []*genai.Part{{Text: d}}},
-			})
-		}
-		w.RecordEvent(chunk, nil)
-	}
+	st := newTestStreamState()
+	st.observe(txn, textChunk("one ", "two "), nil)
+	st.observe(txn, textChunk("first", "second"), nil)
 
-	resp := w.response()
+	resp := st.finish().resp
 	if len(resp.Candidates) != 2 {
 		t.Fatalf("candidates: got %d, want 2", len(resp.Candidates))
 	}
@@ -1744,40 +1601,67 @@ func TestStreamAccumulatesPerCandidate(t *testing.T) {
 			t.Errorf("candidate %d: got %q, want %q", i, got, want)
 		}
 	}
-	txn.End()
 }
 
-// A Close that runs long after the stream finished — a deferred one, say — must
-// not stretch the reported duration past when the chunks actually arrived.
-func TestStreamDurationStampedAsChunksArrive(t *testing.T) {
+func TestStreamStateTimeToFirstTokenSetOnce(t *testing.T) {
 	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+	txn := app.StartTransaction("ttft")
+	defer txn.End()
 
-	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
-	drainStream(stream)
-
-	atDrain := stream.completion.duration
-	time.Sleep(25 * time.Millisecond)
-	if err := stream.Close(); err != nil {
-		t.Fatal(err)
+	st := newTestStreamState()
+	st.observe(txn, textChunk("first"), nil)
+	if st.completion.timeToFirstToken == nil {
+		t.Fatal("expected the first chunk to record a time to first token")
 	}
-	if stream.completion.duration != atDrain {
-		t.Errorf("duration moved after the delay: got %d, want %d",
-			stream.completion.duration, atDrain)
-	}
-}
+	first := *st.completion.timeToFirstToken
 
-// A stream nothing was ever reported for still gets a duration measured at Close.
-func TestStreamDurationWhenNothingRecorded(t *testing.T) {
-	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
-	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
-
-	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
 	time.Sleep(5 * time.Millisecond)
-	if err := stream.Close(); err != nil {
-		t.Fatal(err)
+	st.observe(txn, textChunk("later"), nil)
+	if got := *st.completion.timeToFirstToken; got != first {
+		t.Errorf("timeToFirstToken moved: got %d, want %d", got, first)
 	}
-	if stream.completion.duration <= 0 {
-		t.Errorf("duration: got %d, want > 0", stream.completion.duration)
+}
+
+func TestStreamStateDurationStampedAsChunksArrive(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	txn := app.StartTransaction("duration")
+	defer txn.End()
+
+	st := newTestStreamState()
+	st.observe(txn, textChunk("only"), nil)
+	atChunk := st.completion.duration
+
+	time.Sleep(25 * time.Millisecond)
+	if got := st.finish().duration; got != atChunk {
+		t.Errorf("duration moved after the delay: got %d, want %d", got, atChunk)
+	}
+}
+
+// A stream that yielded nothing still gets a duration.
+func TestStreamStateDurationWhenNothingYielded(t *testing.T) {
+	st := newTestStreamState()
+	time.Sleep(5 * time.Millisecond)
+	if got := st.finish().duration; got <= 0 {
+		t.Errorf("duration: got %d, want > 0", got)
+	}
+}
+
+func TestStreamStateKeepsFirstError(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	txn := app.StartTransaction("errors")
+	defer txn.End()
+
+	first := errors.New("first failure")
+	st := newTestStreamState()
+	st.observe(txn, nil, first)
+	st.observe(txn, nil, errors.New("second failure"))
+
+	c := st.finish()
+	if !errors.Is(c.err, first) {
+		t.Errorf("err: got %v, want %v", c.err, first)
+	}
+	// A failed stream reports request messages only.
+	if c.resp != nil {
+		t.Errorf("resp: got %+v, want nil", c.resp)
 	}
 }

--- a/v3/integrations/nrgemini/nrgemini_test.go
+++ b/v3/integrations/nrgemini/nrgemini_test.go
@@ -1,0 +1,1178 @@
+package nrgemini
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/newrelic/go-agent/v3/internal"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/go-agent/v3/newrelic/integrationsupport"
+	"google.golang.org/genai"
+)
+
+const (
+	testModel     = "gemini-2.5-flash"
+	testPrompt    = "What is 8*5"
+	testResponse  = "Hello there, how may I assist you today?"
+	testMessageID = "resp_abc123"
+)
+
+// noCodeLevelMetrics disables CLM so code.* agent attributes don't appear in
+// test assertions and cause spurious length mismatches.
+func noCodeLevelMetrics(cfg *newrelic.Config) {
+	cfg.CodeLevelMetrics.Enabled = false
+}
+
+// mockGeminiClient returns an NRClient wired to a test HTTP server. The
+// handler is called for every request.
+func mockGeminiClient(t *testing.T, app *newrelic.Application, handler http.HandlerFunc) *NRClient {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	nrClient, err := NewClient(app, context.Background(), &genai.ClientConfig{
+		APIKey:  "test-key",
+		Backend: genai.BackendGeminiAPI,
+		HTTPOptions: genai.HTTPOptions{
+			BaseURL: srv.URL,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return nrClient
+}
+
+func successHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"candidates": []map[string]interface{}{
+			{
+				"content": map[string]interface{}{
+					"role":  "model",
+					"parts": []map[string]interface{}{{"text": testResponse}},
+				},
+				"finishReason": "STOP",
+			},
+		},
+		"modelVersion": testModel,
+		"responseId":   testMessageID,
+		"usageMetadata": map[string]interface{}{
+			"promptTokenCount":     9,
+			"candidatesTokenCount": 12,
+			"totalTokenCount":      21,
+		},
+	})
+}
+
+func errorHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    400,
+			"message": "test error",
+			"status":  "INVALID_ARGUMENT",
+		},
+	})
+}
+
+func streamingHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+
+	writeSSE := func(payload map[string]interface{}) {
+		data, _ := json.Marshal(payload)
+		fmt.Fprintf(w, "data: %s\n\n", data)
+	}
+
+	writeSSE(map[string]interface{}{
+		"candidates": []map[string]interface{}{
+			{
+				"content": map[string]interface{}{
+					"role":  "model",
+					"parts": []map[string]interface{}{{"text": testResponse}},
+				},
+			},
+		},
+		"modelVersion": testModel,
+		"responseId":   testMessageID,
+	})
+
+	writeSSE(map[string]interface{}{
+		"candidates": []map[string]interface{}{
+			{
+				"content": map[string]interface{}{
+					"role":  "model",
+					"parts": []map[string]interface{}{{"text": ""}},
+				},
+				"finishReason": "STOP",
+			},
+		},
+		"modelVersion": testModel,
+		"responseId":   testMessageID,
+	})
+
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func TestAddCustomAttributes(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, successHandler)
+
+	nrClient.AddCustomAttributes(map[string]interface{}{
+		"llm.foo": "bar",
+	})
+	if nrClient.Models.customAttributes["llm.foo"] != "bar" {
+		t.Errorf("expected llm.foo=bar, got %v", nrClient.Models.customAttributes["llm.foo"])
+	}
+}
+
+func TestAddCustomAttributesIncorrectPrefix(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, successHandler)
+
+	nrClient.AddCustomAttributes(map[string]interface{}{
+		"notllm.foo": "bar",
+	})
+	if len(nrClient.Models.customAttributes) != 0 {
+		t.Errorf("expected no custom attributes, got %d", len(nrClient.Models.customAttributes))
+	}
+}
+
+func TestGenerateContent(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, successHandler)
+
+	resp, err := nrClient.Models.GenerateContent(context.Background(), testModel, genai.Text(testPrompt), &genai.GenerateContentConfig{MaxOutputTokens: 150})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Text() != testResponse {
+		t.Errorf("unexpected response text: %q", resp.Text())
+	}
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                             internal.MatchAnything,
+				"span_id":                        internal.MatchAnything,
+				"trace_id":                       internal.MatchAnything,
+				"request.model":                  testModel,
+				"request.max_tokens":             int32(150),
+				"vendor":                         "gemini",
+				"ingest_source":                  "Go",
+				"duration":                       internal.MatchAnything,
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "STOP",
+				"response.number_of_messages":    2,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       0,
+				"role":           "user",
+				"content":        testPrompt,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       1,
+				"role":           "model",
+				"content":        testResponse,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+				"is_response":    true,
+			},
+		},
+	})
+}
+
+func TestGenerateContentAIMonitoringNotEnabled(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil) // AI monitoring NOT enabled
+	nrClient := mockGeminiClient(t, app.Application, successHandler)
+
+	resp, err := nrClient.Models.GenerateContent(context.Background(), testModel, genai.Text(testPrompt), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Text() != testResponse {
+		t.Errorf("unexpected response text: %q", resp.Text())
+	}
+	app.ExpectCustomEvents(t, []internal.WantEvent{})
+}
+
+func TestGenerateContentError(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, errorHandler)
+
+	_, err := nrClient.Models.GenerateContent(context.Background(), testModel, genai.Text(testPrompt), &genai.GenerateContentConfig{MaxOutputTokens: 150})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                          internal.MatchAnything,
+				"span_id":                     internal.MatchAnything,
+				"trace_id":                    internal.MatchAnything,
+				"request.model":               testModel,
+				"request.max_tokens":          int32(150),
+				"vendor":                      "gemini",
+				"ingest_source":               "Go",
+				"duration":                    internal.MatchAnything,
+				"error":                       true,
+				"response.number_of_messages": 1,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       0,
+				"role":           "user",
+				"content":        testPrompt,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+			},
+		},
+	})
+
+	app.ExpectErrorEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":            "TransactionError",
+				"transactionName": "OtherTransaction/Go/GeminiGenerateContent",
+				"guid":            internal.MatchAnything,
+				"priority":        internal.MatchAnything,
+				"sampled":         internal.MatchAnything,
+				"traceId":         internal.MatchAnything,
+				"error.class":     "GeminiError",
+				"error.message":   internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"completion_id": internal.MatchAnything,
+			},
+			AgentAttributes: map[string]interface{}{
+				"llm": true,
+			},
+		},
+	})
+}
+
+func TestGenerateContentWithExistingTxn(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, successHandler)
+
+	txn := app.StartTransaction("my-existing-txn")
+	ctx := newrelic.NewContext(context.Background(), txn)
+
+	resp, err := nrClient.Models.GenerateContent(ctx, testModel, genai.Text(testPrompt), &genai.GenerateContentConfig{MaxOutputTokens: 150})
+	txn.End()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Text() != testResponse {
+		t.Errorf("unexpected response text: %q", resp.Text())
+	}
+
+	// Events should be recorded under the caller's transaction
+	app.ExpectTxnEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "Transaction",
+				"name":      "OtherTransaction/Go/my-existing-txn",
+				"guid":      internal.MatchAnything,
+				"priority":  internal.MatchAnything,
+				"sampled":   internal.MatchAnything,
+				"traceId":   internal.MatchAnything,
+				"timestamp": internal.MatchAnything,
+				"duration":  internal.MatchAnything,
+				"totalTime": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{},
+			AgentAttributes: map[string]interface{}{
+				"llm": true,
+			},
+		},
+	})
+}
+
+func TestGenerateContentStream(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), &genai.GenerateContentConfig{MaxOutputTokens: 150})
+
+	for stream.Next() {
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                             internal.MatchAnything,
+				"span_id":                        internal.MatchAnything,
+				"trace_id":                       internal.MatchAnything,
+				"request.model":                  testModel,
+				"request.max_tokens":             int32(150),
+				"vendor":                         "gemini",
+				"ingest_source":                  "Go",
+				"duration":                       internal.MatchAnything,
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "STOP",
+				"response.number_of_messages":    2,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       0,
+				"role":           "user",
+				"content":        testPrompt,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        internal.MatchAnything,
+				"trace_id":       internal.MatchAnything,
+				"completion_id":  internal.MatchAnything,
+				"sequence":       1,
+				"role":           "model",
+				"content":        testResponse,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"response.model": testModel,
+				"is_response":    true,
+			},
+		},
+	})
+}
+
+func TestGenerateContentStreamAIMonitoringNotEnabled(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil) // AI monitoring NOT enabled
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
+	for stream.Next() {
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+	app.ExpectCustomEvents(t, []internal.WantEvent{})
+	app.ExpectTxnEvents(t, []internal.WantEvent{})
+}
+
+func TestGenerateContentStreamDisabled(t *testing.T) {
+	// AI monitoring enabled but streaming specifically disabled — no txn should be started.
+	app := integrationsupport.NewTestApp(nil,
+		newrelic.ConfigAIMonitoringEnabled(true),
+		func(cfg *newrelic.Config) { cfg.AIMonitoring.Streaming.Enabled = false },
+		noCodeLevelMetrics,
+	)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
+
+	if stream.txn != nil {
+		t.Error("expected txn to be nil when streaming is disabled, but it was set")
+	}
+	if stream.txnOwned {
+		t.Error("expected txnOwned=false when streaming is disabled")
+	}
+
+	for stream.Next() {
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+	app.ExpectCustomEvents(t, []internal.WantEvent{})
+	app.ExpectTxnEvents(t, []internal.WantEvent{})
+}
+
+func TestGenerateContentStreamWithExistingTxn(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	txn := app.StartTransaction("my-existing-streaming-txn")
+	ctx := newrelic.NewContext(context.Background(), txn)
+
+	stream := nrClient.Models.GenerateContentStream(ctx, testModel, genai.Text(testPrompt), nil)
+	for stream.Next() {
+	}
+	stream.Close()
+	txn.End()
+
+	app.ExpectTxnEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "Transaction",
+				"name":      "OtherTransaction/Go/my-existing-streaming-txn",
+				"guid":      internal.MatchAnything,
+				"priority":  internal.MatchAnything,
+				"sampled":   internal.MatchAnything,
+				"traceId":   internal.MatchAnything,
+				"timestamp": internal.MatchAnything,
+				"duration":  internal.MatchAnything,
+				"totalTime": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{},
+			AgentAttributes: map[string]interface{}{
+				"llm": true,
+			},
+		},
+	})
+}
+
+// --- Pure helper function tests ---
+
+func TestExtractContentText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *genai.Content
+		want string
+	}{
+		{name: "nil", in: nil, want: ""},
+		{name: "empty parts", in: &genai.Content{}, want: ""},
+		{
+			name: "single text",
+			in:   &genai.Content{Parts: []*genai.Part{{Text: "hello"}}},
+			want: "hello",
+		},
+		{
+			name: "multiple text",
+			in: &genai.Content{Parts: []*genai.Part{
+				{Text: "hello"},
+				{Text: "world"},
+			}},
+			want: "hello world",
+		},
+		{
+			name: "empty text ignored",
+			in: &genai.Content{Parts: []*genai.Part{
+				{Text: "hello"},
+				{Text: ""},
+				{Text: "world"},
+			}},
+			want: "hello world",
+		},
+		{
+			name: "nil part ignored",
+			in: &genai.Content{Parts: []*genai.Part{
+				{Text: "hello"},
+				nil,
+				{Text: "world"},
+			}},
+			want: "hello world",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractContentText(tc.in); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractResponseText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *genai.GenerateContentResponse
+		want string
+	}{
+		{name: "nil", in: nil, want: ""},
+		{name: "no candidates", in: &genai.GenerateContentResponse{}, want: ""},
+		{
+			name: "nil content",
+			in: &genai.GenerateContentResponse{Candidates: []*genai.Candidate{
+				{Content: nil},
+			}},
+			want: "",
+		},
+		{
+			name: "single text",
+			in: &genai.GenerateContentResponse{Candidates: []*genai.Candidate{
+				{Content: &genai.Content{Parts: []*genai.Part{{Text: "hello"}}}},
+			}},
+			want: "hello",
+		},
+		{
+			name: "multiple text",
+			in: &genai.GenerateContentResponse{Candidates: []*genai.Candidate{
+				{Content: &genai.Content{Parts: []*genai.Part{
+					{Text: "hello"},
+					{Text: "world"},
+				}}},
+			}},
+			want: "hello world",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractResponseText(tc.in); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// --- NRGenerateContentStreamWrapper.appendCustomAttrs tests ---
+
+func TestStreamWrapperAppendCustomAttrs(t *testing.T) {
+	w := &NRGenerateContentStreamWrapper{
+		customAttributes: map[string]interface{}{
+			"llm.key1": "val1",
+			"llm.key2": 42,
+		},
+	}
+	data := map[string]interface{}{"existing": "preserved"}
+	w.appendCustomAttrs(data)
+
+	if data["llm.key1"] != "val1" {
+		t.Errorf("llm.key1: got %v, want val1", data["llm.key1"])
+	}
+	if data["llm.key2"] != 42 {
+		t.Errorf("llm.key2: got %v, want 42", data["llm.key2"])
+	}
+	if data["existing"] != "preserved" {
+		t.Errorf("existing key was overwritten, got %v", data["existing"])
+	}
+}
+
+func TestStreamWrapperAppendCustomAttrsEmpty(t *testing.T) {
+	w := &NRGenerateContentStreamWrapper{customAttributes: map[string]interface{}{}}
+	data := map[string]interface{}{"k": "v"}
+	w.appendCustomAttrs(data)
+	if len(data) != 1 || data["k"] != "v" {
+		t.Errorf("data should be unchanged, got %v", data)
+	}
+}
+
+// --- NRClient.AddCustomAttributes additional tests ---
+
+func TestAddCustomAttributesMixed(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, successHandler)
+
+	nrClient.AddCustomAttributes(map[string]interface{}{
+		"llm.valid":   "yes",
+		"notllm.skip": "no",
+		"also.skip":   "no",
+	})
+
+	if len(nrClient.Models.customAttributes) != 1 {
+		t.Fatalf("expected 1 attribute, got %d: %v", len(nrClient.Models.customAttributes), nrClient.Models.customAttributes)
+	}
+	if nrClient.Models.customAttributes["llm.valid"] != "yes" {
+		t.Errorf("llm.valid: got %v, want yes", nrClient.Models.customAttributes["llm.valid"])
+	}
+}
+
+func TestAddCustomAttributesEmpty(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil)
+	nrClient := mockGeminiClient(t, app.Application, successHandler)
+	nrClient.AddCustomAttributes(map[string]interface{}{})
+	if len(nrClient.Models.customAttributes) != 0 {
+		t.Errorf("expected no attributes, got %d", len(nrClient.Models.customAttributes))
+	}
+}
+
+// --- NRModelsService.recordSummary tests ---
+
+func newTestService(t *testing.T) (*NRModelsService, integrationsupport.ExpectApp) {
+	t.Helper()
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	svc := &NRModelsService{
+		app:              app.Application,
+		customAttributes: make(map[string]interface{}),
+	}
+	return svc, app
+}
+
+func baseContents() []*genai.Content {
+	return genai.Text(testPrompt)
+}
+
+func baseConfig() *genai.GenerateContentConfig {
+	return &genai.GenerateContentConfig{MaxOutputTokens: 150}
+}
+
+func TestRecordSummarySuccess(t *testing.T) {
+	svc, app := newTestService(t)
+	resp := &genai.GenerateContentResponse{
+		ResponseID:   testMessageID,
+		ModelVersion: testModel,
+		Candidates: []*genai.Candidate{
+			{FinishReason: genai.FinishReasonStop},
+		},
+	}
+
+	svc.recordSummary("cid", "sid", "tid", testModel, baseConfig(), baseContents(), resp, 100, false)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                             "cid",
+				"span_id":                        "sid",
+				"trace_id":                       "tid",
+				"request.model":                  testModel,
+				"request.max_tokens":             int32(150),
+				"vendor":                         "gemini",
+				"ingest_source":                  "Go",
+				"duration":                       int64(100),
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "STOP",
+				"response.number_of_messages":    2,
+			},
+		},
+	})
+}
+
+func TestRecordSummaryError(t *testing.T) {
+	svc, app := newTestService(t)
+
+	svc.recordSummary("cid", "sid", "tid", testModel, baseConfig(), baseContents(), nil, 50, true)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                          "cid",
+				"span_id":                     "sid",
+				"trace_id":                    "tid",
+				"request.model":               testModel,
+				"request.max_tokens":          int32(150),
+				"vendor":                      "gemini",
+				"ingest_source":               "Go",
+				"duration":                    int64(50),
+				"error":                       true,
+				"response.number_of_messages": 1,
+			},
+		},
+	})
+}
+
+func TestRecordSummaryWithTemperature(t *testing.T) {
+	svc, app := newTestService(t)
+	// Use a value exactly representable in float32 so the harness comparison
+	// isn't tripped by float32 precision loss.
+	temp := float32(0.5)
+	config := baseConfig()
+	config.Temperature = &temp
+	resp := &genai.GenerateContentResponse{
+		ResponseID:   testMessageID,
+		ModelVersion: testModel,
+		Candidates: []*genai.Candidate{
+			{FinishReason: genai.FinishReasonStop},
+		},
+	}
+
+	svc.recordSummary("cid", "sid", "tid", testModel, config, baseContents(), resp, 10, false)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                             "cid",
+				"span_id":                        "sid",
+				"trace_id":                       "tid",
+				"request.model":                  testModel,
+				"request.max_tokens":             int32(150),
+				"request.temperature":            float32(0.5),
+				"vendor":                         "gemini",
+				"ingest_source":                  "Go",
+				"duration":                       int64(10),
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "STOP",
+				"response.number_of_messages":    2,
+			},
+		},
+	})
+}
+
+func TestRecordSummaryCustomAttrs(t *testing.T) {
+	svc, app := newTestService(t)
+	svc.customAttributes["llm.env"] = "prod"
+	resp := &genai.GenerateContentResponse{
+		ModelVersion: testModel,
+		Candidates: []*genai.Candidate{
+			{FinishReason: genai.FinishReasonStop},
+		},
+	}
+
+	svc.recordSummary("cid", "sid", "tid", testModel, baseConfig(), baseContents(), resp, 10, false)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                             "cid",
+				"span_id":                        "sid",
+				"trace_id":                       "tid",
+				"request.model":                  testModel,
+				"request.max_tokens":             int32(150),
+				"vendor":                         "gemini",
+				"ingest_source":                  "Go",
+				"duration":                       int64(10),
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "STOP",
+				"response.number_of_messages":    2,
+				"llm.env":                        "prod",
+			},
+		},
+	})
+}
+
+func TestRecordSummaryNilConfig(t *testing.T) {
+	svc, app := newTestService(t)
+	resp := &genai.GenerateContentResponse{
+		ModelVersion: testModel,
+		Candidates: []*genai.Candidate{
+			{FinishReason: genai.FinishReasonStop},
+		},
+	}
+
+	svc.recordSummary("cid", "sid", "tid", testModel, nil, baseContents(), resp, 10, false)
+
+	// no request.max_tokens or request.temperature should be recorded when config is nil
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionSummary",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":                             "cid",
+				"span_id":                        "sid",
+				"trace_id":                       "tid",
+				"request.model":                  testModel,
+				"vendor":                         "gemini",
+				"ingest_source":                  "Go",
+				"duration":                       int64(10),
+				"response.model":                 testModel,
+				"response.choices.finish_reason": "STOP",
+				"response.number_of_messages":    2,
+			},
+		},
+	})
+}
+
+// --- NRModelsService.recordMessages tests ---
+
+func TestRecordMessagesWithResp(t *testing.T) {
+	svc, app := newTestService(t)
+	resp := &genai.GenerateContentResponse{
+		ResponseID:   testMessageID,
+		ModelVersion: testModel,
+		Candidates: []*genai.Candidate{
+			{Content: &genai.Content{
+				Role:  genai.RoleModel,
+				Parts: []*genai.Part{{Text: testResponse}},
+			}},
+		},
+	}
+
+	svc.recordMessages("cid", "sid", "tid", testModel, baseContents(), resp)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "user",
+				"completion_id":  "cid",
+				"sequence":       0,
+				"response.model": testModel,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"content":        testPrompt,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             fmt.Sprintf("%s-%d", testMessageID, 1),
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "model",
+				"completion_id":  "cid",
+				"sequence":       1,
+				"response.model": testModel,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"content":        testResponse,
+				"is_response":    true,
+			},
+		},
+	})
+}
+
+func TestRecordMessagesNilResp(t *testing.T) {
+	svc, app := newTestService(t)
+
+	svc.recordMessages("cid", "sid", "tid", testModel, baseContents(), nil)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "user",
+				"completion_id":  "cid",
+				"sequence":       0,
+				"response.model": testModel,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"content":        testPrompt,
+			},
+		},
+	})
+}
+
+func TestRecordMessagesContentDisabled(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil,
+		newrelic.ConfigAIMonitoringEnabled(true),
+		func(cfg *newrelic.Config) { cfg.AIMonitoring.RecordContent.Enabled = false },
+		noCodeLevelMetrics,
+	)
+	svc := &NRModelsService{
+		app:              app.Application,
+		customAttributes: make(map[string]interface{}),
+	}
+	resp := &genai.GenerateContentResponse{
+		ResponseID:   testMessageID,
+		ModelVersion: testModel,
+		Candidates: []*genai.Candidate{
+			{Content: &genai.Content{
+				Role:  genai.RoleModel,
+				Parts: []*genai.Part{{Text: testResponse}},
+			}},
+		},
+	}
+
+	svc.recordMessages("cid", "sid", "tid", testModel, baseContents(), resp)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "user",
+				"completion_id":  "cid",
+				"sequence":       0,
+				"response.model": testModel,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             fmt.Sprintf("%s-%d", testMessageID, 1),
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "model",
+				"completion_id":  "cid",
+				"sequence":       1,
+				"response.model": testModel,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"is_response":    true,
+			},
+		},
+	})
+}
+
+// --- NRGenerateContentStreamWrapper.Next state accumulation ---
+
+func TestStreamWrapperNextAccumulatesState(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
+
+	for stream.Next() {
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if stream.responseID != testMessageID {
+		t.Errorf("responseID: got %q, want %q", stream.responseID, testMessageID)
+	}
+	if stream.responseModel != testModel {
+		t.Errorf("responseModel: got %q, want %q", stream.responseModel, testModel)
+	}
+	if got := stream.responseText.String(); got != testResponse {
+		t.Errorf("responseText: got %q, want %q", got, testResponse)
+	}
+	if stream.finishReason != "STOP" {
+		t.Errorf("finishReason: got %q, want %q", stream.finishReason, "STOP")
+	}
+	if stream.responseRole != genai.RoleModel {
+		t.Errorf("responseRole: got %q, want %q", stream.responseRole, genai.RoleModel)
+	}
+
+	stream.Close()
+}
+
+// --- NRGenerateContentStreamWrapper.Close tests ---
+
+func TestStreamWrapperCloseReturnsNilOnSuccess(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
+	for stream.Next() {
+	}
+
+	if err := stream.Close(); err != nil {
+		t.Errorf("Close() returned unexpected error: %v", err)
+	}
+}
+
+func TestStreamWrapperCloseIdempotent(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
+	for stream.Next() {
+	}
+
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// Second Close should be a no-op (return nil, no double-flush of events).
+	if err := stream.Close(); err != nil {
+		t.Errorf("second Close() should be nil, got: %v", err)
+	}
+}
+
+func TestStreamWrapperCloseEndsTxnWhenOwned(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	// No txn in context — wrapper creates and owns the transaction.
+	stream := nrClient.Models.GenerateContentStream(context.Background(), testModel, genai.Text(testPrompt), nil)
+	for stream.Next() {
+	}
+	stream.Close()
+
+	app.ExpectTxnEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "Transaction",
+				"name":      "OtherTransaction/Go/GeminiGenerateContentStream",
+				"guid":      internal.MatchAnything,
+				"priority":  internal.MatchAnything,
+				"sampled":   internal.MatchAnything,
+				"traceId":   internal.MatchAnything,
+				"timestamp": internal.MatchAnything,
+				"duration":  internal.MatchAnything,
+				"totalTime": internal.MatchAnything,
+			},
+			UserAttributes:  map[string]interface{}{},
+			AgentAttributes: map[string]interface{}{"llm": true},
+		},
+	})
+}
+
+func TestStreamWrapperCloseNoTxnEndWhenNotOwned(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	nrClient := mockGeminiClient(t, app.Application, streamingHandler)
+
+	// Inject an existing txn — wrapper must NOT end it.
+	txn := app.StartTransaction("caller-txn")
+	ctx := newrelic.NewContext(context.Background(), txn)
+
+	stream := nrClient.Models.GenerateContentStream(ctx, testModel, genai.Text(testPrompt), nil)
+	for stream.Next() {
+	}
+	stream.Close()
+
+	// Txn is still open; end it explicitly and verify the name is caller-txn, not the wrapper name.
+	txn.End()
+
+	app.ExpectTxnEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "Transaction",
+				"name":      "OtherTransaction/Go/caller-txn",
+				"guid":      internal.MatchAnything,
+				"priority":  internal.MatchAnything,
+				"sampled":   internal.MatchAnything,
+				"traceId":   internal.MatchAnything,
+				"timestamp": internal.MatchAnything,
+				"duration":  internal.MatchAnything,
+				"totalTime": internal.MatchAnything,
+			},
+			UserAttributes:  map[string]interface{}{},
+			AgentAttributes: map[string]interface{}{"llm": true},
+		},
+	})
+}
+
+// --- LLM content spec check: full content survives to serialized event ---
+
+// The LLM spec requires that LlmChatCompletionMessage.content is NOT truncated
+// at any stage. This test drives a long (>256-byte) prompt through the sync
+// integration and verifies the recorded event carries the full content.
+func TestGenerateContentLongPromptNotTruncated(t *testing.T) {
+	svc, app := newTestService(t)
+	longPrompt := strings.Repeat("a", 1024)
+	resp := &genai.GenerateContentResponse{
+		ResponseID:   testMessageID,
+		ModelVersion: testModel,
+		Candidates: []*genai.Candidate{
+			{Content: &genai.Content{
+				Role:  genai.RoleModel,
+				Parts: []*genai.Part{{Text: testResponse}},
+			}},
+		},
+	}
+
+	svc.recordMessages("cid", "sid", "tid", testModel, genai.Text(longPrompt), resp)
+
+	app.ExpectCustomEvents(t, []internal.WantEvent{
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             internal.MatchAnything,
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "user",
+				"completion_id":  "cid",
+				"sequence":       0,
+				"response.model": testModel,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"content":        longPrompt,
+			},
+		},
+		{
+			Intrinsics: map[string]interface{}{
+				"type":      "LlmChatCompletionMessage",
+				"timestamp": internal.MatchAnything,
+			},
+			UserAttributes: map[string]interface{}{
+				"id":             fmt.Sprintf("%s-%d", testMessageID, 1),
+				"span_id":        "sid",
+				"trace_id":       "tid",
+				"role":           "model",
+				"completion_id":  "cid",
+				"sequence":       1,
+				"response.model": testModel,
+				"vendor":         "gemini",
+				"ingest_source":  "Go",
+				"content":        testResponse,
+				"is_response":    true,
+			},
+		},
+	})
+}

--- a/v3/integrations/nrgemini/nrgemini_test.go
+++ b/v3/integrations/nrgemini/nrgemini_test.go
@@ -1665,3 +1665,22 @@ func TestStreamStateKeepsFirstError(t *testing.T) {
 		t.Errorf("resp: got %+v, want nil", c.resp)
 	}
 }
+
+// A yield carrying neither a chunk nor an error must not mark the stream as
+// observed, or finish would skip measuring the duration and report zero.
+func TestStreamStateEmptyYieldLeavesDurationMeasured(t *testing.T) {
+	app := integrationsupport.NewTestApp(nil, newrelic.ConfigAIMonitoringEnabled(true), noCodeLevelMetrics)
+	txn := app.StartTransaction("empty-yield")
+	defer txn.End()
+
+	st := newTestStreamState()
+	st.observe(txn, nil, nil)
+	if st.observed {
+		t.Error("an empty yield should not count as observed")
+	}
+
+	time.Sleep(5 * time.Millisecond)
+	if got := st.finish().duration; got <= 0 {
+		t.Errorf("duration: got %d, want > 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

New Relic AI monitoring for `google.golang.org/genai`, scoped to chat completions and streaming. Replaces #1189, split so the agent-core change can be reviewed on its own.

`NewClient` wraps a GenAI client; `Models.GenerateContent`, `Models.GenerateContentStream`, and `Models.ProcessContentStream` record `LlmChatCompletionSummary` and `LlmChatCompletionMessage` events and open a segment under the active transaction.


## Streaming

The GenAI SDK returns streams as an `iter.Seq2`. Rather than invert it, the SDK iterator is exposed for the caller to drive, following `nrawsbedrock.ResponseStream`:

```go
stream := nrClient.Models.GenerateContentStream(ctx, model, contents, cfg)
defer stream.Close()
for chunk, err := range stream.Stream {
    stream.RecordEvent(chunk, err)
    if err != nil {
        break
    }
    // ... consume chunk ...
}
```

`ProcessContentStream` runs that loop for you, mirroring `nrawsbedrock.ProcessModelWithResponseStream`.

Ranging over `Stream` is what releases the HTTP body — the SDK closes it when the loop ends or breaks — so `Close` only finishes the New Relic side and is safe to defer. Chunks accumulate into a synthetic `GenerateContentResponse`, letting `Close` report through the same recorder as the non-streaming path. Text deltas append to a `strings.Builder` per candidate to keep accumulation linear, and `duration` is stamped as chunks arrive so a deferred `Close` does not stretch it.

## Attributes

Summary and message events carry the spec set: ids, request/response model, `request.max_tokens`, `request.temperature`, `response.number_of_messages`, `response.choices.finish_reason`, `response.usage.{prompt,completion,total}_tokens`, `request_id`, `response.organization`, `response.headers.<name>`, `duration`, `error`, `content`, `role`, `sequence`, `completion_id`, `is_response`, `token_count`, and `llm.*` custom attributes. `time_to_first_token` is recorded for streaming requests only.

Message ids are `<response id>-<sequence>`, falling back to a UUID. One message is recorded per candidate, since `CandidateCount` can exceed 1. Roles default to `user` for requests and `assistant` for responses; Gemini's own `model` role passes through. Failed calls report `http.statusCode` and `error.code` off `genai.APIError` alongside `completion_id`.


## Testing

`go test -race ./...` in `v3/integrations/nrgemini`. Coverage includes both stream-driving styles, AI-monitoring and streaming-disabled paths, caller-supplied vs integration-started transactions, error paths, multiple candidates, role and message-id defaults, header and request-id precedence, delta accumulation across 500 chunks and across candidates, and duration stamping. Added to the integration test matrix.